### PR TITLE
status: add aggregate effects summary status

### DIFF
--- a/nixbot/nixbot/build_reuse.py
+++ b/nixbot/nixbot/build_reuse.py
@@ -73,11 +73,16 @@ async def replay_terminal_status(
 async def replay_effect_statuses(
     o: Orchestrator, event: ChangeEvent, build: BuildRecord
 ) -> None:
-    """Re-post each finished effect's status onto the reusing commit's
-    SHA, so a failed deploy does not look green there."""
-    for effect in await web_q.web_effects(o.pool, build_id=build.id):
-        if effect.status not in ("succeeded", "failed"):
-            continue
+    """Re-post each finished effect's status and the aggregate summary
+    onto the reusing commit's SHA, so a failed deploy is not green."""
+    effects = [
+        e
+        for e in await web_q.web_effects(o.pool, build_id=build.id)
+        if e.status in ("succeeded", "failed")
+    ]
+    if not effects:
+        return
+    for effect in effects:
         await o.reporter.effect_finished(
             event,
             build,
@@ -85,6 +90,12 @@ async def replay_effect_statuses(
             success=effect.status == "succeeded",
             error=effect.error,
         )
+    await o.reporter.effects_finished(
+        event,
+        build,
+        failed=sum(1 for e in effects if e.status != "succeeded"),
+        succeeded=sum(1 for e in effects if e.status == "succeeded"),
+    )
 
 
 async def finish_linked(

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -14,6 +14,7 @@ from urllib.parse import quote
 
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
+from .db_gen import web as web_q
 from .db_gen import work_queue as wq
 from .effects import (
     EffectsContext,
@@ -91,11 +92,11 @@ async def maybe_run_effects(
     # Effects removed from the flake since the last run would
     # otherwise linger as stale pending rows.
     await q.drop_removed_effects(o.pool, build_id=build.id, names=names)
-    await _enqueue_effects(o, build, names)
+    await _enqueue_effects(o, event, build, names)
 
 
 async def _enqueue_effects(
-    o: Orchestrator, build: BuildRecord, names: list[str]
+    o: Orchestrator, event: ChangeEvent, build: BuildRecord, names: list[str]
 ) -> None:
     """One queue item per effect, on the build's dedup key."""
     # Effect names are repo-controlled; a duplicate inside one batch
@@ -105,6 +106,7 @@ async def _enqueue_effects(
     if not names:
         return
     await builds_q.start_pending_effects(o.pool, build_id=build.id, names=names)
+    await o.reporter.effects_started(event, build, len(names))
     await wq.enqueue_effect_items(
         o.pool,
         dedup_key=f"build-{build.id}",
@@ -142,8 +144,25 @@ async def run_effect_item(
                 task_token=task_token,
             )
             await _run_one_effect(o, event, ctx, build, name)
+            await _maybe_post_effects_summary(o, event, build)
         finally:
             o.task_tokens.revoke(task_token)
+
+
+async def _maybe_post_effects_summary(
+    o: Orchestrator, event: ChangeEvent, build: BuildRecord
+) -> None:
+    """Post the aggregate status once all effects settle; the items run
+    independently, so the last to finish reports it."""
+    statuses = [e.status for e in await web_q.web_effects(o.pool, build_id=build.id)]
+    if any(s in ("pending", "running") for s in statuses):
+        return
+    await o.reporter.effects_finished(
+        event,
+        build,
+        failed=sum(1 for s in statuses if s != "succeeded"),
+        succeeded=sum(1 for s in statuses if s == "succeeded"),
+    )
 
 
 async def _run_one_effect(

--- a/nixbot/nixbot/events.py
+++ b/nixbot/nixbot/events.py
@@ -92,6 +92,19 @@ class StatusReporter(Protocol):
         error: str | None = None,
     ) -> None: ...
 
+    async def effects_started(
+        self, event: ChangeEvent, build: BuildRecord, total: int
+    ) -> None: ...
+
+    async def effects_finished(
+        self,
+        event: ChangeEvent,
+        build: BuildRecord,
+        *,
+        failed: int,
+        succeeded: int,
+    ) -> None: ...
+
 
 class NullStatusReporter:
     async def build_started(self, event: ChangeEvent, build: BuildRecord) -> None:
@@ -129,5 +142,20 @@ class NullStatusReporter:
         *,
         success: bool,
         error: str | None = None,
+    ) -> None:
+        pass
+
+    async def effects_started(
+        self, event: ChangeEvent, build: BuildRecord, total: int
+    ) -> None:
+        pass
+
+    async def effects_finished(
+        self,
+        event: ChangeEvent,
+        build: BuildRecord,
+        *,
+        failed: int,
+        succeeded: int,
     ) -> None:
         pass

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -150,6 +150,23 @@ class RetryingReporter:
             event, build, name, success=success, error=error
         )
 
+    async def effects_started(
+        self, event: ChangeEvent, build: BuildRecord, total: int
+    ) -> None:
+        await self.inner.effects_started(event, build, total)
+
+    async def effects_finished(
+        self,
+        event: ChangeEvent,
+        build: BuildRecord,
+        *,
+        failed: int,
+        succeeded: int,
+    ) -> None:
+        await self.inner.effects_finished(
+            event, build, failed=failed, succeeded=succeeded
+        )
+
     async def build_finished(
         self, event: ChangeEvent, build: BuildRecord, result: BuildResult
     ) -> None:

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -382,6 +382,17 @@ def effect_status_context(
     return f"{context_prefix}/effect {forge}:{project_name}#{name}"
 
 
+def effects_summary_context(context_prefix: str = "nixbot") -> str:
+    return f"{context_prefix}/effects"
+
+
+def effects_summary_description(failed: int, succeeded: int) -> str:
+    total = failed + succeeded
+    if failed:
+        return f"{failed} of {total} effects failed"
+    return f"{succeeded} effect{'s' if succeeded != 1 else ''} succeeded"
+
+
 def eval_description(success: bool, warnings: list[str]) -> str:
     base = "evaluation succeeded" if success else "evaluation failed"
     if warnings:
@@ -551,6 +562,33 @@ class ForgeStatusReporter:
             StatusState.success if success else StatusState.failure,
             "effect succeeded" if success else (error or "effect failed"),
             text=_fence(error) if error else None,
+        )
+
+    async def effects_started(
+        self, event: ChangeEvent, build: BuildRecord, total: int
+    ) -> None:
+        await self._post(
+            event,
+            build,
+            effects_summary_context(self.context_prefix),
+            StatusState.pending,
+            f"running {total} effect{'s' if total != 1 else ''}",
+        )
+
+    async def effects_finished(
+        self,
+        event: ChangeEvent,
+        build: BuildRecord,
+        *,
+        failed: int,
+        succeeded: int,
+    ) -> None:
+        await self._post(
+            event,
+            build,
+            effects_summary_context(self.context_prefix),
+            StatusState.failure if failed else StatusState.success,
+            effects_summary_description(failed, succeeded),
         )
 
     async def build_finished(

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -161,6 +161,21 @@ class RecordingReporter:
     ) -> None:
         self.events.append(("effect-finished", build.id, name, success))
 
+    async def effects_started(
+        self, event: ChangeEvent, build: BuildRecord, total: int
+    ) -> None:
+        self.events.append(("effects-started", build.id, total))
+
+    async def effects_finished(
+        self,
+        event: ChangeEvent,
+        build: BuildRecord,
+        *,
+        failed: int,
+        succeeded: int,
+    ) -> None:
+        self.events.append(("effects-finished", build.id, failed, succeeded))
+
 
 # --- helpers --------------------------------------------------------------------
 
@@ -1366,9 +1381,12 @@ async def test_failed_effect_reports_failure_status(
     assert build is not None
     await drain_effect_items(orchestrator, project, pool)
 
-    effect_events = [e for e in reporter.events if e[0].startswith("effect-")]
+    effect_events = [e for e in reporter.events if e[0].startswith("effect")]
     assert ("effect-started", build.id, "deploy") in effect_events
     assert ("effect-finished", build.id, "deploy", False) in effect_events
+    # Aggregate summary mirrors the nix-build summary.
+    assert ("effects-started", build.id, 1) in effect_events
+    assert ("effects-finished", build.id, 1, 0) in effect_events
 
 
 async def test_post_process_error_does_not_wedge_build(
@@ -1577,8 +1595,9 @@ async def test_reuse_replays_effect_statuses_to_new_commit(
     )
     assert reused is not None
     assert reused.id == first.id
-    replayed = [e for e in reporter.events if e[0] == "effect-finished"]
+    replayed = [e for e in reporter.events if e[0].startswith("effect")]
     assert ("effect-finished", first.id, "deploy", False) in replayed
+    assert ("effects-finished", first.id, 1, 0) in replayed
 
 
 async def test_attach_to_already_terminal_build_replays_status(

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -453,6 +453,19 @@ async def test_failed_effect_posts_failure_status() -> None:
     assert poster.extras[1]["text"] == "```\nboom\nmore\n```"
 
 
+async def test_effects_summary_status() -> None:
+    """Effects get an aggregate status alongside the per-effect ones,
+    like nix-build's summary."""
+    reporter, poster, _ = make_reporter()
+    await reporter.effects_started(EVENT, BUILD, 3)
+    await reporter.effects_finished(EVENT, BUILD, failed=1, succeeded=2)
+    summary = [p for p in poster.posts if p.context == "nixbot/effects"]
+    assert [(p.state, p.description) for p in summary] == [
+        (StatusState.pending, "running 3 effects"),
+        (StatusState.failure, "1 of 3 effects failed"),
+    ]
+
+
 async def test_attr_prefix_follows_repo_configuration() -> None:
     """Repos with attribute = "hydraJobs" keep their old context names."""
     reporter, poster, store = make_reporter()


### PR DESCRIPTION

Per-effect statuses had no overall summary, unlike nix-build. Add a
<prefix>/effects context: pending when effects are enqueued, then a
terminal pass/fail aggregate posted by the last effect to settle (and
replayed on build reuse).
