### PR TITLE
github: switch to Check Runs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ We have the following two roles:
 ##### GitHub Integration
 
 Nixbot uses GitHub App authentication to integrate with GitHub repositories.
-This enables automatic webhook setup, commit status updates, and secure
-authentication.
+This enables automatic webhook setup, check-run reporting (with a working Re-run
+button), and secure authentication.
 
 See the [GitHub documentation](./docs/GITHUB.md) for setup instructions.
 

--- a/checks/nixbot.nix
+++ b/checks/nixbot.nix
@@ -36,7 +36,7 @@ in
           import re
           from http.server import BaseHTTPRequestHandler, HTTPServer
 
-          STATUS_LOG = "/var/lib/fake-github/statuses.jsonl"
+          CHECK_RUNS_LOG = "/var/lib/fake-github/check_runs.jsonl"
 
           REPO = {
               "id": 1,
@@ -70,18 +70,33 @@ in
                   else:
                       self._json({"message": "not found"}, 404)
 
+              def do_PATCH(self):
+                  length = int(self.headers.get("Content-Length") or 0)
+                  body = self.rfile.read(length)
+                  path = self.path.split("?")[0]
+                  if re.fullmatch(r"/repos/acme/test-flake/check-runs/[0-9]+", path):
+                      entry = json.loads(body)
+                      with open(CHECK_RUNS_LOG, "a") as f:
+                          f.write(json.dumps(entry) + "\n")
+                      self._json({"id": int(path.rsplit("/", 1)[1])}, 200)
+                  else:
+                      self._json({"message": "not found"}, 404)
+
               def do_POST(self):
                   length = int(self.headers.get("Content-Length") or 0)
                   body = self.rfile.read(length)
                   path = self.path.split("?")[0]
                   if re.fullmatch(r"/app/installations/1/access_tokens", path):
                       self._json({"token": "fake-token"}, 201)
-                  elif re.fullmatch(r"/repos/acme/test-flake/statuses/[0-9a-f]+", path):
+                  elif path == "/repos/acme/test-flake/check-runs":
                       entry = json.loads(body)
-                      entry["sha"] = path.rsplit("/", 1)[1]
-                      with open(STATUS_LOG, "a") as f:
+                      # The poster stores this id to PATCH the run on
+                      # completion; key it by name so each check keeps a
+                      # distinct id like the real API.
+                      check_run_id = abs(hash(entry["name"])) % 1_000_000
+                      with open(CHECK_RUNS_LOG, "a") as f:
                           f.write(json.dumps(entry) + "\n")
-                      self._json({}, 201)
+                      self._json({"id": check_run_id}, 201)
                   else:
                       self._json({"message": "not found"}, 404)
 
@@ -311,21 +326,21 @@ in
             f"-d {shlex.quote(body.decode())}"
         )
 
-        def github_statuses_posted(_ignore):
-            out = github.execute("cat /var/lib/fake-github/statuses.jsonl")[1]
-            statuses = [json.loads(line) for line in out.splitlines() if line]
-            print(statuses)
+        def github_checks_posted(_ignore):
+            out = github.execute("cat /var/lib/fake-github/check_runs.jsonl")[1]
+            check_runs = [json.loads(line) for line in out.splitlines() if line]
+            print(check_runs)
             done = {
-                s["context"]: s["state"]
-                for s in statuses
-                if s["state"] in ("success", "failure", "error")
+                cr["name"]: cr.get("conclusion")
+                for cr in check_runs
+                if cr.get("status") == "completed"
             }
             return (
                 done.get("nixbot/nix-eval") == "success"
                 and done.get("nixbot/nix-build") == "success"
             )
 
-        retry(github_statuses_posted, timeout_seconds=300)
+        retry(github_checks_posted, timeout_seconds=300)
 
     with subtest("gitea: nixbot becomes healthy"):
         gitea.wait_for_unit("nixbot.service")

--- a/docs/GITHUB.md
+++ b/docs/GITHUB.md
@@ -1,7 +1,7 @@
 # GitHub Integration
 
 Buildbot-nix uses GitHub App authentication to integrate with GitHub
-repositories. This enables automatic webhook setup, commit status updates, and
+repositories. This enables automatic webhook setup, check-run reporting, and
 secure authentication.
 
 ## Step 1: Create a GitHub App
@@ -23,13 +23,13 @@ secure authentication.
 3. Set the required permissions:
    - **Repository Permissions:**
      - Contents: Read-only (to clone repositories)
-     - Commit statuses: Read and write (to report build status)
+     - Checks: Read and write (to report build status as check runs)
      - Metadata: Read-only (basic repository info)
      - Pull requests: Read-only (required to subscribe to the pull_request
        event)
    - **Organization Permissions** (if app is for an organization):
      - Members: Read-only (to verify organization membership for access control)
-   - **Subscribe to events**: Push, Pull request
+   - **Subscribe to events**: Push, Pull request, Check run, Check suite
 
    Note: when adding permissions to an existing app, every installation (your
    user account and each organization) must accept the new permissions under
@@ -90,8 +90,9 @@ For each repository you want to build:
    - Toggle the project on in the web UI (as admin)
 
 2. **Webhook delivery**:
-   - GitHub delivers push and pull_request events through the App-level webhook
-     configured in Step 1; no per-repository webhooks are created.
+   - GitHub delivers push, pull_request, check_run and check_suite events
+     through the App-level webhook configured in Step 1; no per-repository
+     webhooks are created.
    - The endpoint is `https://nixbot.<your-domain>/webhooks/github` (the legacy
      `/change_hook/github` path also works).
 
@@ -102,10 +103,11 @@ For each repository you want to build:
 - **Project Discovery**: Automatically discovers repositories the app has access
   to (restricted by `userAllowlist`/`repoAllowlist` if set); discovered projects
   are built once enabled in the web UI
-- **Webhook Delivery**: Push and pull_request events arrive via the GitHub App
-  webhook; the payload signature is verified with the webhook secret
-- **Status Updates**: Reports build status back to GitHub commits and pull
-  requests
+- **Webhook Delivery**: Push, pull_request, check_run and check_suite events
+  arrive via the GitHub App webhook; the payload signature is verified with the
+  webhook secret
+- **Status Updates**: Reports build status as Check Runs (with markdown log
+  excerpts and a working Re-run button) on commits and pull requests
 - **Access Control**:
   - Admins: Configured users can reload projects and manage builds
   - Organization members: Can restart their own builds

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -44,11 +44,15 @@ OAuth callback URLs change: update your GitHub App / Gitea application to
 `https://<domain>/auth/<provider>/callback` (buildbot used `/auth/login`), e.g.
 `https://buildbot.example.com/auth/github/callback`.
 
-**Commit statuses.** Context names default to the `nixbot/` prefix
-(`nixbot/nix-eval`, `nixbot/nix-build ...`). Set
+**Commit statuses / check runs.** GitHub now receives Check Runs instead of
+commit statuses; Gitea/GitLab keep commit statuses. Names default to the
+`nixbot/` prefix (`nixbot/nix-eval`, `nixbot/nix-build ...`). Set
 `services.nixbot.statusContextPrefix = "buildbot"` to keep the buildbot-era
-names so existing branch protection rules keep working; otherwise update the
-required status checks on every repository. Statuses link to the new web UI.
+names so existing branch protection rules keep working (GitHub matches check-run
+names and commit-status contexts in the same required-checks namespace);
+otherwise update the required status checks on every repository. Grant the
+GitHub App the **Checks: read & write** permission and subscribe it to the
+**Check run** / **Check suite** events.
 
 **Webhooks.** The old GitHub endpoint (`/change_hook/github`) still works as an
 alias. `/change_hook/gitea` is gone: legacy Gitea hooks carry old buildbot
