### PR TITLE
nix_eval: stream deduplicated eval warnings to the build page

### DIFF
--- a/nixbot/nixbot/db.py
+++ b/nixbot/nixbot/db.py
@@ -204,20 +204,33 @@ class BuildDB:
             )
             return _build_record(row)
 
+    async def set_eval_warnings(self, build_id: int, warnings_json: str) -> None:
+        """Streamed, deduplicated eval warnings; updated while the eval
+        is still running (the trigger pushes a build_events notify)."""
+        await self.pool.execute(
+            "UPDATE builds SET eval_warnings = $2::jsonb WHERE id = $1",
+            build_id,
+            warnings_json,
+        )
+
     async def set_build_status(
         self,
         build_id: int,
         status: str,
         *,
         error: str | None = None,
-        eval_warnings: str | None = None,
     ) -> None:
         await self.pool.execute(
             """
             UPDATE builds
             SET status = $2,
                 error = COALESCE($3, error),
-                eval_warnings = COALESCE($4::jsonb, eval_warnings),
+                -- A fresh eval must not show the previous attempt's
+                -- streamed warnings.
+                eval_warnings = CASE
+                    WHEN $2 = 'evaluating' THEN NULL
+                    ELSE eval_warnings
+                END,
                 started_at = CASE
                     WHEN started_at IS NULL AND $2 <> 'pending' THEN now()
                     ELSE started_at
@@ -225,7 +238,7 @@ class BuildDB:
                 -- Invariant: non-terminal states never carry finished_at,
                 -- else reruns show negative durations.
                 finished_at = CASE
-                    WHEN $2 = ANY($5::text[]) THEN now()
+                    WHEN $2 = ANY($4::text[]) THEN now()
                     ELSE NULL
                 END
             WHERE id = $1
@@ -233,7 +246,6 @@ class BuildDB:
             build_id,
             status,
             error,
-            eval_warnings,
             list(BuildStatus.TERMINAL),
         )
         if status in (BuildStatus.FAILED, BuildStatus.CANCELLED):

--- a/nixbot/nixbot/live_warnings.py
+++ b/nixbot/nixbot/live_warnings.py
@@ -1,0 +1,70 @@
+"""Deduplicated live eval warnings.
+
+Evaluator stderr lines (warnings/errors) are normalized into stable
+group keys so retry spam ("retrying in 120081 ms (attempt 2/5)" for
+hundreds of narinfo URLs) collapses into one row with a counter that
+the build page renders while the eval is still running.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Volatile parts that would defeat deduplication: per-path URLs (keep
+# the host), retry timers/attempt counters, nix base32 hashes.
+_URL_RE = re.compile(r"(https?://[^/'\"\s)]+)[^'\"\s)]*")
+_RETRY_RE = re.compile(r";? retrying in \d+ ms")
+_ATTEMPT_RE = re.compile(r"\s*\(attempt \d+/\d+\)")
+_NIX_HASH_RE = re.compile(r"\b[0-9a-df-np-sv-z]{32}\b")
+_PREFIX_RE = re.compile(r"^(?:evaluation warning:|warning:|error:)\s*")
+_WS_RE = re.compile(r"\s+")
+
+MAX_GROUPS = 50
+# Warning text is repo-controlled; keep single messages bounded.
+MAX_MESSAGE_LEN = 500
+
+
+def normalize_warning(line: str) -> tuple[str, str]:
+    """(level, dedupe message) for one ANSI-stripped stderr line."""
+    level = "error" if "error:" in line.split("warning:", maxsplit=1)[0] else "warning"
+    msg = _PREFIX_RE.sub("", line.strip())
+    msg = _URL_RE.sub(r"\1/…", msg)
+    msg = _RETRY_RE.sub("", msg)
+    msg = _ATTEMPT_RE.sub("", msg)
+    msg = _NIX_HASH_RE.sub("…", msg)
+    msg = _WS_RE.sub(" ", msg).strip()
+    if len(msg) > MAX_MESSAGE_LEN:
+        msg = msg[: MAX_MESSAGE_LEN - 1] + "…"
+    return level, msg
+
+
+class LiveWarningAggregator:
+    """Counts occurrences per normalized warning; bounded group count."""
+
+    def __init__(self, max_groups: int = MAX_GROUPS) -> None:
+        self._groups: dict[tuple[str, str], int] = {}
+        self._max_groups = max_groups
+
+    def add(self, line: str) -> bool:
+        """Record a line; True when the snapshot changed."""
+        key = normalize_warning(line)
+        if key in self._groups:
+            self._groups[key] += 1
+            return True
+        if len(self._groups) >= self._max_groups:
+            return False
+        self._groups[key] = 1
+        return True
+
+    def __bool__(self) -> bool:
+        return bool(self._groups)
+
+    def snapshot(self) -> list[dict[str, str | int]]:
+        """Errors first, then insertion order."""
+        items = sorted(
+            self._groups.items(), key=lambda kv: 0 if kv[0][0] == "error" else 1
+        )
+        return [
+            {"level": level, "message": message, "count": count}
+            for (level, message), count in items
+        ]

--- a/nixbot/nixbot/migrations/0014_streamed_eval_warnings.sql
+++ b/nixbot/nixbot/migrations/0014_streamed_eval_warnings.sql
@@ -1,0 +1,20 @@
+-- Replace end-of-eval warning text with warnings streamed during the
+-- eval, deduplicated into [{"level", "message", "count"}] groups.
+ALTER TABLE builds DROP COLUMN eval_warnings;
+ALTER TABLE builds ADD COLUMN eval_warnings JSONB;
+
+-- The build page listens on build_events to refresh; without this the
+-- warnings panel would only update on status transitions.
+CREATE OR REPLACE FUNCTION notify_build_status() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'UPDATE'
+        AND OLD.status IS NOT DISTINCT FROM NEW.status
+        AND OLD.eval_warnings IS NOT DISTINCT FROM NEW.eval_warnings THEN
+        RETURN NEW;
+    END IF;
+    PERFORM pg_notify('build_events', json_build_object(
+        'build_id', NEW.id,
+        'project_id', NEW.project_id,
+        'status', NEW.status)::text);
+    RETURN NEW;
+END $$ LANGUAGE plpgsql;

--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -2,8 +2,8 @@
 
 Ported from the buildbot step in nixbot/nix_eval.py: streams
 nix-eval-jobs JSON lines, honors the repo's `nixbot.toml`
-(flake_dir/lock_file/attribute), extracts evaluation warnings from
-stderr, and sizes workers/memory dynamically (memory.py).
+(flake_dir/lock_file/attribute), streams warnings/errors from stderr,
+and sizes workers/memory dynamically (memory.py).
 
 The evaluator runs inside a bubblewrap sandbox as defense in depth:
 only the worktree, the nix store, the gc-roots dir, the nix daemon
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from .ansi import strip_ansi
 from .environ import passthrough_env
 from .models import NixEvalJob, NixEvalJobModel
 
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
     from .repo_config import BranchConfig
 
     JobBatchCallback = Callable[[list[NixEvalJob]], Awaitable[None]]
+    StderrLineCallback = Callable[[str], Awaitable[None]]
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +92,6 @@ class EvalSettings:
 @dataclass
 class EvalResult:
     jobs: list[NixEvalJob]
-    warnings: list[str]
 
 
 def build_eval_command(
@@ -341,57 +342,56 @@ def build_full_command(
     return cmd
 
 
-def extract_eval_warnings(stderr_output: str) -> list[str]:
-    """Extract `evaluation warning:` blocks from nix-eval-jobs stderr,
-    filtering out Nix configuration warnings. Ported from
-    NixEvalCommand._format_warnings."""
-    warning_lines = stderr_output.strip().split("\n") if stderr_output else []
-    eval_warnings: list[str] = []
-    i = 0
-    while i < len(warning_lines):
-        line = warning_lines[i]
-        if "evaluation warning:" in line:
-            first_line = line.replace("evaluation warning:", "").strip()
-            warning_block = [first_line] if first_line else []
-            i += 1
-            # Collect continuation lines (indented, or empty lines
-            # followed by an indented line).
-            while i < len(warning_lines):
-                next_line = warning_lines[i]
-                if next_line.startswith((" ", "\t")):
-                    warning_block.append(next_line.strip())
-                    i += 1
-                elif not next_line.strip():
-                    if i + 1 < len(warning_lines) and warning_lines[i + 1].startswith(
-                        (" ", "\t")
-                    ):
-                        warning_block.append("")
-                        i += 1
-                    else:
-                        break
-                else:
-                    break
-            if warning_block:
-                eval_warnings.append("\n".join(warning_block))
-        else:
-            i += 1
-    return eval_warnings
-
-
 async def _drain(stream: asyncio.StreamReader) -> None:
     while await stream.read(64 * 1024):
         pass
 
 
+def _is_stderr_noise(line: str) -> bool:
+    """Known-harmless nix stderr noise: the sandboxed evaluator parses
+    the host nix.conf with a libstore that lacks daemon-only settings,
+    and concurrent evals contend on the local sqlite caches (matching
+    "SQLite database" alone would also swallow corruption errors)."""
+    return "warning: unknown setting" in line or (
+        "SQLite database" in line and "is busy" in line
+    )
+
+
 async def _read_stderr_tail(
-    stream: asyncio.StreamReader, limit: int = STDERR_TAIL_LIMIT
+    stream: asyncio.StreamReader,
+    limit: int = STDERR_TAIL_LIMIT,
+    on_line: StderrLineCallback | None = None,
 ) -> bytes:
-    """Read a stream to EOF keeping only the last `limit` bytes."""
+    """Read stderr to EOF keeping only the last `limit` bytes, dropping
+    known-noise lines and live-streaming warnings/errors to the
+    optional `on_line` callback."""
     buf = bytearray()
+    pending = bytearray()
+
+    async def keep(raw_line: bytes) -> bool:
+        text = strip_ansi(raw_line.decode(errors="replace")).strip()
+        if _is_stderr_noise(text):
+            return False
+        if on_line is not None and ("warning:" in text or "error:" in text):
+            await on_line(text)
+        return True
+
     while chunk := await stream.read(64 * 1024):
-        buf += chunk
+        pending += chunk
+        *lines, rest = pending.split(b"\n")
+        pending = bytearray(rest)
+        # A single line larger than the tail limit (huge eval trace):
+        # keep it without waiting for its newline so memory stays bounded.
+        if len(pending) > 2 * limit:
+            buf += pending
+            pending.clear()
+        for line in lines:
+            if await keep(line):
+                buf += line + b"\n"
         if len(buf) > 2 * limit:
             del buf[:-limit]
+    if pending and await keep(bytes(pending)):
+        buf += pending
     return bytes(buf[-limit:])
 
 
@@ -486,9 +486,12 @@ class EvalRunner:
         branch_config: BranchConfig,
         settings: EvalSettings,
         on_jobs: JobBatchCallback | None = None,
+        on_stderr_line: StderrLineCallback | None = None,
     ) -> EvalResult:
         async with self._semaphore:
-            return await self._run(worktree_path, branch_config, settings, on_jobs)
+            return await self._run(
+                worktree_path, branch_config, settings, on_jobs, on_stderr_line
+            )
 
     async def _run(
         self,
@@ -496,6 +499,7 @@ class EvalRunner:
         branch_config: BranchConfig,
         settings: EvalSettings,
         on_jobs: JobBatchCallback | None = None,
+        on_stderr_line: StderrLineCallback | None = None,
     ) -> EvalResult:
         settings.gc_roots_dir.mkdir(parents=True, exist_ok=True)
 
@@ -528,6 +532,7 @@ class EvalRunner:
                 settings,
                 preexec_fn=join_eval_cgroup if eval_cgroup is not None else None,
                 on_jobs=on_jobs,
+                on_stderr_line=on_stderr_line,
                 eval_cgroup=eval_cgroup,
             )
         finally:
@@ -541,6 +546,7 @@ class EvalRunner:
         settings: EvalSettings,
         preexec_fn: Callable[[], None] | None = None,
         on_jobs: JobBatchCallback | None = None,
+        on_stderr_line: StderrLineCallback | None = None,
         eval_cgroup: Path | None = None,
     ) -> EvalResult:
         cmd = build_full_command(worktree_path, branch_config, settings)
@@ -575,7 +581,7 @@ class EvalRunner:
             async with asyncio.timeout(settings.timeout):
                 _, stderr_bytes = await asyncio.gather(
                     _read_job_stream(proc.stdout, jobs, parse_errors, on_jobs),
-                    _read_stderr_tail(proc.stderr),
+                    _read_stderr_tail(proc.stderr, on_line=on_stderr_line),
                 )
                 returncode = await proc.wait()
         except BaseException as e:
@@ -588,7 +594,6 @@ class EvalRunner:
                 raise EvalError(msg) from None
             raise
         stderr_text = stderr_bytes.decode(errors="replace")
-        warnings = extract_eval_warnings(stderr_text)
 
         if returncode != 0:
             tail = "\n".join(stderr_text.splitlines()[-50:])
@@ -606,4 +611,4 @@ class EvalRunner:
         if parse_errors:
             msg = "; ".join(parse_errors)
             raise EvalError(msg)
-        return EvalResult(jobs=jobs, warnings=warnings)
+        return EvalResult(jobs=jobs)

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -15,6 +15,7 @@ import contextlib
 import json
 import logging
 import shutil
+import time
 import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -41,6 +42,7 @@ from .effects_state import TaskTokens
 from .events import ChangeEvent, NullStatusReporter, RepoInfo, StatusReporter
 from .executor import LogWriter, failure_excerpt
 from .gitrepo import GitError, MergeConflictError, run_git
+from .live_warnings import LiveWarningAggregator
 from .memory import calculate_eval_workers
 from .models import NixEvalJobSuccess
 from .nix_eval import EvalError, EvalSettings
@@ -63,13 +65,15 @@ if TYPE_CHECKING:
     from .db import BuildDB, BuildRecord
     from .gitrepo import FetchCredentials, RepoManager
     from .models import NixEvalJob
-    from .nix_eval import EvalResult, JobBatchCallback
+    from .nix_eval import EvalResult, JobBatchCallback, StderrLineCallback
     from .scheduler import CachedFailure, FailedBuildCache
 
     GcrootRegistrar = Callable[[Path, str, str, str], Awaitable[None]]
     OutputWriter = Callable[[Path, str, str, str, str, str, str], Path]
 
 logger = logging.getLogger(__name__)
+
+LIVE_WARNINGS_FLUSH_INTERVAL = 2.0
 
 
 def pr_refspec(forge: str, pr_number: int) -> str:
@@ -92,6 +96,7 @@ class EvalRunnerLike(Protocol):
         branch_config: BranchConfig,
         settings: EvalSettings,
         on_jobs: JobBatchCallback | None = None,
+        on_stderr_line: StderrLineCallback | None = None,
     ) -> EvalResult: ...
 
 
