### PR TITLE
web: clearer dashboard metric labels

### DIFF
--- a/nixbot/nixbot/web/queries.py
+++ b/nixbot/nixbot/web/queries.py
@@ -112,7 +112,7 @@ class WebQueries:
     ) -> list[dict[str, Any]]:
         """Homepage pipeline rows: each project with its latest build,
         the last ten builds (status + duration) for the bar chart, and
-        speed/reliability over the last thirty builds."""
+        median duration/pass rate over the last thirty builds."""
         rows = await self.pool.fetch(
             """
             SELECT p.*,
@@ -146,7 +146,7 @@ class WebQueries:
                            ORDER BY EXTRACT(EPOCH FROM (t.finished_at - t.started_at))
                        ) FILTER (WHERE t.status = 'succeeded') AS median_secs,
                        -- Cancelled builds say nothing about the code:
-                       -- they must not drag reliability toward zero.
+                       -- they must not drag the pass rate toward zero.
                        count(*) FILTER (WHERE t.status = 'succeeded')::float
                            / NULLIF(
                                count(*) FILTER (

--- a/nixbot/nixbot/web/templates/index.html
+++ b/nixbot/nixbot/web/templates/index.html
@@ -82,11 +82,13 @@
                      title="{{ bar_title }}"></i>
                 {% endfor %}
               </div>
-              <div class="pipeline-metric">
+              <div class="pipeline-metric"
+                   title="median duration of the last 30 successful builds">
                 <b>{{ p.median_secs | duration_secs }}</b>
-                <span class="muted">speed</span>
+                <span class="muted">median duration</span>
               </div>
-              <div class="pipeline-metric">
+              <div class="pipeline-metric"
+                   title="succeeded share of the last 30 finished builds (cancelled excluded)">
                 <b>
                   {% if p.pass_rate is not none %}
                     {{ (100 * p.pass_rate) | round | int }}%
@@ -94,7 +96,7 @@
                     —
                   {% endif %}
                 </b>
-                <span class="muted">reliability</span>
+                <span class="muted">pass rate</span>
               </div>
             </a>
             {% if toggleable is none or p.id in toggleable %}{{ toggle_form(p, q, "disable") }}{% endif %}


### PR DESCRIPTION

'speed' and 'reliability' confused users: neither says what is
measured or over which window. Label them 'median duration' and
'pass rate' and add tooltips with the 30-build window and the
cancelled-builds exclusion.