@@ -57,12 +61,12 @@ the service re-registers Gitea hooks against `/webhooks/gitea` automatically.
 However, per-repository GitHub webhooks are no longer created: events arrive
 through the App-level webhook. Enable the webhook on your GitHub App (Active,
 URL `https://<domain>/webhooks/github`, secret matching `webhookSecretFile`,
-events `push` and `pull_request`); see [docs/GITHUB.md](./docs/GITHUB.md).
-Subscribing to the `pull_request` event requires the "Pull requests: Read-only"
-repository permission. Adding a permission must be accepted on every
-installation of the app (your user account and each organization) under Settings
-→ GitHub Apps → Configure. The service logs a warning at startup if the app is
-misconfigured.
+events `push`, `pull_request`, `check_run`, `check_suite`); see
+[docs/GITHUB.md](./docs/GITHUB.md). Subscribing to the `pull_request` event
+requires the "Pull requests: Read-only" repository permission. Adding a
+permission must be accepted on every installation of the app (your user account
+and each organization) under Settings → GitHub Apps → Configure. The service
+logs a warning at startup if the app is misconfigured.
 
 Gitea webhooks now register at `https://<domain>/webhooks/gitea` with an
 auto-generated per-repository secret stored in the database —

--- a/nixbot/nixbot/bootstrap.py
+++ b/nixbot/nixbot/bootstrap.py
@@ -55,11 +55,12 @@ from .orchestrator import Orchestrator
 from .polling import PolledRepository, PollingService
 from .repos import RepoStore
 from .status import (
+    CheckRunStore,
     CommitStatusPoster,
     FailedStatusStore,
     ForgeStatusReporter,
     GiteaStatusPoster,
-    GitHubStatusPoster,
+    GitHubCheckRunPoster,
     GitlabStatusPoster,
 )
 from .visibility import AccessCache, ForgeRepoAccessFetcher, VisibilityService
@@ -200,7 +201,7 @@ def _netrc_credentials(
     )
 
 
