### PR TITLE
reruns: re-post the eval status when resuming from stored results

### DIFF
--- a/nixbot/nixbot/reruns.py
+++ b/nixbot/nixbot/reruns.py
@@ -114,6 +114,9 @@ async def rerun_pending_attributes(
             event,
             worktree_path,
         ):
+            # No re-eval on this path: re-post the eval context green,
+            # the previous run may have left it red or pending.
+            await o.reporter.eval_finished(event, build, success=True, warnings=[])
             # cache_failures=False: see _ReadOnlyFailedBuildCache.
             status = await build_run.build_attributes(
                 o,

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -731,6 +731,24 @@ async def test_eval_warnings_null_when_empty(
     assert warnings is None
 
 
+async def test_rerun_flips_stale_red_eval_status(
+    pool: asyncpg.Pool, make_env: EnvFactory, upstream: Path
+) -> None:
+    """Resuming from stored eval results skips eval; the eval status
+    must still be re-posted green over a stale red one."""
+    sha = add_commit(upstream, "eval-flip")
+    # Failing attribute: keeps the effects path out of this test.
+    orchestrator, reporter, project = await make_env(
+        FakeEvalRunner([]),
+        FakeExecutor(outcomes={"a": BuildOutcome.failure}),
+        "eval-flip",
+    )
+    db = BuildDB(pool)
+    build, _ = await db.get_or_create_build(project.id, "eval-flip-tree", sha, "main")
+    await orchestrator.rerun_pending_attributes(project, build, [mk_job("a")])
+    assert ("eval", build.id, True, ()) in reporter.events
+
+
 async def test_recovery_rerun_failures_not_cached(
     pool: asyncpg.Pool, make_env: EnvFactory, upstream: Path
 ) -> None:


### PR DESCRIPTION
The attribute-rerun path reuses stored eval results and never posts the nix-eval context, so a red or pending status from the previous run (eval cancelled/failed) stuck around after a restart.

Post eval success at the start of the rerun, like the eval-reuse path in build_run.