### PR TITLE
status: don't disable a forge on a missing Checks grant

### DIFF
--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -395,10 +395,6 @@ class ForgeStatusReporter:
         self.base_url = base_url.rstrip("/")
         self.failed_build_report_limit = failed_build_report_limit
         self.context_prefix = context_prefix
-        # Forges whose poster is latched off after a permission error;
-        # without the latch a missing Checks grant would fill the
-        # report queue and hammer the API on every build.
-        self._disabled: set[str] = set()
         # build id -> highest generation posted (drop stale posts).
         # Bounded LRU: stale-post races only matter around a build's
         # final re-aggregation, so old entries are safe to evict.
@@ -420,7 +416,7 @@ class ForgeStatusReporter:
         propagate: bool = False,
     ) -> None:
         poster = self.posters.get(event.repo.forge)
-        if poster is None or event.repo.forge in self._disabled:
+        if poster is None:
             return
         try:
             await poster.post(
@@ -439,11 +435,12 @@ class ForgeStatusReporter:
                 text=text,
             )
         except CheckPermissionError:
+            # Per-org and not transient: log the hint and move on, never
+            # latch off posting for the whole forge.
             logger.exception(
-                "disabling status posting until restart",
+                "failed to post commit status",
                 extra={"forge": event.repo.forge},
             )
-            self._disabled.add(event.repo.forge)
         except (httpx.HTTPError, ForgeError, StatusPostError):
             # Transient failures must not propagate into the
             # orchestrator task and leave builds stuck — except the

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -437,9 +437,9 @@ async def test_reporter_forwards_attr_and_text() -> None:
     assert "`flaky`" in (poster.extras[summary_idx]["text"] or "")
 
 
-async def test_check_permission_error_latches() -> None:
-    """A missing Checks grant must not fill the report queue or
-    hammer the API on every build."""
+async def test_check_permission_error_does_not_disable_forge() -> None:
+    """One repo's missing Checks grant must not stop posting for every
+    other repo: a 403 is logged and swallowed, never latched off."""
     calls = 0
 
     class ForbiddenPoster:
@@ -454,7 +454,8 @@ async def test_check_permission_error_latches() -> None:
     )
     await reporter.build_started(EVENT, BUILD)
     await reporter.build_finished(EVENT, BUILD, "succeeded", 1, [])
-    assert calls == 1  # latched after the first 403
+    # Both phases still attempt to post; the forge is never latched off.
+    assert calls == 2
 
 
 def test_failure_table() -> None:


### PR DESCRIPTION
A single org without the GitHub App's Checks permission returned 403, which latched off commit-status posting for the whole forge until the next restart. One org's missing grant then silently stopped status updates for every other repo. Log the actionable hint and continue.