@@ -431,9 +436,30 @@ class Orchestrator:
             )
             await jobs_queue.put(jobs)
 
+        # Deduplicated warnings appear on the build page while the eval
+        # runs; DB writes are throttled since retry storms emit one
+        # line per narinfo.
+        live_warnings = LiveWarningAggregator()
+        last_flush = 0.0
+
+        async def record_stderr_line(line: str) -> None:
+            nonlocal last_flush
+            if not live_warnings.add(line):
+                return
+            now = time.monotonic()
+            if now - last_flush >= LIVE_WARNINGS_FLUSH_INTERVAL:
+                last_flush = now
+                await self.db.set_eval_warnings(
+                    build.id, json.dumps(live_warnings.snapshot())
+                )
+
         eval_task = asyncio.ensure_future(
             self.eval_runner.run(
-                worktree_path, branch_config, eval_settings, on_jobs=record_job_batch
+                worktree_path,
+                branch_config,
+                eval_settings,
+                on_jobs=record_job_batch,
+                on_stderr_line=record_stderr_line,
             )
         )
         # Builds start as soon as the first eval batch arrives.
@@ -453,15 +479,16 @@ class Orchestrator:
                 await self._settle_aborted(event, build, BuildStatus.CANCELLED)
                 return
             # EvalError and anything else propagate to run_build,
