### PR TITLE
nixbot: bundle build_finished parameters into BuildResult

### DIFF
--- a/nixbot/nixbot/build_reuse.py
+++ b/nixbot/nixbot/build_reuse.py
@@ -18,12 +18,12 @@ from .canceller import RegisterOutcome
 from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
+from .events import BuildResult
 from .gitrepo import GitError, run_git
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from .build_scheduler import AttributeResult
     from .db import BuildRecord
     from .events import ChangeEvent
     from .gitrepo import FetchCredentials
@@ -65,16 +65,14 @@ async def replay_terminal_status(
         )
         await o.reporter.eval_finished(event, build, success=eval_success, warnings=[])
     await o.reporter.build_finished(
-        event, build, build.status, build.status_generation, []
+        event, build, BuildResult(build.status, build.status_generation, [])
     )
 
 
-async def finish_linked(  # noqa: PLR0913
+async def finish_linked(
     o: Orchestrator,
     build: BuildRecord,
-    status: str,
-    generation: int,
-    results: list[AttributeResult],
+    result: BuildResult,
     *,
     eval_success: bool | None = None,
 ) -> None:
@@ -85,11 +83,11 @@ async def finish_linked(  # noqa: PLR0913
             await o.reporter.eval_finished(
                 linked, build, success=eval_success, warnings=[]
             )
-        elif status == BuildStatus.CANCELLED:
+        elif result.status == BuildStatus.CANCELLED:
             # Cancel during eval: the linked contexts' nix-eval
             # status would otherwise stay pending forever.
             await o.reporter.eval_cancelled(linked, build)
-        await o.reporter.build_finished(linked, build, status, generation, results)
+        await o.reporter.build_finished(linked, build, result)
 
 
 async def is_ancestor(

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -25,6 +25,7 @@ from .build_scheduler import (
 )
 from .db import BuildStatus
 from .db_gen import builds as q
+from .events import BuildResult
 from .executor import failure_excerpt
 from .live_warnings import LiveWarningAggregator
 from .memory import calculate_eval_workers
@@ -191,12 +192,12 @@ async def _settle_aborted(
         await o.reporter.eval_cancelled(event, build)
     else:
         await o.reporter.eval_finished(event, build, success=False, warnings=[])
-    await o.reporter.build_finished(event, build, status, build.status_generation, [])
+    await o.reporter.build_finished(
+        event, build, BuildResult(status, build.status_generation, [])
+    )
     await o.finish_linked(
         build,
-        status,
-        build.status_generation,
-        [],
+        BuildResult(status, build.status_generation, []),
         eval_success=None if status == BuildStatus.CANCELLED else False,
     )
 
@@ -459,17 +460,21 @@ async def build_attributes(  # noqa: PLR0913
     await o.reporter.build_finished(
         event,
         build,
-        status,
-        generation,
-        schedule_result.results,
-        attr_statuses={
-            r.attr: r.status
-            for r in await q.attribute_statuses(o.pool, build_id=build.id)
-        },
-        attr_prefix=BranchConfig.load(worktree_path).attribute,
+        BuildResult(
+            status,
+            generation,
+            schedule_result.results,
+            attr_statuses={
+                r.attr: r.status
+                for r in await q.attribute_statuses(o.pool, build_id=build.id)
+            },
+            attr_prefix=BranchConfig.load(worktree_path).attribute,
+        ),
     )
     await o.finish_linked(
-        build, status, generation, schedule_result.results, eval_success=True
+        build,
+        BuildResult(status, generation, schedule_result.results),
+        eval_success=True,
     )
     o.cancel_events.pop(build.id, None)
 

--- a/nixbot/nixbot/events.py
+++ b/nixbot/nixbot/events.py
@@ -46,6 +46,17 @@ class ChangeEvent:
     commit_message: str = ""
 
 
+@dataclass(frozen=True)
+class BuildResult:
+    """The final outcome of a build, as reported to a forge."""
+
+    status: str
+    generation: int
+    results: list[AttributeResult]
+    attr_statuses: dict[str, str] | None = None
+    attr_prefix: str = "checks"
+
+
 class StatusReporter(Protocol):
     """Receives lifecycle events; forge integration implements this."""
 
@@ -63,16 +74,8 @@ class StatusReporter(Protocol):
 
     async def eval_cancelled(self, event: ChangeEvent, build: BuildRecord) -> None: ...
 
-    async def build_finished(  # noqa: PLR0913
-        self,
-        event: ChangeEvent,
-        build: BuildRecord,
-        status: str,
-        generation: int,
-        results: list[AttributeResult],
-        *,
-        attr_statuses: dict[str, str] | None = None,
-        attr_prefix: str = "checks",
+    async def build_finished(
+        self, event: ChangeEvent, build: BuildRecord, result: BuildResult
     ) -> None: ...
 
 
@@ -94,15 +97,7 @@ class NullStatusReporter:
     async def eval_cancelled(self, event: ChangeEvent, build: BuildRecord) -> None:
         pass
 
-    async def build_finished(  # noqa: PLR0913
-        self,
-        event: ChangeEvent,
-        build: BuildRecord,
-        status: str,
-        generation: int,
-        results: list[AttributeResult],
-        *,
-        attr_statuses: dict[str, str] | None = None,
-        attr_prefix: str = "checks",
+    async def build_finished(
+        self, event: ChangeEvent, build: BuildRecord, result: BuildResult
     ) -> None:
         pass

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -35,7 +35,13 @@ from .canceller import (
 )
 from .db import BuildStatus
 from .effects_state import TaskTokens
-from .events import ChangeEvent, NullStatusReporter, RepoInfo, StatusReporter
+from .events import (
+    BuildResult,
+    ChangeEvent,
+    NullStatusReporter,
+    RepoInfo,
+    StatusReporter,
+)
 from .executor import LogWriter
 from .gitrepo import MergeConflictError, pr_refspec
 from .web.logs import LogRegistry
@@ -48,7 +54,7 @@ if TYPE_CHECKING:
 
     import asyncpg
 
-    from .build_scheduler import AttributeResult, BuildOutcome, FailedBuildCache
+    from .build_scheduler import BuildOutcome, FailedBuildCache
     from .config import Config
     from .db import BuildRecord
     from .gitrepo import FetchCredentials, RepoManager
@@ -174,7 +180,9 @@ class Orchestrator:
                 pr_author=event.pr_author,
             )
             await self.reporter.eval_finished(event, build, success=False, warnings=[])
-            await self.reporter.build_finished(event, build, BuildStatus.FAILED, 0, [])
+            await self.reporter.build_finished(
+                event, build, BuildResult(BuildStatus.FAILED, 0, [])
+            )
             return build
 
         try:
@@ -267,7 +275,9 @@ class Orchestrator:
             if created:
                 await db.set_build_status(self.pool, build.id, BuildStatus.CANCELLED)
                 await self.reporter.build_finished(
-                    event, build, BuildStatus.CANCELLED, build.status_generation, []
+                    event,
+                    build,
+                    BuildResult(BuildStatus.CANCELLED, build.status_generation, []),
                 )
             return
         if not rebuild:
@@ -377,17 +387,13 @@ class Orchestrator:
     async def finish_linked(
         self,
         build: BuildRecord,
-        status: str,
-        generation: int,
-        results: list[AttributeResult],
+        result: BuildResult,
         *,
         eval_success: bool | None = None,
     ) -> None:
         """Final status fan-out for second contexts attached to this
         build; eval_success is None when no eval result exists."""
-        await build_reuse.finish_linked(
-            self, build, status, generation, results, eval_success=eval_success
-        )
+        await build_reuse.finish_linked(self, build, result, eval_success=eval_success)
 
     async def post_process_skipped(
         self, event: ChangeEvent, skipped: list[tuple[str, str]]

--- a/nixbot/nixbot/restart_dispatch.py
+++ b/nixbot/nixbot/restart_dispatch.py
@@ -13,7 +13,7 @@ from . import db
 from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
-from .events import ChangeEvent
+from .events import BuildResult, ChangeEvent
 from .recovery import check_store_paths, find_unfinished_builds
 from .repos import repo_info
 
@@ -176,5 +176,5 @@ async def _report_interrupted(s: CIService, resumable: ResumableBuild) -> None:
         event, build, success=False, warnings=[]
     )
     await s.orchestrator.reporter.build_finished(
-        event, build, BuildStatus.FAILED, build.status_generation, []
+        event, build, BuildResult(BuildStatus.FAILED, build.status_generation, [])
     )

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -20,7 +20,7 @@ from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import failed as failed_q
 from .db_gen import maintenance as q
-from .events import ChangeEvent, StatusReporter
+from .events import BuildResult, ChangeEvent, StatusReporter
 from .gitrepo import (
     CredentialsProvider,
     FetchCredentials,
@@ -49,7 +49,6 @@ if TYPE_CHECKING:
 
     import asyncpg
 
-    from .build_scheduler import AttributeResult
     from .config import Config
     from .db import BuildRecord
     from .forge import GiteaClient, GitHubAppClient, GitlabClient
@@ -133,27 +132,11 @@ class RetryingReporter:
     async def eval_cancelled(self, event: ChangeEvent, build: BuildRecord) -> None:
         await self.inner.eval_cancelled(event, build)
 
-    async def build_finished(  # noqa: PLR0913
-        self,
-        event: ChangeEvent,
-        build: BuildRecord,
-        status: str,
-        generation: int,
-        results: list[AttributeResult],
-        *,
-        attr_statuses: dict[str, str] | None = None,
-        attr_prefix: str = "checks",
+    async def build_finished(
+        self, event: ChangeEvent, build: BuildRecord, result: BuildResult
     ) -> None:
         try:
-            await self.inner.build_finished(
-                event,
-                build,
-                status,
-                generation,
-                results,
-                attr_statuses=attr_statuses,
-                attr_prefix=attr_prefix,
-            )
+            await self.inner.build_finished(event, build, result)
         except Exception as e:
             logger.exception(
                 "status post failed; queueing a retry", extra={"build_id": build.id}
@@ -431,10 +414,12 @@ class CIService:
             await reporter.build_finished(
                 event,
                 build,
-                build.status,
-                build.status_generation,
-                [],
-                attr_statuses={row.attr: row.status for row in rows},
+                BuildResult(
+                    build.status,
+                    build.status_generation,
+                    [],
+                    attr_statuses={row.attr: row.status for row in rows},
+                ),
             )
         except Exception as e:
             if attempt < MAX_REPORT_ATTEMPTS:
@@ -544,7 +529,7 @@ class CIService:
             pr_number=build.pr_number,
         )
         await self.orchestrator.reporter.build_finished(
-            change, build, status, generation, []
+            change, build, BuildResult(status, generation, [])
         )
 
     # -- background loops ---------------------------------------------------

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 
     from .build_scheduler import AttributeResult
     from .db import BuildRecord
-    from .events import ChangeEvent
+    from .events import BuildResult, ChangeEvent
     from .forge import GiteaClient, GitHubAppClient, GitlabClient
     from .models import NixEvalJobSuccess
 
@@ -505,17 +505,12 @@ class ForgeStatusReporter:
             "build cancelled",
         )
 
-    async def build_finished(  # noqa: PLR0913
-        self,
-        event: ChangeEvent,
-        build: BuildRecord,
-        status: str,
-        generation: int,
-        results: list[AttributeResult],
-        *,
-        attr_statuses: dict[str, str] | None = None,
-        attr_prefix: str = "checks",
+    async def build_finished(
+        self, event: ChangeEvent, build: BuildRecord, result: BuildResult
     ) -> None:
+        generation = result.generation
+        results = result.results
+        attr_statuses = result.attr_statuses
         # Monotonic generation: drop stale posts after re-aggregation.
         if generation < self._posted_generations.get(build.id, 0):
             logger.info(
@@ -528,7 +523,9 @@ class ForgeStatusReporter:
         while len(self._posted_generations) > POSTED_GENERATIONS_MAX:
             self._posted_generations.popitem(last=False)
 
-        counts = await self._post_attribute_statuses(event, build, results, attr_prefix)
+        counts = await self._post_attribute_statuses(
+            event, build, results, result.attr_prefix
+        )
         if attr_statuses is not None:
             # Reruns pass only the re-run subset as `results`: the
             # summary description must still cover the whole build.
@@ -536,7 +533,7 @@ class ForgeStatusReporter:
             for attr_status in attr_statuses.values():
                 counts[_count_key(attr_status)] += 1
         table_statuses = attr_statuses or {r.attr: r.status.value for r in results}
-        await self._post_summary(event, build, status, counts, table_statuses)
+        await self._post_summary(event, build, result.status, counts, table_statuses)
 
     async def _post_attribute_statuses(
         self,

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -19,7 +19,7 @@ from nixbot.auth import AuthzConfig, User
 from nixbot.bootstrap import build_service
 from nixbot.config import Config
 from nixbot.db_gen import builds as builds_q
-from nixbot.events import ChangeEvent, NullStatusReporter
+from nixbot.events import BuildResult, ChangeEvent, NullStatusReporter
 from nixbot.forge_tokens import ForgeTokenStore
 from nixbot.service import (
     MAX_REPORT_ATTEMPTS,
@@ -662,19 +662,11 @@ async def test_report_retry(
         fail = True
 
         class FakeReporter(NullStatusReporter):
-            async def build_finished(  # noqa: PLR0913
-                self,
-                event: ChangeEvent,
-                build: Any,
-                status: str,
-                generation: int,
-                results: Any,
-                *,
-                attr_statuses: dict[str, str] | None = None,
-                attr_prefix: str = "checks",
+            async def build_finished(
+                self, event: ChangeEvent, build: Any, result: BuildResult
             ) -> None:
-                del event, status, generation, results, attr_prefix
-                posts.append({"build": build.id, "attrs": attr_statuses})
+                del event
+                posts.append({"build": build.id, "attrs": result.attr_statuses})
                 if fail:
                     msg = "forge 502"
                     raise RuntimeError(msg)
@@ -688,7 +680,7 @@ async def test_report_retry(
         assert record is not None
         event = ChangeEvent(repo=repo_info(record), branch="main", commit_sha="c9")
         # Inline post fails: the wrapper swallows and queues.
-        await wrapper.build_finished(event, build, "succeeded", 0, [])
+        await wrapper.build_finished(event, build, BuildResult("succeeded", 0, []))
         fail = False
         await service.drain_work()
         assert [p["build"] for p in posts] == [build_id, build_id]
@@ -698,7 +690,7 @@ async def test_report_retry(
         # Permanent failure: attempts are bounded.
         posts.clear()
         fail = True
-        await wrapper.build_finished(event, build, "succeeded", 0, [])
+        await wrapper.build_finished(event, build, BuildResult("succeeded", 0, []))
         await service.drain_work()
         assert len(posts) == MAX_REPORT_ATTEMPTS + 1  # inline + retries
         failed = await pool.fetchval(

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -24,7 +24,7 @@ from nixbot.build_scheduler import (
 from nixbot.config import Config
 from nixbot.db import BuildStatus
 from nixbot.db_gen import builds as builds_q
-from nixbot.events import ChangeEvent, RepoInfo
+from nixbot.events import BuildResult, ChangeEvent, RepoInfo
 from nixbot.gitrepo import FetchCredentials, RepoManager
 from nixbot.memory import EvalWorkerConfig
 from nixbot.models import CacheStatus
@@ -140,18 +140,10 @@ class RecordingReporter:
     async def eval_cancelled(self, event: ChangeEvent, build: BuildRecord) -> None:
         self.events.append(("eval-cancelled", build.id))
 
-    async def build_finished(  # noqa: PLR0913
-        self,
-        event: ChangeEvent,
-        build: BuildRecord,
-        status: str,
-        generation: int,
-        results: list[AttributeResult],
-        *,
-        attr_statuses: dict[str, str] | None = None,
-        attr_prefix: str = "checks",
+    async def build_finished(
+        self, event: ChangeEvent, build: BuildRecord, result: BuildResult
     ) -> None:
-        self.events.append(("finished", build.id, status, generation))
+        self.events.append(("finished", build.id, result.status, result.generation))
 
 
 # --- helpers --------------------------------------------------------------------

--- a/nixbot/nixbot/tests/test_service.py
+++ b/nixbot/nixbot/tests/test_service.py
@@ -20,7 +20,7 @@ from nixbot.config import (
     PullBasedRepository,
     resolve_credential_path,
 )
-from nixbot.events import NullStatusReporter
+from nixbot.events import BuildResult, NullStatusReporter
 from nixbot.forge import DiscoveredRepo
 from nixbot.schedule_runner import scheduled_worktree_id
 from nixbot.schedules import DueEffect, ScheduleWhen
@@ -519,16 +519,8 @@ class RecordingReporter(NullStatusReporter):
     def __init__(self) -> None:
         self.finished: list[tuple[int, str, int]] = []
 
-    async def build_finished(
-        self,
-        event: Any,
-        build: Any,
-        status: str,
-        generation: int,
-        results: list,
-        **kwargs: Any,
-    ) -> None:
-        self.finished.append((build.id, status, generation))
+    async def build_finished(self, event: Any, build: Any, result: BuildResult) -> None:
+        self.finished.append((build.id, result.status, result.generation))
 
 
 async def test_cancel_not_running_posts_forge_status(service: CIService) -> None:

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -18,7 +18,7 @@ import pytest
 
 from nixbot.build_scheduler import AttributeResult, AttributeStatus
 from nixbot.db_gen.models import Build as BuildRecord
-from nixbot.events import ChangeEvent, RepoInfo
+from nixbot.events import BuildResult, ChangeEvent, RepoInfo
 from nixbot.forge import GitlabClient
 from nixbot.models import NixEvalJobError
 from nixbot.status import (
@@ -145,7 +145,7 @@ async def test_posted_generations_bounded() -> None:
     reporter, _poster, _store = make_reporter()
     for build_id in range(POSTED_GENERATIONS_MAX + 100):
         build = replace(BUILD, id=build_id)
-        await reporter.build_finished(EVENT, build, "succeeded", 1, [])
+        await reporter.build_finished(EVENT, build, BuildResult("succeeded", 1, []))
     assert len(reporter._posted_generations) <= POSTED_GENERATIONS_MAX  # noqa: SLF001
     assert (POSTED_GENERATIONS_MAX + 99) in reporter._posted_generations  # noqa: SLF001
 
@@ -178,7 +178,7 @@ async def test_context_prefix_configurable() -> None:
     # both must honor the prefix. The phase ordering itself is covered
     # by test_phase_statuses_and_target_url.
     await reporter.build_started(EVENT, BUILD)
-    await reporter.build_finished(EVENT, BUILD, "succeeded", 1, [])
+    await reporter.build_finished(EVENT, BUILD, BuildResult("succeeded", 1, []))
     assert {p.context for p in poster.posts} == {
         "buildbot/nix-eval",
         "buildbot/nix-build",
@@ -196,7 +196,7 @@ async def test_phase_statuses_and_target_url() -> None:
 
     await reporter.build_started(EVENT, BUILD)
     await reporter.eval_finished(EVENT, BUILD, success=True, warnings=["w"])
-    await reporter.build_finished(EVENT, BUILD, "succeeded", 1, [])
+    await reporter.build_finished(EVENT, BUILD, BuildResult("succeeded", 1, []))
     contexts = [(p.context, p.state) for p in poster.posts]
     assert contexts == [
         ("nixbot/nix-eval", StatusState.pending),
@@ -244,13 +244,15 @@ async def test_build_finished_table_sorts_failures_first() -> None:
     await reporter.build_finished(
         EVENT,
         BUILD,
-        "failed",
-        1,
-        [
-            attr_result("a", AttributeStatus.succeeded),
-            attr_result("z", AttributeStatus.failed),
-        ],
-        attr_statuses={"a": "succeeded", "z": "failed"},
+        BuildResult(
+            "failed",
+            1,
+            [
+                attr_result("a", AttributeStatus.succeeded),
+                attr_result("z", AttributeStatus.failed),
+            ],
+            attr_statuses={"a": "succeeded", "z": "failed"},
+        ),
     )
     summary_idx = next(
         i for i, p in enumerate(poster.posts) if p.context == "nixbot/nix-build"
@@ -270,7 +272,7 @@ async def test_per_attribute_failure_statuses_capped() -> None:
         for i in range(4)
     ]
 
-    await reporter.build_finished(EVENT, BUILD, "failed", 1, results)
+    await reporter.build_finished(EVENT, BUILD, BuildResult("failed", 1, results))
     failure_posts = [
         p for p in poster.posts if p.context.startswith("nixbot/nix-build ")
     ]
@@ -287,16 +289,16 @@ async def test_success_flip_on_rebuild() -> None:
 
     # First build: flaky fails.
     await reporter.build_finished(
-        EVENT, BUILD, "failed", 1, [attr_result("flaky", AttributeStatus.failed)]
+        EVENT,
+        BUILD,
+        BuildResult("failed", 1, [attr_result("flaky", AttributeStatus.failed)]),
     )
     assert context in await store.get_failed("sha1")
     # Rebuild succeeds: status flipped, record cleared.
     await reporter.build_finished(
         EVENT,
         BUILD,
-        "succeeded",
-        2,
-        [attr_result("flaky", AttributeStatus.succeeded)],
+        BuildResult("succeeded", 2, [attr_result("flaky", AttributeStatus.succeeded)]),
     )
     assert context not in await store.get_failed("sha1")
     flip = [p for p in poster.posts if p.context == context]
@@ -306,10 +308,10 @@ async def test_success_flip_on_rebuild() -> None:
 async def test_stale_generation_dropped() -> None:
     reporter, poster, _ = make_reporter()
 
-    await reporter.build_finished(EVENT, BUILD, "succeeded", 5, [])
+    await reporter.build_finished(EVENT, BUILD, BuildResult("succeeded", 5, []))
     posts_before = len(poster.posts)
     # Stale post with lower generation: dropped entirely.
-    await reporter.build_finished(EVENT, BUILD, "failed", 3, [])
+    await reporter.build_finished(EVENT, BUILD, BuildResult("failed", 3, []))
     assert len(poster.posts) == posts_before
 
 
@@ -318,9 +320,7 @@ async def test_cancelled_attributes_recorded_as_failed_statuses() -> None:
     await reporter.build_finished(
         EVENT,
         BUILD,
-        "cancelled",
-        1,
-        [attr_result("a", AttributeStatus.cancelled)],
+        BuildResult("cancelled", 1, [attr_result("a", AttributeStatus.cancelled)]),
     )
     context = attr_status_context("github", "acme/widget", "a")
     assert context in await store.get_failed("sha1")
@@ -335,13 +335,15 @@ async def test_attribute_cancel_summary_is_not_superseded() -> None:
     await reporter.build_finished(
         EVENT,
         BUILD,
-        "cancelled",
-        1,
-        [
-            attr_result("a", AttributeStatus.cancelled),
-            attr_result("b", AttributeStatus.succeeded),
-            attr_result("c", AttributeStatus.succeeded),
-        ],
+        BuildResult(
+            "cancelled",
+            1,
+            [
+                attr_result("a", AttributeStatus.cancelled),
+                attr_result("b", AttributeStatus.succeeded),
+                attr_result("c", AttributeStatus.succeeded),
+            ],
+        ),
     )
     combined = next(p for p in poster.posts if p.context == "nixbot/nix-build")
     assert combined.state == StatusState.error
@@ -351,7 +353,7 @@ async def test_attribute_cancel_summary_is_not_superseded() -> None:
 
 async def test_build_level_cancel_keeps_supersede_wording() -> None:
     reporter, poster, _ = make_reporter()
-    await reporter.build_finished(EVENT, BUILD, "cancelled", 1, [])
+    await reporter.build_finished(EVENT, BUILD, BuildResult("cancelled", 1, []))
     combined = next(p for p in poster.posts if p.context == "nixbot/nix-build")
     assert combined.description == "build cancelled (superseded)"
 
@@ -363,9 +365,15 @@ async def test_attribute_descriptions_are_ansi_stripped() -> None:
     await reporter.build_finished(
         EVENT,
         BUILD,
-        "failed",
-        1,
-        [attr_result("a", AttributeStatus.failed, error="\x1b[31merror: boom\x1b[0m")],
+        BuildResult(
+            "failed",
+            1,
+            [
+                attr_result(
+                    "a", AttributeStatus.failed, error="\x1b[31merror: boom\x1b[0m"
+                )
+            ],
+        ),
     )
     attr_post = next(
         p for p in poster.posts if p.context.startswith("nixbot/nix-build ")
@@ -382,18 +390,22 @@ async def test_previously_failed_reposts_do_not_consume_budget() -> None:
     await reporter.build_finished(
         EVENT,
         BUILD,
-        "failed",
-        1,
-        [attr_result(f"a{i}", AttributeStatus.failed) for i in range(2)],
+        BuildResult(
+            "failed",
+            1,
+            [attr_result(f"a{i}", AttributeStatus.failed) for i in range(2)],
+        ),
     )
     poster.posts.clear()
     # Rebuild: same two still fail, plus one new failure.
     await reporter.build_finished(
         EVENT,
         BUILD,
-        "failed",
-        2,
-        [attr_result(f"a{i}", AttributeStatus.failed) for i in range(3)],
+        BuildResult(
+            "failed",
+            2,
+            [attr_result(f"a{i}", AttributeStatus.failed) for i in range(3)],
+        ),
     )
     failure_posts = {
         p.context for p in poster.posts if p.context.startswith("nixbot/nix-build ")
@@ -410,10 +422,12 @@ async def test_summary_counts_use_all_attribute_statuses() -> None:
     await reporter.build_finished(
         EVENT,
         BUILD,
-        "succeeded",
-        1,
-        [attr_result("flaky", AttributeStatus.succeeded)],
-        attr_statuses=all_statuses,
+        BuildResult(
+            "succeeded",
+            1,
+            [attr_result("flaky", AttributeStatus.succeeded)],
+            attr_statuses=all_statuses,
+        ),
     )
     combined = next(p for p in poster.posts if p.context == "nixbot/nix-build")
     assert combined.description == "100 attributes built"
@@ -426,10 +440,12 @@ async def test_attr_prefix_follows_repo_configuration() -> None:
     await reporter.build_finished(
         EVENT,
         BUILD,
-        "failed",
-        1,
-        [attr_result("foo", AttributeStatus.failed)],
-        attr_prefix="hydraJobs",
+        BuildResult(
+            "failed",
+            1,
+            [attr_result("foo", AttributeStatus.failed)],
+            attr_prefix="hydraJobs",
+        ),
     )
     assert any(
         p.context == "nixbot/nix-build github:acme/widget#hydraJobs.foo"
@@ -452,7 +468,7 @@ async def test_poster_network_errors_do_not_propagate() -> None:
 
     await reporter.build_started(EVENT, BUILD)  # must not raise
     with pytest.raises(httpx.ConnectError):
-        await reporter.build_finished(EVENT, BUILD, "succeeded", 1, [])
+        await reporter.build_finished(EVENT, BUILD, BuildResult("succeeded", 1, []))
 
 
 async def test_reporter_forwards_attr_and_text() -> None:
@@ -472,9 +488,11 @@ async def test_reporter_forwards_attr_and_text() -> None:
     await reporter.build_finished(
         EVENT,
         BUILD,
-        "failed",
-        1,
-        [attr_result("flaky", AttributeStatus.failed, error="log line 1\nline 2")],
+        BuildResult(
+            "failed",
+            1,
+            [attr_result("flaky", AttributeStatus.failed, error="log line 1\nline 2")],
+        ),
     )
     attr_idx = next(
         i
@@ -501,7 +519,7 @@ async def test_check_permission_error_does_not_disable_forge() -> None:
         {"github": ForbiddenPoster()}, MemoryFailedStatuses(), "https://ci"
     )
     await reporter.build_started(EVENT, BUILD)
-    await reporter.build_finished(EVENT, BUILD, "succeeded", 1, [])
+    await reporter.build_finished(EVENT, BUILD, BuildResult("succeeded", 1, []))
     # Both phases still attempt to post; the forge is never latched off.
     assert calls == 2
 


### PR DESCRIPTION

StatusReporter.build_finished took five values that describe one thing,
a finished build's outcome: status, generation, per-attribute results,
and optional attr_statuses/attr_prefix. The signature was duplicated
across the protocol, every reporter, and finish_linked, and each copy
had to silence the too-many-arguments lint.

Pass a frozen BuildResult instead. Removes five PLR0913 suppressions
and keeps the outcome fields from drifting apart at call sites. No
behavior change.