-def _forge_clients(config: Config) -> _ForgeClients:
+def _forge_clients(config: Config, pool: asyncpg.Pool) -> _ForgeClients:
     clients = _ForgeClients()
     if config.github is not None:
         clients.github = GitHubAppClient(
@@ -211,7 +212,9 @@ def _forge_clients(config: Config) -> _ForgeClients:
         clients.credentials_providers["github"] = GitHubFetchCredentialsProvider(
             clients.github
         )
-        clients.posters["github"] = GitHubStatusPoster(clients.github)
+        clients.posters["github"] = GitHubCheckRunPoster(
+            clients.github, CheckRunStore(pool)
+        )
     if config.gitea is not None:
         clients.gitea = GiteaClient(config.gitea.instance_url, config.gitea.token)
         clients.credentials_providers["gitea"] = _netrc_credentials(config.gitea)
@@ -231,7 +234,7 @@ async def build_service(config: Config) -> tuple[CIService, FastAPI]:
     await apply_migrations(dsn)
     pool = await asyncpg.create_pool(dsn)
 
-    forges = _forge_clients(config)
+    forges = _forge_clients(config, pool)
     github, gitea, gitlab = forges.github, forges.gitea, forges.gitlab
     credentials_providers = forges.credentials_providers
     posters = forges.posters

--- a/nixbot/nixbot/db_gen/failed.py
+++ b/nixbot/nixbot/db_gen/failed.py
@@ -5,13 +5,18 @@
 from __future__ import annotations
 
 __all__: collections.abc.Sequence[str] = (
+    "CheckRunAttrRow",
     "FailedBuildByDrvRow",
     "QueryResults",
+    "check_run_attr",
     "clear_failed_status",
     "failed_build_by_drv",
     "failed_status_names",
+    "get_check_run_id",
+    "latest_build_for_sha",
     "prune_old_failed_builds",
     "prune_old_failed_statuses",
+    "upsert_check_run",
     "upsert_failed_build",
     "upsert_failed_status",
 )
@@ -34,11 +39,22 @@ from nixbot.db_gen import models
 
 
 @dataclasses.dataclass()
+class CheckRunAttrRow:
+    found: str
+    attr: str | None
+
+
+@dataclasses.dataclass()
 class FailedBuildByDrvRow:
     derivation: str
     timestamp: float
     url: str
 
+
+CHECK_RUN_ATTR: typing.Final[str] = """-- name: CheckRunAttr :one
+SELECT '' AS found, attr FROM check_runs
+WHERE project_id = $1 AND sha = $2 AND name = $3
+"""
 
 CLEAR_FAILED_STATUS: typing.Final[str] = """-- name: ClearFailedStatus :exec
 DELETE FROM failed_statuses WHERE revision = $1 AND status_name = $2
@@ -54,6 +70,16 @@ FAILED_STATUS_NAMES: typing.Final[str] = """-- name: FailedStatusNames :many
 SELECT status_name FROM failed_statuses WHERE revision = $1
 """
 
+GET_CHECK_RUN_ID: typing.Final[str] = """-- name: GetCheckRunId :one
+SELECT external_id FROM check_runs
+WHERE project_id = $1 AND sha = $2 AND name = $3
+"""
+
+LATEST_BUILD_FOR_SHA: typing.Final[str] = """-- name: LatestBuildForSha :one
+SELECT id FROM builds WHERE project_id = $1 AND commit_sha = $2
+ORDER BY id DESC LIMIT 1
+"""
+
 PRUNE_OLD_FAILED_BUILDS: typing.Final[str] = """-- name: PruneOldFailedBuilds :exec
 DELETE FROM failed_builds
 WHERE to_timestamp(timestamp) < now() - make_interval(days => $1::int)
@@ -62,6 +88,14 @@ WHERE to_timestamp(timestamp) < now() - make_interval(days => $1::int)
 PRUNE_OLD_FAILED_STATUSES: typing.Final[str] = """-- name: PruneOldFailedStatuses :exec
 DELETE FROM failed_statuses
 WHERE to_timestamp(timestamp) < now() - make_interval(days => $1::int)
+"""
+
+UPSERT_CHECK_RUN: typing.Final[str] = """-- name: UpsertCheckRun :exec
+INSERT INTO check_runs (project_id, sha, name, attr, external_id, timestamp)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (project_id, sha, name)
+DO UPDATE SET attr = EXCLUDED.attr, external_id = EXCLUDED.external_id,
+              timestamp = EXCLUDED.timestamp
 """
 
 UPSERT_FAILED_BUILD: typing.Final[str] = """-- name: UpsertFailedBuild :exec
@@ -123,6 +157,13 @@ class QueryResults(typing.Generic[T]):
         return self._decode_hook(record)
 
 
+async def check_run_attr(conn: ConnectionLike, *, project_id: int, sha: str, name: str) -> CheckRunAttrRow | None:
+    row = await conn.fetchrow(CHECK_RUN_ATTR, project_id, sha, name)
+    if row is None:
+        return None
+    return CheckRunAttrRow(found=row[0], attr=row[1])
+
+
 async def clear_failed_status(conn: ConnectionLike, *, revision: str, status_name: str) -> None:
     await conn.execute(CLEAR_FAILED_STATUS, revision, status_name)
 
@@ -138,12 +179,30 @@ def failed_status_names(conn: ConnectionLike, *, revision: str) -> QueryResults[
     return QueryResults[str](conn, FAILED_STATUS_NAMES, operator.itemgetter(0), revision)
 
 
+async def get_check_run_id(conn: ConnectionLike, *, project_id: int, sha: str, name: str) -> int | None:
+    row = await conn.fetchrow(GET_CHECK_RUN_ID, project_id, sha, name)
+    if row is None:
+        return None
+    return row[0]
+
+
+async def latest_build_for_sha(conn: ConnectionLike, *, project_id: int, commit_sha: str) -> int | None:
+    row = await conn.fetchrow(LATEST_BUILD_FOR_SHA, project_id, commit_sha)
+    if row is None:
+        return None
+    return row[0]
+
+
 async def prune_old_failed_builds(conn: ConnectionLike, *, retention_days: int) -> None:
     await conn.execute(PRUNE_OLD_FAILED_BUILDS, retention_days)
 
 
 async def prune_old_failed_statuses(conn: ConnectionLike, *, retention_days: int) -> None:
     await conn.execute(PRUNE_OLD_FAILED_STATUSES, retention_days)
+
+
+async def upsert_check_run(conn: ConnectionLike, *, project_id: int, sha: str, name: str, attr: str | None, external_id: int, timestamp: float) -> None:
+    await conn.execute(UPSERT_CHECK_RUN, project_id, sha, name, attr, external_id, timestamp)
 
 
 async def upsert_failed_build(conn: ConnectionLike, *, project_id: int, derivation: str, timestamp: float, url: str) -> None:

--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -126,6 +126,10 @@ WITH del_builds AS (
     DELETE FROM failed_builds
     WHERE to_timestamp(timestamp)
         < now() - make_interval(days => $1::int)
+), pruned_check_runs AS (
+    DELETE FROM check_runs
+    WHERE to_timestamp(timestamp)
+        < now() - make_interval(days => $1::int)
 )
 SELECT 'build' AS kind, del_builds.id FROM del_builds
 UNION ALL

--- a/nixbot/nixbot/forge/github.py
+++ b/nixbot/nixbot/forge/github.py
@@ -190,7 +190,7 @@ class GitHubAppClient:
         problems.extend(
             f"GitHub App is not subscribed to the {required!r} event; "
             "enable it under the app's 'Permissions & events' settings"
-            for required in ("push", "pull_request")
+            for required in ("push", "pull_request", "check_run", "check_suite")
             if required not in events
         )
         return problems

--- a/nixbot/nixbot/migrations/0017_check_runs.sql
+++ b/nixbot/nixbot/migrations/0017_check_runs.sql
@@ -1,0 +1,25 @@
+-- GitHub check-run ids per (project, sha, check name).
+--
+-- Keyed by sha, NOT build_id: GitHub does not dedupe check runs by
+-- name, and the same sha routinely has >=2 builds here (branch push +
+-- PR on the same commit, build reuse). Keying by build would stack
+-- duplicate nixbot/nix-eval runs in the merge box - a regression vs
+-- commit status, which dedupes by (sha, context).
+--
+-- attr is NULL for the nix-eval / nix-build summary runs and carries
+-- the attribute name for per-attr runs so a check_run rerequested
+-- webhook maps straight to restart_attribute().
+CREATE TABLE check_runs (
+    project_id  BIGINT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    sha         TEXT   NOT NULL,
+    name        TEXT   NOT NULL,
+    attr        TEXT,
+    external_id BIGINT NOT NULL,
+    -- Retention only; rows can outlive any single build on the sha.
+    timestamp   DOUBLE PRECISION NOT NULL,
+    PRIMARY KEY (project_id, sha, name)
+);
+
+-- check_suite rerequested only carries head_sha; resolve it to the
+-- newest build on that commit.
+CREATE INDEX builds_project_commit_sha_idx ON builds (project_id, commit_sha);

--- a/nixbot/nixbot/queries/failed.sql
+++ b/nixbot/nixbot/queries/failed.sql
@@ -30,3 +30,25 @@ WHERE to_timestamp(timestamp) < now() - make_interval(days => sqlc.arg(retention
 -- name: PruneOldFailedBuilds :exec
 DELETE FROM failed_builds
 WHERE to_timestamp(timestamp) < now() - make_interval(days => sqlc.arg(retention_days)::int);
+
+-- name: GetCheckRunId :one
+SELECT external_id FROM check_runs
+WHERE project_id = $1 AND sha = $2 AND name = $3;
+
+-- name: CheckRunAttr :one
+-- Unwrap ('', attr): :one returns NULL for both "no row" and a NULL
+-- attr, but the rerequested handler must distinguish a summary run
+-- (row with NULL attr -> full restart) from an unknown name (no row).
+SELECT '' AS found, attr FROM check_runs
+WHERE project_id = $1 AND sha = $2 AND name = $3;
+
+-- name: UpsertCheckRun :exec
+INSERT INTO check_runs (project_id, sha, name, attr, external_id, timestamp)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (project_id, sha, name)
+DO UPDATE SET attr = EXCLUDED.attr, external_id = EXCLUDED.external_id,
+              timestamp = EXCLUDED.timestamp;
+
+-- name: LatestBuildForSha :one
+SELECT id FROM builds WHERE project_id = $1 AND commit_sha = $2
+ORDER BY id DESC LIMIT 1;

--- a/nixbot/nixbot/queries/maintenance.sql
+++ b/nixbot/nixbot/queries/maintenance.sql
@@ -121,6 +121,10 @@ WITH del_builds AS (
     DELETE FROM failed_builds
     WHERE to_timestamp(timestamp)
         < now() - make_interval(days => sqlc.arg(retention_days)::int)
+), pruned_check_runs AS (
+    DELETE FROM check_runs
+    WHERE to_timestamp(timestamp)
+        < now() - make_interval(days => sqlc.arg(retention_days)::int)
 )
 SELECT 'build' AS kind, del_builds.id FROM del_builds
 UNION ALL

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -18,6 +18,7 @@ from . import db, discovery, restarts, scheduled_runs
 from .config import ScheduleWhen
 from .db import BuildStatus
 from .db_gen import builds as builds_q
+from .db_gen import failed as failed_q
 from .db_gen import maintenance as q
 from .events import ChangeEvent, StatusReporter
 from .gitrepo import (
@@ -36,6 +37,7 @@ from .repos import repo_info
 from .scheduled import DueEffect
 from .webhooks import (
     ChangeRequest,
+    CheckRerequested,
     PrClosed,
     WebhookEvent,
     should_build_branch,
@@ -213,7 +215,39 @@ class CIService:
                 pr_number=event.pr_number,
             )
             return
+        if isinstance(event, CheckRerequested):
+            await self._submit_rerequest(event)
+            return
         await self._submit_change(event)
+
+    async def _submit_rerequest(self, event: CheckRerequested) -> None:
+        """GitHub "Re-run" button → existing restart paths. Per-attr
+        runs restart that attr only; summary runs and check_suite
+        restart the whole build."""
+        project = await self.repo_store.by_forge_id(event.forge, event.forge_repo_id)
+        if project is None:
+            return
+        build_id = event.build_id
+        if build_id is not None:
+            build = await builds_q.get_build(self.pool, id_=build_id)
+            # external_id is attacker-influenced (set by whichever app
+            # created the run); never restart another project's build.
+            if build is None or build.project_id != project.id:
+                build_id = None
+        if build_id is None:
+            build_id = await failed_q.latest_build_for_sha(
+                self.pool, project_id=project.id, commit_sha=event.head_sha
+            )
+        if build_id is None:
+            return
+        if event.name is not None:
+            row = await failed_q.check_run_attr(
+                self.pool, project_id=project.id, sha=event.head_sha, name=event.name
+            )
+            if row is not None and row.attr is not None:
+                await self.restart_attribute(build_id, row.attr)
+                return
+        await self.restart_build(build_id)
 
     async def _submit_change(self, change: ChangeRequest) -> None:
         """Enqueue only; the dispatcher runs _process_change. The key

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -1,4 +1,9 @@
-"""Commit status reporting.
+"""Commit status / check-run reporting.
+
+GitHub uses the Check Runs API (create + PATCH by stored id);
+Gitea/GitLab keep posting commit statuses. Check-run *names* and
+commit-status *contexts* share the required-checks namespace, so
+branch protection rules are unaffected.
 
 Combined per-phase contexts are `nixbot/nix-eval` (warning count
 appended to the description) and `nixbot/nix-build`; the prefix is
@@ -46,6 +51,9 @@ if TYPE_CHECKING:
     from .forge import GiteaClient, GitHubAppClient, GitlabClient
     from .scheduler import AttributeResult
 
+# GitHub caps output.text at 65535 chars.
+CHECK_RUN_TEXT_LIMIT = 60_000
+
 logger = logging.getLogger(__name__)
 
 # Cap on remembered (build id -> posted generation) entries; one entry
@@ -71,6 +79,11 @@ class StatusPostError(Exception):
     def __init__(self, message: str, retry_after: float | None = None) -> None:
         super().__init__(message)
         self.retry_after = retry_after
+
+
+class CheckPermissionError(ForgeError):
+    """The GitHub App lacks Checks: write; latched so we stop
+    hammering the API until the operator fixes the permission."""
 
 
 def _retry_after_seconds(response: httpx.Response) -> float | None:
@@ -110,12 +123,85 @@ class CommitStatusPoster(Protocol):
         state: StatusState,
         description: str,
         target_url: str,
+        *,
+        project_id: int = 0,
+        build_id: int = 0,
+        attr: str | None = None,
+        text: str | None = None,
     ) -> None: ...
 
 