-            # which settles the build as failed.
-            eval_result = await eval_task
-            await self.db.set_build_status(
-                build.id,
-                BuildStatus.BUILDING,
-                eval_warnings=(
-                    json.dumps(eval_result.warnings) if eval_result.warnings else None
-                ),
-            )
+            # which settles the build as failed. Flush warnings dropped
+            # by the throttle either way (run_build settles failures).
+            try:
+                eval_result = await eval_task
+            finally:
+                if live_warnings:
+                    await self.db.set_eval_warnings(
+                        build.id, json.dumps(live_warnings.snapshot())
+                    )
+            await self.db.set_build_status(build.id, BuildStatus.BUILDING)
             # Idempotent backstop for the streaming inserts above;
             # pending rows are what crash recovery resumes from. The
             # scheduler drops unsupported systems; their pending rows
@@ -476,7 +503,10 @@ class Orchestrator:
                 ],
             )
             await self.reporter.eval_finished(
-                event, build, success=True, warnings=eval_result.warnings
+                event,
+                build,
+                success=True,
+                warnings=[str(g["message"]) for g in live_warnings.snapshot()],
             )
 
             # Re-send the complete eval result: the scheduler dedupes

--- a/nixbot/nixbot/tests/test_live_warnings.py
+++ b/nixbot/nixbot/tests/test_live_warnings.py
@@ -1,0 +1,65 @@
+"""Tests for live warning deduplication."""
+
+# ruff: noqa: PLR2004
+
+from __future__ import annotations
+
+from nixbot.live_warnings import LiveWarningAggregator, normalize_warning
+
+
+def test_normalize_collapses_retry_spam() -> None:
+    a = (
+        "warning: unable to download 'https://nix-community.cachix.org/"
+        "6qsj3m683ix5xdj92sq4f55gbv6srdr7.narinfo': HTTP error 524; "
+        "retrying in 120081 ms (attempt 1/5)"
+    )
+    b = (
+        "warning: unable to download 'https://nix-community.cachix.org/"
+        "9a93i56z2vly62nx7cnsmi532zbb16wa.narinfo': HTTP error 524; "
+        "retrying in 240120 ms (attempt 2/5)"
+    )
+    assert normalize_warning(a) == normalize_warning(b)
+    level, msg = normalize_warning(a)
+    assert level == "warning"
+    assert "nix-community.cachix.org" in msg
+    assert "120081" not in msg
+    assert "attempt" not in msg
+
+
+def test_normalize_levels_and_prefix() -> None:
+    assert normalize_warning("error: builder failed")[0] == "error"
+    assert normalize_warning("evaluation warning: deprecated thing") == (
+        "warning",
+        "deprecated thing",
+    )
+    # "error:" inside the message of a warning stays a warning.
+    assert normalize_warning("warning: unable to download: HTTP error 524")[0] == (
+        "warning"
+    )
+
+
+def test_aggregator_counts_and_order() -> None:
+    agg = LiveWarningAggregator()
+    assert not agg
+    agg.add("warning: foo 'https://h/a.narinfo': HTTP error 524; retrying in 1 ms")
+    agg.add("warning: foo 'https://h/b.narinfo': HTTP error 524; retrying in 2 ms")
+    agg.add("error: gave up on bar")
+    snap = agg.snapshot()
+    assert snap[0]["level"] == "error"  # errors sort first
+    assert snap[1]["count"] == 2
+    assert agg
+
+
+def test_long_messages_truncated() -> None:
+    level, msg = normalize_warning("warning: " + "x" * 2000)
+    assert level == "warning"
+    assert len(msg) == 500
+    assert msg.endswith("…")
+
+
+def test_aggregator_bounded() -> None:
+    agg = LiveWarningAggregator(max_groups=2)
+    assert agg.add("warning: one")
+    assert agg.add("warning: two")
+    assert not agg.add("warning: three")
+    assert len(agg.snapshot()) == 2

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -28,7 +28,6 @@ from nixbot.nix_eval import (
     build_eval_command,
     build_full_command,
     build_sandbox_command,
-    extract_eval_warnings,
 )
 from nixbot.repo_config import BranchConfig
 
