### PR TITLE
web: wrap long branch text in build meta

### DIFF
--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -590,6 +590,7 @@ details.menu .menu-label {
 p.build-meta {
 	margin-top: 0;
 	color: var(--muted);
+	overflow-wrap: anywhere;
 }
 
 /* Headings */


### PR DESCRIPTION

Long branch names overflowed the build-meta line on narrow viewports,
breaking the layout. Allow word breaks anywhere so the text wraps.

Closes #29
