### PR TITLE
build_reuse: replay effect statuses onto reused commit

### DIFF
--- a/nixbot/nixbot/build_reuse.py
+++ b/nixbot/nixbot/build_reuse.py
@@ -18,6 +18,7 @@ from .canceller import RegisterOutcome
 from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
+from .db_gen import web as web_q
 from .events import BuildResult
 from .gitrepo import GitError, run_git
 
@@ -67,6 +68,23 @@ async def replay_terminal_status(
     await o.reporter.build_finished(
         event, build, BuildResult(build.status, build.status_generation, [])
     )
+
+
+async def replay_effect_statuses(
+    o: Orchestrator, event: ChangeEvent, build: BuildRecord
+) -> None:
+    """Re-post each finished effect's status onto the reusing commit's
+    SHA, so a failed deploy does not look green there."""
+    for effect in await web_q.web_effects(o.pool, build_id=build.id):
+        if effect.status not in ("succeeded", "failed"):
+            continue
+        await o.reporter.effect_finished(
+            event,
+            build,
+            effect.name,
+            success=effect.status == "succeeded",
+            error=effect.error,
+        )
 
 
 async def finish_linked(
@@ -142,10 +160,14 @@ async def reuse_terminal_build(  # noqa: PLR0913
         # failure must not strand this context without a status.
         try:
             await _post_process_existing(o, event, build)
-            # A build that ran as a PR never started effects, so a
-            # default-branch push reusing it must still deploy; the
-            # effects_started flag prevents re-deploys.
-            await o.maybe_run_effects(event, build, worktree_path, credentials)
+            if build.effects_started:
+                # Effects already ran and will not re-run; replay their
+                # statuses so the reusing commit is not left blank.
+                await replay_effect_statuses(o, event, build)
+            else:
+                # A build that never started effects (e.g. a PR build)
+                # must still deploy when a default-branch push reuses it.
+                await o.maybe_run_effects(event, build, worktree_path, credentials)
             await o.refresh_schedules(event)
         except Exception:
             logger.exception(

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -1541,6 +1541,46 @@ async def test_reuse_for_default_branch_push_runs_effects(
     assert ran == ["deploy"]
 
 
+async def test_reuse_replays_effect_statuses_to_new_commit(
+    pool: asyncpg.Pool,
+    make_env: EnvFactory,
+    upstream: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A commit reusing a build whose effects already ran must get
+    those effect statuses replayed onto its SHA (Mic92/nixbot#30)."""
+
+    async def failing_run(ctx: object, name: str, log_write: object = None) -> bool:
+        return False
+
+    patch_effects(monkeypatch, run_effect=failing_run)
+    add_commit(upstream, "reuse-replay")
+    sha = git(upstream, "rev-parse", "HEAD")
+    orchestrator, reporter, project = await make_env(
+        FakeEvalRunner([mk_job("a")]),
+        FakeExecutor(),
+        name="reuse-replay",
+    )
+    first = await orchestrator.handle_change_event(
+        ChangeEvent(repo=project, branch="main", commit_sha=sha)
+    )
+    assert first is not None
+    await drain_effect_items(orchestrator, project, pool)
+
+    # A second commit with an identical tree reuses the build; its
+    # effects do not re-run, so the statuses must be replayed.
+    git(upstream, "commit", "--allow-empty", "-m", "reuse-replay-empty")
+    sha2 = git(upstream, "rev-parse", "HEAD")
+    reporter.events.clear()
+    reused = await orchestrator.handle_change_event(
+        ChangeEvent(repo=project, branch="main", commit_sha=sha2)
+    )
+    assert reused is not None
+    assert reused.id == first.id
+    replayed = [e for e in reporter.events if e[0] == "effect-finished"]
+    assert ("effect-finished", first.id, "deploy", False) in replayed
+
+
 async def test_attach_to_already_terminal_build_replays_status(
     pool: asyncpg.Pool, make_env: EnvFactory, tmp_path: Path, upstream: Path
 ) -> None:


### PR DESCRIPTION

A commit reusing a terminal build by tree hash (e.g. a merge commit
with an identical tree) does not re-run effects, since effects_started
is already set. The reuse path replayed only eval/build statuses, so
the new commit showed no effect status -- a failed deploy looked green.

Replay each finished effect's status onto the reusing commit's SHA.