@@ -141,27 +140,6 @@ def test_full_command_composition(tmp_path: Path) -> None:
     assert cmd[0] == "nix-eval-jobs"
 
 
-def test_extract_eval_warnings() -> None:
-    stderr = (
-        "warning: unknown setting 'foo'\n"
-        "evaluation warning: first warning\n"
-        "  with indented detail\n"
-        "\n"
-        "  more detail after blank\n"
-        "evaluation warning: second warning\n"
-        "some other output\n"
-    )
-    warnings = extract_eval_warnings(stderr)
-    assert len(warnings) == 2
-    assert warnings[0].startswith("first warning")
-    assert "with indented detail" in warnings[0]
-    assert "more detail after blank" in warnings[0]
-    assert warnings[1] == "second warning"
-    # Nix configuration warnings are not eval warnings.
-    assert extract_eval_warnings("warning: unknown setting 'bar'\n") == []
-    assert extract_eval_warnings("") == []
-
-
 def test_memory_info_zfs_arc(tmp_path: Path) -> None:
     arcstats = tmp_path / "arcstats"
     arcstats.write_text("name type data\nsize 4 2147483648\n")
@@ -234,11 +212,57 @@ def test_eval_runner_integration(tmp_path: Path) -> None:
         sandbox=False,
         systemd_scope=False,
     )