-class GitHubStatusPoster:
-    def __init__(self, client: GitHubAppClient) -> None:
+class CheckRunIds(Protocol):
+    async def get(self, project_id: int, sha: str, name: str) -> int | None: ...
+
+    async def set(
+        self, project_id: int, sha: str, name: str, attr: str | None, external_id: int
+    ) -> None: ...
+
+
+class CheckRunStore:
+    """(project, sha, name) → GitHub check-run id; lets the poster
+    PATCH the existing run instead of stacking duplicates on a SHA."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self.pool = pool
+
+    async def get(self, project_id: int, sha: str, name: str) -> int | None:
+        return await q.get_check_run_id(
+            self.pool, project_id=project_id, sha=sha, name=name
+        )
+
+    async def set(
+        self, project_id: int, sha: str, name: str, attr: str | None, external_id: int
+    ) -> None:
+        await q.upsert_check_run(
+            self.pool,
+            project_id=project_id,
+            sha=sha,
+            name=name,
+            attr=attr,
+            external_id=external_id,
+            timestamp=datetime.now(tz=UTC).timestamp(),
+        )
+
+
+# StatusState → (status, conclusion). "error" becomes cancelled so
+# dashboards separate infra problems from CI verdicts.
+_CHECK_RUN_FIELDS: dict[StatusState, tuple[str, str | None]] = {
+    StatusState.pending: ("in_progress", None),
+    StatusState.success: ("completed", "success"),
+    StatusState.failure: ("completed", "failure"),
+    StatusState.error: ("completed", "cancelled"),
+}
+
+
+def _check_run_output(context: str, summary: str, text: str | None) -> dict[str, str]:
+    # The full context repeats the repo path; keep the title short.
+    output = {"title": context.split(" ", 1)[0], "summary": summary}
+    if text:
+        if len(text) > CHECK_RUN_TEXT_LIMIT:
+            text = text[:CHECK_RUN_TEXT_LIMIT] + "\n… (truncated)"
+        output["text"] = text
+    return output
+
+
+def _raise_for_check_run(response: httpx.Response, repo: str) -> None:
+    if response.status_code == httpx.codes.FORBIDDEN:
+        msg = (
+            f"GitHub check-run post for {repo} returned 403; grant the "
+            "GitHub App the 'Checks: read & write' permission"
+        )
+        raise CheckPermissionError(msg)
+    _raise_for_status(response, repo)
+
+
+class GitHubCheckRunPoster:
+    """Upserts GitHub check runs. external_id is set to our build id
+    so a check_run rerequested webhook hands it straight back."""
+
+    def __init__(self, client: GitHubAppClient, store: CheckRunIds) -> None:
         self.client = client
+        self.store = store
 
     async def post(  # noqa: PLR0913
         self,
@@ -126,23 +212,49 @@ class GitHubStatusPoster:
         state: StatusState,
         description: str,
         target_url: str,
+        *,
+        project_id: int = 0,
+        build_id: int = 0,
+        attr: str | None = None,
+        text: str | None = None,
     ) -> None:
         installation_id = await self.client.installation_for_repo(f"{owner}/{repo}")
         if installation_id is None:
             # installation_for_repo already logged the failed lookup.
             return
         token = await self.client.installation_token(installation_id)
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        }
+        status, conclusion = _CHECK_RUN_FIELDS[state]
+        body: dict[str, object] = {
+            "name": context,
+            "status": status,
+            "external_id": str(build_id),
+            "details_url": target_url,
+            "output": _check_run_output(context, description, text),
+        }
+        if conclusion is not None:
+            body["conclusion"] = conclusion
+
+        base = f"{self.client.api_url}/repos/{owner}/{repo}/check-runs"
+        run_id = await self.store.get(project_id, sha, context)
+        if run_id is not None:
+            response = await self.client.http.patch(
+                f"{base}/{run_id}", headers=headers, json=body
+            )
+            # The DB row can outlive the GitHub run; recreate instead
+            # of retrying the terminal summary forever.
+            if response.status_code not in (httpx.codes.NOT_FOUND, httpx.codes.GONE):
+                _raise_for_check_run(response, f"{owner}/{repo}")
+                await self.store.set(project_id, sha, context, attr, run_id)
+                return
         response = await self.client.http.post(
-            f"{self.client.api_url}/repos/{owner}/{repo}/statuses/{sha}",
-            headers={"Authorization": f"Bearer {token}"},
-            json={
-                "state": state.value,
-                "context": context,
-                "description": description[:140],
-                "target_url": target_url,
-            },
+            base, headers=headers, json=body | {"head_sha": sha}
         )
-        _raise_for_status(response, f"{owner}/{repo}")
+        _raise_for_check_run(response, f"{owner}/{repo}")
+        await self.store.set(project_id, sha, context, attr, int(response.json()["id"]))
 
 
 class GiteaStatusPoster:
@@ -158,6 +270,7 @@ class GiteaStatusPoster:
         state: StatusState,
         description: str,
         target_url: str,
+        **_: object,
     ) -> None:
         response = await self.client.http.post(
             f"{self.client.instance_url}/api/v1/repos/{owner}/{repo}/statuses/{sha}",
@@ -193,6 +306,7 @@ class GitlabStatusPoster:
         state: StatusState,
         description: str,
         target_url: str,
+        **_: object,
     ) -> None:
         response = await self.client.http.post(
             f"{self.client.project_api_url(owner, repo)}/statuses/{sha}",
@@ -281,6 +395,10 @@ class ForgeStatusReporter:
         self.base_url = base_url.rstrip("/")
         self.failed_build_report_limit = failed_build_report_limit
         self.context_prefix = context_prefix
+        # Forges whose poster is latched off after a permission error;
+        # without the latch a missing Checks grant would fill the
+        # report queue and hammer the API on every build.
+        self._disabled: set[str] = set()
         # build id -> highest generation posted (drop stale posts).
         # Bounded LRU: stale-post races only matter around a build's
         # final re-aggregation, so old entries are safe to evict.
@@ -297,10 +415,12 @@ class ForgeStatusReporter:
         state: StatusState,
         description: str,
         *,
+        attr: str | None = None,
+        text: str | None = None,
         propagate: bool = False,
     ) -> None:
         poster = self.posters.get(event.repo.forge)
-        if poster is None:
+        if poster is None or event.repo.forge in self._disabled:
             return
         try:
             await poster.post(
@@ -313,7 +433,17 @@ class ForgeStatusReporter:
                 # colors (kept for the web UI); forges show them verbatim.
                 strip_ansi(description),
                 self.build_url(event, build),
+                project_id=event.repo.id,
+                build_id=build.id,
+                attr=attr,
+                text=text,
             )
+        except CheckPermissionError:
+            logger.exception(
+                "disabling status posting until restart",
+                extra={"forge": event.repo.forge},
+            )
+            self._disabled.add(event.repo.forge)
         except (httpx.HTTPError, ForgeError, StatusPostError):
             # Transient failures must not propagate into the
             # orchestrator task and leave builds stuck — except the
@@ -348,6 +478,7 @@ class ForgeStatusReporter:
             f"{self.context_prefix}/nix-eval",
             StatusState.success if success else StatusState.failure,
             eval_description(success, warnings),
+            text=_fence("\n".join(warnings)) if warnings else None,
         )
         if success:
             await self._post(
@@ -393,13 +524,14 @@ class ForgeStatusReporter:
             self._posted_generations.popitem(last=False)
 
         counts = await self._post_attribute_statuses(event, build, results, attr_prefix)
+        table = _failure_table(results, attr_statuses)
         if attr_statuses is not None:
             # Reruns pass only the re-run subset as `results`: the
             # summary description must still cover the whole build.
             counts = {"failed": 0, "succeeded": 0, "cancelled": 0}
             for attr_status in attr_statuses.values():
                 counts[_count_key(attr_status)] += 1
-        await self._post_summary(event, build, status, counts)
+        await self._post_summary(event, build, status, counts, table)
 
     async def _post_attribute_statuses(
         self,
@@ -435,7 +567,13 @@ class ForgeStatusReporter:
                 await self.failed_statuses.mark_failed(revision, context)
                 description = result.error or result.status.value
                 await self._post(
-                    event, build, context, StatusState.failure, description
+                    event,
+                    build,
+                    context,
+                    StatusState.failure,
+                    description,
+                    attr=result.attr,
+                    text=_fence(result.error) if result.error else None,
                 )
             else:
                 counts["succeeded"] += 1
@@ -443,7 +581,12 @@ class ForgeStatusReporter:
                     # Success-flip for a previously failed status.
                     await self.failed_statuses.clear(revision, context)
                     await self._post(
-                        event, build, context, StatusState.success, "succeeded"
+                        event,
+                        build,
+                        context,
+                        StatusState.success,
+                        "succeeded",
+                        attr=result.attr,
                     )
         return counts
 
@@ -453,6 +596,7 @@ class ForgeStatusReporter:
         build: BuildRecord,
         status: str,
         counts: dict[str, int],
+        table: str | None,
     ) -> None:
         if status == "succeeded":
             state = StatusState.success
@@ -481,5 +625,47 @@ class ForgeStatusReporter:
             f"{self.context_prefix}/nix-build",
             state,
             description or "failed",
+            text=table,
             propagate=True,
         )
+
+
+def _fence(text: str) -> str:
+    return f"```\n{strip_ansi(text)}\n```"
+
+
+def _failure_table(
+    results: list[AttributeResult], attr_statuses: dict[str, str] | None
+) -> str | None:
+    """Markdown failure table for the nix-build check run; one place
+    to see every failure even when per-attr runs hit the report cap.
+    Reruns pass attr_statuses (full build) plus a results subset; the
+    table must match the summary count, so attr_statuses wins (no
+    error column available there)."""
+    errors = {r.attr: r.error for r in results}
+    items = (
+        sorted(attr_statuses.items())
+        if attr_statuses is not None
+        else ((r.attr, r.status.value) for r in results)
+    )
+    rows = [
+        (
+            attr,
+            status,
+            strip_ansi(errors.get(attr) or "")
+            .split("\n", 1)[0][:200]
+            .replace("|", "\\|"),
+        )
+        for attr, status in items
+        if status in FAILED_STATUS_STATES
+    ]
+    if not rows:
+        return None
+    lines = ["| attr | status | error |", "| --- | --- | --- |"]
+    for attr, status, err in rows:
+        line = f"| `{attr}` | {status} | {err} |"
+        if sum(map(len, lines)) + len(line) > CHECK_RUN_TEXT_LIMIT:
+            lines.append(f"| … | | {len(rows) - (len(lines) - 2)} more |")
+            break
+        lines.append(line)
+    return "\n".join(lines)

--- a/nixbot/nixbot/tests/test_bootstrap.py
+++ b/nixbot/nixbot/tests/test_bootstrap.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import shutil
+import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -19,7 +22,6 @@ from .support import make_config
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
-    from pathlib import Path
 
     import pytest
 
@@ -132,7 +134,10 @@ async def test_lifespan_runs_once_with_two_listeners(tmp_path: Path) -> None:
             stops.append("x")
 
     app = FastAPI(lifespan=lifespan)
-    sock = tmp_path / "web.sock"
+    # AF_UNIX paths cap at ~107 bytes; xdist's nested tmp_path easily
+    # exceeds that, so bind under a short tempdir.
+    sock_dir = Path(tempfile.mkdtemp(prefix="nb-"))
+    sock = sock_dir / "web.sock"
     config = make_config(
         "postgresql://x", tmp_path, http_unix_socket=sock, http_listen=True
     )
@@ -145,5 +150,6 @@ async def test_lifespan_runs_once_with_two_listeners(tmp_path: Path) -> None:
     task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await task
+    shutil.rmtree(sock_dir, ignore_errors=True)
     assert starts == ["x"]
     assert stops == ["x"]

--- a/nixbot/nixbot/tests/test_db.py
+++ b/nixbot/nixbot/tests/test_db.py
@@ -18,7 +18,7 @@ from nixbot.failed_builds import PostgresFailedBuildCache
 from nixbot.migrations import apply_migrations, load_migrations
 from nixbot.models import CacheStatus
 from nixbot.scheduler import AttributeResult, AttributeStatus
-from nixbot.status import FailedStatusStore
+from nixbot.status import CheckRunStore, FailedStatusStore
 
 from .support import attribute_statuses, db_pool, insert_build, insert_project, mk_job
 
@@ -141,6 +141,17 @@ async def test_schema_constraints(postgres_dsn: str) -> None:
         assert await conn.fetchval("SELECT count(*) FROM logs") == 0
     finally:
         await conn.close()
+
+
+async def test_check_run_store_round_trip(pool: asyncpg.Pool) -> None:
+    project_id = await insert_project(pool, forge_repo_id="check-run-store")
+    store = CheckRunStore(pool)
+    assert await store.get(project_id, "sha", "ctx") is None
+    await store.set(project_id, "sha", "ctx", "flaky", 555)
+    assert await store.get(project_id, "sha", "ctx") == 555
+    # Upsert overwrites (later build on the same sha takes over).
+    await store.set(project_id, "sha", "ctx", None, 777)
+    assert await store.get(project_id, "sha", "ctx") == 777
 
 
 async def test_failed_status_store_component(pool: asyncpg.Pool) -> None:

--- a/nixbot/nixbot/tests/test_forge.py
+++ b/nixbot/nixbot/tests/test_forge.py
@@ -39,9 +39,10 @@ from nixbot.reconcile import (
 from nixbot.repos import RepoStore
 from nixbot.status import (
     GiteaStatusPoster,
-    GitHubStatusPoster,
+    GitHubCheckRunPoster,
     StatusState,
 )
+from nixbot.tests.test_status import _MemoryCheckRunIds
 
 from .support import (
     FakeGitea,
@@ -110,7 +111,7 @@ def test_filter_repos(filters: RepoFilters, expected_indices: list[int]) -> None
 
 def github_transport(
     hook_url: str = "https://buildbot.example.com/webhooks/github",
-    events: tuple[str, ...] = ("push", "pull_request"),
+    events: tuple[str, ...] = ("push", "pull_request", "check_run", "check_suite"),
 ) -> httpx.MockTransport:
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
@@ -179,6 +180,7 @@ async def test_github_webhook_check_misconfigured(
     problems = await github_client.check_app_webhook("https://buildbot.example.com")
     assert any("webhook URL" in p for p in problems)
     assert any("pull_request" in p for p in problems)
+    assert any("check_run" in p for p in problems)
 
 
 @pytest.mark.skipif(shutil.which("openssl") is None, reason="openssl required")
@@ -820,14 +822,17 @@ async def test_reconcile_watermark_store(pool: asyncpg.Pool) -> None:
 
 
 @pytest.mark.skipif(shutil.which("openssl") is None, reason="openssl required")
-async def test_github_status_post(github_client: GitHubAppClient) -> None:
+async def test_github_check_run_post(github_client: GitHubAppClient) -> None:
+    """End-to-end through the real App client (JWT, installation
+    token, repo lookup); the upsert/PATCH details are covered in
+    test_status."""
     posted: list[dict] = []
     fallback = github_transport()
 
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/repos/acme/repo11/statuses/sha1":
+        if request.url.path == "/repos/acme/repo11/check-runs":
             posted.append(json.loads(request.content))
-            return httpx.Response(201, json={})
+            return httpx.Response(201, json={"id": 1})
         return fallback.handler(request)  # type: ignore[attr-defined,return-value]
 
     github_client.http = httpx.AsyncClient(
@@ -835,7 +840,7 @@ async def test_github_status_post(github_client: GitHubAppClient) -> None:
     )
 
     await github_client.discover_repos()
-    poster = GitHubStatusPoster(github_client)
+    poster = GitHubCheckRunPoster(github_client, _MemoryCheckRunIds())
     await poster.post(
         "acme",
         "repo11",
@@ -844,13 +849,18 @@ async def test_github_status_post(github_client: GitHubAppClient) -> None:
         StatusState.success,
         "evaluation succeeded",
         "https://ci.test/repos/acme/repo11/builds/1",
+        project_id=1,
+        build_id=1,
     )
     assert posted == [
         {
-            "state": "success",
-            "context": "nixbot/nix-eval",
-            "description": "evaluation succeeded",
-            "target_url": "https://ci.test/repos/acme/repo11/builds/1",
+            "name": "nixbot/nix-eval",
+            "head_sha": "sha1",
+            "status": "completed",
+            "conclusion": "success",
+            "external_id": "1",
+            "details_url": "https://ci.test/repos/acme/repo11/builds/1",
+            "output": {"title": "nixbot/nix-eval", "summary": "evaluation succeeded"},
         }
     ]
 

--- a/nixbot/nixbot/tests/test_service.py
+++ b/nixbot/nixbot/tests/test_service.py
@@ -24,7 +24,8 @@ from nixbot.events import NullStatusReporter
 from nixbot.forge import DiscoveredRepo
 from nixbot.scheduled import DueEffect, ScheduleWhen
 from nixbot.scheduled_runs import scheduled_worktree_id
-from nixbot.webhooks import ChangeRequest, PrClosed
+from nixbot.status import CheckRunStore
+from nixbot.webhooks import ChangeRequest, CheckRerequested, PrClosed
 from nixbot.work_queue import WorkQueue
 
 from .support import FakeGitlab, git, insert_build, insert_project, make_config
@@ -524,6 +525,46 @@ async def test_cancel_not_running_posts_forge_status(service: CIService) -> None
     # Cancelling again is a no-op: no duplicate forge status.
     await service.cancel_build(build_id)
     assert len(reporter.finished) == 1
+
+
+async def test_check_rerequested_dispatch(service: CIService) -> None:
+    """GitHub Re-run button: per-attr name -> attribute restart,
+    summary / suite -> full restart, foreign external_id falls back
+    to the head_sha lookup."""
+    pool = service.pool
+    project_id = await seed_project(pool, "http://example/repo")
+    forge_repo_id = await pool.fetchval(
+        "SELECT forge_repo_id FROM projects WHERE id = $1", project_id
+    )
+    build_id = await insert_build(pool, project_id, commit_sha="deadbeef")
+    store = CheckRunStore(pool)
+    await store.set(project_id, "deadbeef", "nixbot/nix-build", None, 1)
+    await store.set(project_id, "deadbeef", "nixbot/nix-build a", "flaky", 2)
+
+    enqueued: list[tuple[str, dict]] = []
+
+    async def fake_enqueue(kind: str, key: str, payload: dict) -> None:
+        enqueued.append((kind, payload))
+
+    service.enqueue_work = fake_enqueue  # type: ignore[method-assign,assignment]
+
+    base = {"forge": "github", "forge_repo_id": forge_repo_id, "head_sha": "deadbeef"}
+    await service.submit(
+        CheckRerequested(**base, build_id=build_id, name="nixbot/nix-build a")
+    )
+    await service.submit(
+        CheckRerequested(**base, build_id=build_id, name="nixbot/nix-build")
+    )
+    # check_suite: no build_id, no name; resolved via LatestBuildForSha.
+    await service.submit(CheckRerequested(**base))
+    # external_id from another project's app must not be honoured.
+    await service.submit(CheckRerequested(**base, build_id=99999999))
+    assert enqueued == [
+        ("restart", {"build_id": build_id, "attr": "flaky"}),
+        ("restart", {"build_id": build_id}),
+        ("restart", {"build_id": build_id}),
+        ("restart", {"build_id": build_id}),
+    ]
 
 
 async def test_cancel_not_running_settles_attribute_rows(service: CIService) -> None:

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from nixbot.forge import GitHubAppClient
 
 import httpx
 import pytest
@@ -18,10 +22,15 @@ from nixbot.forge import GitlabClient
 from nixbot.models import NixEvalJobError
 from nixbot.scheduler import AttributeResult, AttributeStatus
 from nixbot.status import (
+    CHECK_RUN_TEXT_LIMIT,
     POSTED_GENERATIONS_MAX,
+    CheckPermissionError,
     ForgeStatusReporter,
+    GitHubCheckRunPoster,
     GitlabStatusPoster,
     StatusState,
+    _check_run_output,
+    _failure_table,
     attr_status_context,
     eval_description,
 )
@@ -39,6 +48,7 @@ class Posted:
 @dataclass
 class FakePoster:
     posts: list[Posted] = field(default_factory=list)
+    extras: list[dict] = field(default_factory=list)
 
     async def post(  # noqa: PLR0913
         self,
@@ -49,8 +59,10 @@ class FakePoster:
         state: StatusState,
         description: str,
         target_url: str,
+        **extra: object,
     ) -> None:
         self.posts.append(Posted(sha, context, state, description, target_url))
+        self.extras.append(extra)
 
 
 class MemoryFailedStatuses:
@@ -389,6 +401,229 @@ async def test_poster_network_errors_do_not_propagate() -> None:
     await reporter.build_started(EVENT, BUILD)  # must not raise
     with pytest.raises(httpx.ConnectError):
         await reporter.build_finished(EVENT, BUILD, "succeeded", 1, [])
+
+
+async def test_reporter_forwards_attr_and_text() -> None:
+    """Per-attr posts carry the attr (so the check-run store records
+    it for rerequested) and the full error as markdown text; the eval
+    run carries the warnings."""
+    reporter, poster, _ = make_reporter()
+
+    await reporter.eval_finished(EVENT, BUILD, success=True, warnings=["w1", "w2"])
+    eval_extra = poster.extras[0]
+    assert eval_extra["text"] == "```\nw1\nw2\n```"
+    assert eval_extra["project_id"] == PROJECT.id
+    assert eval_extra["build_id"] == BUILD.id
+
+    poster.posts.clear()
+    poster.extras.clear()
+    await reporter.build_finished(
+        EVENT,
+        BUILD,
+        "failed",
+        1,
+        [attr_result("flaky", AttributeStatus.failed, error="log line 1\nline 2")],
+    )
+    attr_idx = next(
+        i
+        for i, p in enumerate(poster.posts)
+        if p.context.startswith("nixbot/nix-build ")
+    )
+    assert poster.extras[attr_idx]["attr"] == "flaky"
+    assert poster.extras[attr_idx]["text"] == "```\nlog line 1\nline 2\n```"
+    summary_idx = next(
+        i for i, p in enumerate(poster.posts) if p.context == "nixbot/nix-build"
+    )
+    assert "`flaky`" in (poster.extras[summary_idx]["text"] or "")
+
+
+async def test_check_permission_error_latches() -> None:
+    """A missing Checks grant must not fill the report queue or
+    hammer the API on every build."""
+    calls = 0
+
+    class ForbiddenPoster:
+        async def post(self, *args: object, **kwargs: object) -> None:
+            nonlocal calls
+            calls += 1
+            msg = "403"
+            raise CheckPermissionError(msg)
+
+    reporter = ForgeStatusReporter(
+        {"github": ForbiddenPoster()}, MemoryFailedStatuses(), "https://ci"
+    )
+    await reporter.build_started(EVENT, BUILD)
+    await reporter.build_finished(EVENT, BUILD, "succeeded", 1, [])
+    assert calls == 1  # latched after the first 403
+
+
+def test_failure_table() -> None:
+    table = _failure_table(
+        [
+            attr_result(
+                "a", AttributeStatus.failed, error="\x1b[31mboom | bang\x1b[0m"
+            ),
+            attr_result("b", AttributeStatus.succeeded),
+        ],
+        None,
+    )
+    assert table is not None
+    assert table.startswith("| attr |")
+    assert "`a`" in table
+    assert "boom \\| bang" in table
+    assert "`b`" not in table
+    # Re-report path: no results, attr_statuses only.
+    table = _failure_table([], {"a": "failed", "b": "succeeded"})
+    assert table is not None
+    assert "`a`" in table
+    assert "`b`" not in table
+    assert _failure_table([], {"a": "succeeded"}) is None
+
+
+def test_check_run_output_title_and_truncate() -> None:
+    out = _check_run_output("nixbot/nix-build repo#a", "summary", "body")
+    assert out == {"title": "nixbot/nix-build", "summary": "summary", "text": "body"}
+    out = _check_run_output("ctx", "s", "x" * (CHECK_RUN_TEXT_LIMIT + 100))
+    assert "truncated" in out["text"]
+    assert "text" not in _check_run_output("ctx", "s", None)
+
+
+# --- GitHub check-run poster -----------------------------------------------
+
+
+class _MemoryCheckRunIds:
+    def __init__(self) -> None:
+        self.ids: dict[tuple[int, str, str], tuple[str | None, int]] = {}
+
+    async def get(self, project_id: int, sha: str, name: str) -> int | None:
+        entry = self.ids.get((project_id, sha, name))
+        return entry[1] if entry else None
+
+    async def set(
+        self, project_id: int, sha: str, name: str, attr: str | None, external_id: int
+    ) -> None:
+        self.ids[(project_id, sha, name)] = (attr, external_id)
+
+
+class _StubGitHub:
+    """Just enough GitHubAppClient for GitHubCheckRunPoster."""
+
+    api_url = "https://api.github.com"
+
+    def __init__(self, transport: httpx.MockTransport) -> None:
+        self.http = httpx.AsyncClient(transport=transport)
+
+    async def installation_for_repo(self, name: str) -> int | None:
+        return 11
+
+    async def installation_token(self, installation_id: int) -> str:
+        return "ghs_token"
+
+
+def _check_run_poster(
+    handler: httpx.MockTransport, store: _MemoryCheckRunIds
+) -> GitHubCheckRunPoster:
+    return GitHubCheckRunPoster(cast("GitHubAppClient", _StubGitHub(handler)), store)
+
+
+async def test_github_check_run_poster_upsert() -> None:
+    requests: list[tuple[str, str, dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        requests.append((request.method, request.url.path, body))
+        if request.method == "POST":
+            return httpx.Response(201, json={"id": 555})
+        return httpx.Response(
+            200, json={"id": int(request.url.path.rsplit("/", 1)[-1])}
+        )
+
+    store = _MemoryCheckRunIds()
+    poster = _check_run_poster(httpx.MockTransport(handler), store)
+
+    await poster.post(
+        "acme",
+        "widget",
+        "sha1",
+        "nixbot/nix-eval",
+        StatusState.pending,
+        "d",
+        "u",
+        project_id=1,
+        build_id=10,
+    )
+    await poster.post(
+        "acme",
+        "widget",
+        "sha1",
+        "nixbot/nix-eval",
+        StatusState.error,
+        "d",
+        "u",
+        project_id=1,
+        build_id=10,
+    )
+    assert [r[0] for r in requests] == ["POST", "PATCH"]
+    assert requests[0][1] == "/repos/acme/widget/check-runs"
+    assert requests[1][1] == "/repos/acme/widget/check-runs/555"
+    create = requests[0][2]
+    assert create["head_sha"] == "sha1"
+    assert create["external_id"] == "10"
+    assert create["status"] == "in_progress"
+    assert "conclusion" not in create
+    patch = requests[1][2]
+    assert patch["status"] == "completed"
+    assert patch["conclusion"] == "cancelled"
+    assert store.ids[(1, "sha1", "nixbot/nix-eval")] == (None, 555)
+
+
+async def test_github_check_run_patch_404_recreates() -> None:
+    """The DB row outlives the GitHub run; without the fallback the
+    terminal summary would retry forever via the report work item."""
+    methods: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        methods.append(request.method)
+        if request.method == "PATCH":
+            return httpx.Response(404, json={})
+        return httpx.Response(201, json={"id": 777})
+
+    store = _MemoryCheckRunIds()
+    store.ids[(1, "sha1", "ctx")] = (None, 1)  # stale
+    poster = _check_run_poster(httpx.MockTransport(handler), store)
+
+    await poster.post(
+        "acme",
+        "widget",
+        "sha1",
+        "ctx",
+        StatusState.success,
+        "d",
+        "u",
+        project_id=1,
+        build_id=10,
+    )
+    assert methods == ["PATCH", "POST"]
+    assert store.ids[(1, "sha1", "ctx")] == (None, 777)
+
+
+async def test_github_check_run_403_is_permission_error() -> None:
+    poster = _check_run_poster(
+        httpx.MockTransport(lambda _r: httpx.Response(403, json={})),
+        _MemoryCheckRunIds(),
+    )
+    with pytest.raises(CheckPermissionError):
+        await poster.post(
+            "acme",
+            "widget",
+            "sha1",
+            "ctx",
+            StatusState.pending,
+            "d",
+            "u",
+            project_id=1,
+            build_id=10,
+        )
 
 
 async def test_gitlab_status_states() -> None:

--- a/nixbot/nixbot/tests/test_webhooks.py
+++ b/nixbot/nixbot/tests/test_webhooks.py
@@ -21,6 +21,7 @@ from nixbot.config import BranchConfig, BranchConfigDict
 from nixbot.gitrepo import RepoManager
 from nixbot.webhooks import (
     ChangeRequest,
+    CheckRerequested,
     DeliveryDeduper,
     PrClosed,
     WebhookEvent,
@@ -176,6 +177,58 @@ def test_parse_github_pr() -> None:
 
     payload["action"] = "labeled"
     assert parse_github_event("pull_request", payload) is None
+
+
+def test_parse_github_check_rerequested() -> None:
+    run = {"head_sha": "abc", "name": "nixbot/nix-build", "external_id": "42"}
+    event = parse_github_event(
+        "check_run",
+        {"action": "rerequested", "repository": {"id": 7}, "check_run": run},
+    )
+    assert event == CheckRerequested(
+        forge="github",
+        forge_repo_id="7",
+        head_sha="abc",
+        build_id=42,
+        name="nixbot/nix-build",
+    )
+    # Our own created/completed echoes are ignored.
+    assert (
+        parse_github_event(
+            "check_run",
+            {"action": "completed", "repository": {"id": 7}, "check_run": run},
+        )
+        is None
+    )
+    # Runs from other apps carry no integer external_id.
+    run2 = {"head_sha": "abc", "name": "other/ci", "external_id": ""}
+    event = parse_github_event(
+        "check_run",
+        {"action": "rerequested", "repository": {"id": 7}, "check_run": run2},
+    )
+    assert isinstance(event, CheckRerequested)
+    assert event.build_id is None
+
+
+def test_parse_github_check_suite_rerequested() -> None:
+    suite = {"head_sha": "abc"}
+    event = parse_github_event(
+        "check_suite",
+        {"action": "rerequested", "repository": {"id": 7}, "check_suite": suite},
+    )
+    assert event == CheckRerequested(
+        forge="github",
+        forge_repo_id="7",
+        head_sha="abc",
+    )
+    # "requested" fires on every push and would double-trigger.
+    assert (
+        parse_github_event(
+            "check_suite",
+            {"action": "requested", "repository": {"id": 7}, "check_suite": suite},
+        )
+        is None
+    )
 
 
 def test_parse_github_pr_retarget() -> None:

--- a/nixbot/nixbot/webhooks.py
+++ b/nixbot/nixbot/webhooks.py
@@ -132,7 +132,21 @@ class PrClosed:
     pr_number: int
 
 
-WebhookEvent = ChangeRequest | PrClosed
+@dataclass(frozen=True)
+class CheckRerequested:
+    """GitHub "Re-run" button. build_id round-trips via the check
+    run's external_id (set by GitHubCheckRunPoster); name resolves the
+    per-attr restart. check_suite carries neither — head_sha is the
+    fallback."""
+
+    forge: str
+    forge_repo_id: str
+    head_sha: str
+    build_id: int | None = None
+    name: str | None = None
+
+
+WebhookEvent = ChangeRequest | PrClosed | CheckRerequested
 
 
 def _pr_action_builds(action: str, payload: dict[str, Any], sync_action: str) -> bool:
@@ -181,7 +195,9 @@ def _parse_pr_event(
     )
 
 
-def parse_github_event(event_type: str, payload: dict[str, Any]) -> WebhookEvent | None:
+def parse_github_event(  # noqa: PLR0911
+    event_type: str, payload: dict[str, Any]
+) -> WebhookEvent | None:
     repo = payload.get("repository") or {}
     repo_id = str(repo.get("id", ""))
     if not repo_id:
@@ -203,7 +219,34 @@ def parse_github_event(event_type: str, payload: dict[str, Any]) -> WebhookEvent
         )
     if event_type == "pull_request":
         return _parse_pr_event("github", repo_id, payload, "synchronize")
+    if event_type in ("check_run", "check_suite"):
+        return _parse_github_check_event(event_type, repo_id, payload)
     return None
+
+
+def _parse_github_check_event(
+    event_type: str, repo_id: str, payload: dict[str, Any]
+) -> CheckRerequested | None:
+    # "requested" fires on every push (push hook already covers that)
+    # and "created"/"completed" are echoes of our own posts; only the
+    # explicit Re-run button matters.
+    if payload.get("action") != "rerequested":
+        return None
+    obj = payload.get(event_type) or {}
+    if event_type == "check_suite":
+        return CheckRerequested(
+            forge="github", forge_repo_id=repo_id, head_sha=obj.get("head_sha", "")
+        )
+    external = obj.get("external_id") or ""
+    return CheckRerequested(
+        forge="github",
+        forge_repo_id=repo_id,
+        head_sha=obj.get("head_sha", ""),
+        # Runs from other apps carry no (or a non-integer) external id;
+        # fall back to the head_sha lookup.
+        build_id=int(external) if external.isdigit() else None,
+        name=obj.get("name"),
+    )
 
 
 def parse_gitea_event(event_type: str, payload: dict[str, Any]) -> WebhookEvent | None:

--- a/nixosModules/nixbot.nix
+++ b/nixosModules/nixbot.nix
@@ -501,11 +501,11 @@ in
       default = "nixbot";
       example = "buildbot";
       description = ''
-        Prefix of commit status contexts ("<prefix>/nix-eval",
-        "<prefix>/nix-build"). Set to "buildbot" when migrating from
-        buildbot-nix to keep existing branch protection rules working;
-        changing the prefix requires updating required status checks on
-        every repository.
+        Prefix of check-run names / commit-status contexts
+        ("<prefix>/nix-eval", "<prefix>/nix-build"). Set to "buildbot"
+        when migrating from buildbot-nix to keep existing branch
+        protection rules working; changing the prefix requires updating
+        required status checks on every repository.
       '';
     };
 
@@ -513,9 +513,9 @@ in
       type = lib.types.ints.unsigned;
       default = 47;
       description = ''
-        Maximum number of failed builds reported individually per evaluation
-        (3 of the typical 50 commit-status slots stay reserved for the
-        eval/build/effects summary statuses).
+        Maximum number of failed builds reported as individual check
+        runs / commit statuses per evaluation (3 of the typical 50
+        slots stay reserved for the eval/build/effects summaries).
       '';
     };
 


### PR DESCRIPTION
GitHub now gets Check Runs instead of commit statuses, same as gitea-mq. That gives us markdown bodies (eval warnings, log excerpts, a failure table on nix-build) and a working Re-run button that maps onto the existing restart paths. Gitea/GitLab keep posting commit statuses; check-run names equal the old contexts so branch protection rules keep matching.

To migrate, on your GitHub App: grant the Checks read/write repository permission, subscribe to the Check run and Check suite events, and accept the permission change on each installation. Without the permission the first post 403s and status posting is latched off with a log line telling you what to grant.

Also fixes the lifespan test that flaked under xdist because the unix socket path overflowed AF_UNIX.