-    result = asyncio.run(EvalRunner().run(flake, BranchConfig(), settings))
+    seen: list[str] = []
+
+    async def on_line(line: str) -> None:
+        seen.append(line)
+
+    result = asyncio.run(
+        EvalRunner().run(flake, BranchConfig(), settings, on_stderr_line=on_line)
+    )
     assert len(result.jobs) == 1
     job = result.jobs[0]
     assert job.attr == "x86_64-linux.ok"  # type: ignore[union-attr]
-    assert any("eval warning here" in w for w in result.warnings)
+    assert any("eval warning here" in line for line in seen)
+
+
+def test_stderr_noise_filtered_and_warnings_reach_callback(tmp_path: Path) -> None:
+    """Noise stays out of both the tail and the callback; warning and
+    error lines reach the callback ANSI-stripped, progress output does
+    not."""
+    script = tmp_path / "warn.sh"
+    script.write_text(
+        "#!/bin/sh\n"
+        "printf '\\033[35;1mwarning:\\033[0m unable to download foo\\n' >&2\n"
+        "echo 'plain progress output' >&2\n"
+        "echo \"warning: unknown setting 'allowed-users'\" >&2\n"
+        "echo \"warning: SQLite database '/nix/var/nix/db/db.sqlite' is busy\" >&2\n"
+        "echo 'error: something broke' >&2\n"
+    )
+    script.chmod(0o755)
+    seen: list[str] = []
+
+    async def on_line(line: str) -> None:
+        seen.append(line)
+
+    async def run() -> bytes:
+        proc = await asyncio.create_subprocess_exec(
+            str(script), stderr=asyncio.subprocess.PIPE
+        )
+        assert proc.stderr is not None
+        tail = await nix_eval._read_stderr_tail(proc.stderr, on_line=on_line)  # noqa: SLF001
+        await proc.wait()
+        return tail
+
+    tail = asyncio.run(run())
+    assert seen == [
+        "warning: unable to download foo",
+        "error: something broke",
+    ]
+    assert b"unknown setting" not in tail
+    assert b"is busy" not in tail
+    assert b"plain progress output" in tail
+    assert b"error: something broke" in tail
 
 
 def test_stderr_tail_is_bounded(tmp_path: Path) -> None:

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -52,6 +52,7 @@ pytestmark = [
 @dataclass
 class FakeEvalRunner:
     jobs: list[NixEvalJobSuccess]
+    # Emitted as stderr warning lines through on_stderr_line.
     warnings: list[str] = field(default_factory=list)
     calls: int = 0
     last_settings: EvalSettings | None = None
@@ -64,6 +65,7 @@ class FakeEvalRunner:
         branch_config: object,
         settings: EvalSettings,
         on_jobs: object = None,
+        on_stderr_line: object = None,
     ) -> EvalResult:
         self.calls += 1
         self.started.set()
@@ -71,7 +73,10 @@ class FakeEvalRunner:
         settings.gc_roots_dir.mkdir(parents=True, exist_ok=True)
         if self.block is not None:
             await self.block.wait()
-        return EvalResult(jobs=list(self.jobs), warnings=list(self.warnings))
+        if callable(on_stderr_line):
+            for warning in self.warnings:
+                await on_stderr_line(f"warning: {warning}")
+        return EvalResult(jobs=list(self.jobs))
 
 
 @dataclass
@@ -1608,6 +1613,7 @@ def test_unexpected_eval_path_error_settles_build(
             branch_config: object,
             settings: EvalSettings,
             on_jobs: object = None,
+            on_stderr_line: object = None,
         ) -> EvalResult:
             msg = "db outage"
             raise RuntimeError(msg)

--- a/nixbot/nixbot/tests/test_recovery.py
+++ b/nixbot/nixbot/tests/test_recovery.py
@@ -324,6 +324,34 @@ def test_failed_rebuild_settles_pending_effects(postgres_dsn: str) -> None:
     asyncio.run(run())
 
 
+def test_eval_start_clears_stale_eval_warnings(postgres_dsn: str) -> None:
+    """A re-run build must not show the previous attempt's warnings."""
+
+    async def run() -> None:
+        pool = await asyncpg.create_pool(postgres_dsn)
+        try:
+            build_id = await make_build(pool, "lw-rerun")
+            db = BuildDB(pool)
+            await db.set_eval_warnings(
+                build_id, '[{"level": "warning", "message": "old", "count": 3}]'
+            )
+            await db.set_build_status(build_id, "failed")
+            assert await pool.fetchval(
+                "SELECT eval_warnings FROM builds WHERE id = $1", build_id
+            )
+            await db.set_build_status(build_id, "evaluating")
+            assert (
+                await pool.fetchval(
+                    "SELECT eval_warnings FROM builds WHERE id = $1", build_id
+                )
+                is None
+            )
+        finally:
+            await pool.close()
+
+    asyncio.run(run())
+
+
 def test_interrupted_effects_fail_on_recovery(postgres_dsn: str) -> None:
     """Effects never auto-re-run, so rows left running by a crash
     would spin forever without the startup sweep."""

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -196,39 +196,44 @@ def test_attribute_rows_fragment_paginates(client: WebHarness) -> None:
     assert client.get(f"{base}?group=nonsense").status_code == 404
 
 
-def test_build_page_shows_eval_warnings_as_text(client: WebHarness) -> None:
+def test_build_page_shows_eval_warning_groups(client: WebHarness) -> None:
     async def seed() -> None:
         ctx = client.ctx
         await ctx.pool.execute(
             "UPDATE builds SET eval_warnings = $1::jsonb WHERE number = 2",
-            json.dumps(["evaluation warning: foo is deprecated", "trace: bar"]),
+            json.dumps(
+                [
+                    {"level": "error", "message": "download failed", "count": 24},
+                    {"level": "warning", "message": "foo is deprecated", "count": 1},
+                ]
+            ),
         )
 
     client.loop.run_until_complete(seed())
     text = client.get("/repos/github/acme/widget/builds/2").text
-    assert "evaluation warning: foo is deprecated" in text
-    assert "trace: bar" in text
+    assert "foo is deprecated" in text
+    assert "download failed" in text
+    assert "\u00d724" in text
+    assert "2 kinds" in text
+    assert "25 occurrences" in text
     # Decoded, not the raw jsonb string.
     assert "[&#34;" not in text
-    assert '["' not in text
 
 
-def test_build_page_renders_ansi_in_error_and_warnings(client: WebHarness) -> None:
+def test_build_page_renders_ansi_in_error(client: WebHarness) -> None:
     """Eval failures carry nix's colored output; raw escape codes must
     not reach the HTML (the API already strips them)."""
 
     async def seed() -> None:
         await client.ctx.pool.execute(
-            "UPDATE builds SET error = $1, eval_warnings = $2::jsonb WHERE number = 2",
+            "UPDATE builds SET error = $1 WHERE number = 2",
             "evaluation failed: \x1b[31mred error\x1b[0m",
-            json.dumps(["\x1b[33myellow warning\x1b[0m"]),
         )
 
     client.loop.run_until_complete(seed())
     text = client.get("/repos/github/acme/widget/builds/2").text
     assert "\x1b" not in text
     assert "red error" in text
-    assert "yellow warning" in text
 
 
 def test_running_build_shows_progress(client: WebHarness) -> None:

--- a/nixbot/nixbot/web/api_routes.py
+++ b/nixbot/nixbot/web/api_routes.py
@@ -42,6 +42,14 @@ class Repo(BaseModel):
     updated_at: datetime
 
 
+class EvalWarningGroup(BaseModel):
+    """Deduplicated evaluator warning streamed during the eval."""
+
+    level: str  # warning | error
+    message: str
+    count: int
+
+
 class Build(BaseModel):
     """One CI run of a commit."""
 
@@ -54,7 +62,7 @@ class Build(BaseModel):
     pr_number: int | None
     pr_author: str | None
     status: str  # pending | evaluating | building | succeeded | failed | cancelled
-    eval_warnings: list[str] | None
+    eval_warnings: list[EvalWarningGroup] | None
     error: str | None
     created_at: datetime
     started_at: datetime | None
@@ -113,7 +121,7 @@ class FailureSummary(BaseModel):
 
     status: str
     error: str | None
-    eval_warnings: list[str] | None
+    eval_warnings: list[EvalWarningGroup] | None
     failures: list[AttributeFailure]
 
 

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -416,8 +416,8 @@ class _PageRoutes:
         if build is None:
             raise HTTPException(status_code=404)
         if isinstance(build.get("eval_warnings"), str):
-            # asyncpg returns jsonb as a string; render plain text.
-            build["eval_warnings"] = "\n\n".join(json.loads(build["eval_warnings"]))
+            # asyncpg returns jsonb as a string.
+            build["eval_warnings"] = json.loads(build["eval_warnings"])
         prev_number, next_number = await ctx.queries.neighbor_numbers(
             project["id"], number
         )

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -323,6 +323,64 @@ pre.warning {
 details summary {
 	cursor: pointer;
 }
+/* Live (deduplicated) eval warnings streamed during evaluation. */
+.live-warnings {
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	margin: 0.5rem 0;
+	overflow: hidden;
+}
+.live-warnings .lw-head {
+	background: var(--card);
+	padding: 0.35rem 0.6rem;
+	font-size: 0.85rem;
+}
+.live-warnings .lw-muted {
+	color: var(--muted);
+}
+.live-warnings .lw-badge {
+	background: var(--warn);
+	color: var(--bg);
+	border-radius: 999px;
+	font-size: 0.75rem;
+	padding: 0 0.55em;
+	font-weight: 600;
+}
+.live-warnings ul {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	font-family: var(--mono);
+	font-size: 0.8125rem;
+}
+.live-warnings li {
+	display: flex;
+	gap: 0.7em;
+	align-items: baseline;
+	padding: 0.25rem 0.6rem;
+	border-top: 1px solid var(--border);
+}
+.live-warnings li .lw-level {
+	color: var(--warn);
+}
+.live-warnings li.error .lw-level {
+	color: var(--bad);
+}
+.live-warnings li .lw-msg {
+	flex: 1;
+	overflow-wrap: anywhere;
+}
+.live-warnings li .lw-count {
+	font-size: 0.75rem;
+	color: var(--bg);
+	background: var(--muted);
+	border-radius: 999px;
+	padding: 0 0.5em;
+	white-space: nowrap;
+}
+.live-warnings li .lw-count.hot {
+	background: var(--warn);
+}
 /* Groups scroll internally: an expanding group must not push the
    summaries below it out of reach (infinite-scroll footer problem). */
 .attr-scroll {

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -74,12 +74,6 @@
         </div>
       </div>
       {% if build.error %}<pre class="error">{{ build.error | excerpt(2000) | ansi }}</pre>{% endif %}
-      {% if build.eval_warnings %}
-        <details>
-          <summary>evaluation warnings</summary>
-          <pre class="error warning">{{ build.eval_warnings | ansi }}</pre>
-        </details>
-      {% endif %}
       {% if build.status in RUNNING_STATUSES and attrs_total %}
         <div class="build-progress"
              role="progressbar"
@@ -99,6 +93,25 @@
             {% endfor %}
           </div>
           <span class="muted">{{ attrs_done }} of {{ attrs_total }} attributes done</span>
+        </div>
+      {% endif %}
+      {% if build.eval_warnings %}
+        {% set lw_total = build.eval_warnings | sum(attribute="count") %}
+        <div class="live-warnings">
+          <div class="lw-head">
+            eval warnings
+            <span class="lw-badge">{{ build.eval_warnings | length }} kind{{ "s" if build.eval_warnings | length != 1 }}</span>
+            <span class="lw-muted">· {{ lw_total }} occurrence{{ "s" if lw_total != 1 }}</span>
+          </div>
+          <ul>
+            {% for g in build.eval_warnings %}
+              <li class="{{ g.level }}">
+                <span class="lw-level">{{ "error" if g.level == "error" else "warn" }}</span>
+                <span class="lw-msg">{{ g.message }}</span>
+                <span class="lw-count{{ ' hot' if g.count > 1 }}">×{{ g.count }}</span>
+              </li>
+            {% endfor %}
+          </ul>
         </div>
       {% endif %}
       <p>


### PR DESCRIPTION
Evaluator stderr only surfaced after the eval finished, so a cache outage (cachix answering 524 with 2-minute retry backoffs) looked like a silent hang until the worker hit its memory limit.

Stream warning/error lines into builds.live_warnings while the eval runs. Lines are normalized (URL reduced to host, retry timers, attempt counters and nix hashes stripped) so retry storms collapse into one group with a counter. Writes are throttled to one per 2s and capped at 50 groups; the build_events trigger now also fires on live_warnings changes so the SSE-driven build page refreshes.

Drop known-harmless noise: "unknown setting" (the sandboxed evaluator parses the host nix.conf with a libstore that lacks daemon-only settings) and SQLite busy warnings from concurrent evals.