### PR TITLE
effects_run: report effect statuses on the triggering commit

### DIFF
--- a/nixbot/nixbot/db_gen/builds.py
+++ b/nixbot/nixbot/db_gen/builds.py
@@ -76,7 +76,7 @@ class LockBuildRowRow:
 
 
 ATTACH_BUILD_TO_PR: typing.Final[str] = """-- name: AttachBuildToPr :one
-UPDATE builds SET pr_number = $2, pr_author = $3 WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed
+UPDATE builds SET pr_number = $2, pr_author = $3 WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number
 """
 
 ATTRIBUTE_STATUS_LIST: typing.Final[str] = """-- name: AttributeStatusList :many
@@ -88,7 +88,7 @@ SELECT attr, status FROM build_attributes WHERE build_id = $1
 """
 
 BACKFILL_PR_AUTHOR: typing.Final[str] = """-- name: BackfillPrAuthor :one
-UPDATE builds SET pr_author = $2 WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed
+UPDATE builds SET pr_author = $2 WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number
 """
 
 BUMP_BUILD_STATUS: typing.Final[str] = """-- name: BumpBuildStatus :one
@@ -148,7 +148,7 @@ SELECT $1::bigint, n.number, $2::text,
        $3::text, $4::text,
        $5::bigint, $6::text
 FROM n
-RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed
+RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number
 """
 
 CREATE_FAILED_BUILD: typing.Final[str] = """-- name: CreateFailedBuild :one
@@ -163,14 +163,14 @@ SELECT $1::bigint, n.number, $2::text,
        $3::text, $4::bigint,
        $5::text, 'failed', $6::text, now()
 FROM n
-RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed
+RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number
 """
 
 DETACH_BUILD_FROM_PR: typing.Final[str] = """-- name: DetachBuildFromPr :one
 UPDATE builds SET pr_number = NULL, pr_author = NULL,
     branch = CASE WHEN $2::bigint IS NULL
              THEN $3 ELSE branch END
-WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed
+WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number
 """
 
 EFFECTS_FOR_BUILD: typing.Final[str] = """-- name: EffectsForBuild :many
@@ -189,7 +189,7 @@ ORDER BY id DESC LIMIT 1
 """
 
 FIND_REUSABLE_BUILD: typing.Final[str] = """-- name: FindReusableBuild :one
-SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed FROM builds WHERE project_id = $1 AND tree_hash = $2
+SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds WHERE project_id = $1 AND tree_hash = $2
 AND status <> 'cancelled' ORDER BY id DESC LIMIT 1
 """
 
@@ -201,7 +201,7 @@ WHERE build_id = $1 AND name = $2
 """
 
 GET_BUILD: typing.Final[str] = """-- name: GetBuild :one
-SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed FROM builds WHERE id = $1
+SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds WHERE id = $1
 """
 
 LOCK_BUILD_IDENTITY: typing.Final[str] = """-- name: LockBuildIdentity :exec
@@ -226,8 +226,11 @@ RETURNING attr
 """
 
 MARK_EFFECTS_STARTED: typing.Final[str] = """-- name: MarkEffectsStarted :one
-UPDATE builds SET effects_started = TRUE
-WHERE id = $1 AND effects_started = FALSE RETURNING id
+UPDATE builds SET effects_started = TRUE,
+    effects_commit_sha = $1::text,
+    effects_branch = $2::text,
+    effects_pr_number = $3::bigint
+WHERE id = $4::bigint AND effects_started = FALSE RETURNING id
 """
 
 MARK_EVAL_COMPLETED: typing.Final[str] = """-- name: MarkEvalCompleted :exec
@@ -355,7 +358,7 @@ async def attach_build_to_pr(conn: ConnectionLike, *, id_: int, pr_number: int |
     row = await conn.fetchrow(ATTACH_BUILD_TO_PR, id_, pr_number, pr_author)
     if row is None:
         return None
-    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16])
+    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
 
 
 def attribute_status_list(conn: ConnectionLike, *, build_id: int) -> QueryResults[str]:
@@ -372,7 +375,7 @@ async def backfill_pr_author(conn: ConnectionLike, *, id_: int, pr_author: str |
     row = await conn.fetchrow(BACKFILL_PR_AUTHOR, id_, pr_author)
     if row is None:
         return None
-    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16])
+    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
 
 
 async def bump_build_status(conn: ConnectionLike, *, id_: int, status: str) -> int | None:
@@ -390,21 +393,21 @@ async def create_build(conn: ConnectionLike, *, project_id: int, tree_hash: str 
     row = await conn.fetchrow(CREATE_BUILD, project_id, tree_hash, commit_sha, branch, pr_number, pr_author)
     if row is None:
         return None
-    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16])
+    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
 
 
 async def create_failed_build(conn: ConnectionLike, *, project_id: int, commit_sha: str, branch: str, pr_number: int | None, pr_author: str | None, error: str | None) -> models.Build | None:
     row = await conn.fetchrow(CREATE_FAILED_BUILD, project_id, commit_sha, branch, pr_number, pr_author, error)
     if row is None:
         return None
-    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16])
+    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
 
 
 async def detach_build_from_pr(conn: ConnectionLike, *, id_: int, pr_number: int | None, branch: str) -> models.Build | None:
     row = await conn.fetchrow(DETACH_BUILD_FROM_PR, id_, pr_number, branch)
     if row is None:
         return None
-    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16])
+    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
 
 
 def effects_for_build(conn: ConnectionLike, *, build_id: int) -> QueryResults[models.BuildEffect]:
@@ -430,7 +433,7 @@ async def find_reusable_build(conn: ConnectionLike, *, project_id: int, tree_has
     row = await conn.fetchrow(FIND_REUSABLE_BUILD, project_id, tree_hash)
     if row is None:
         return None
-    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16])
+    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
 
 
 async def finish_effect(conn: ConnectionLike, *, build_id: int, name: str, status: str, log_size: int, log_truncated: bool, error: str | None, log_path: str | None) -> None:
@@ -441,7 +444,7 @@ async def get_build(conn: ConnectionLike, *, id_: int) -> models.Build | None:
     row = await conn.fetchrow(GET_BUILD, id_)
     if row is None:
         return None
-    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16])
+    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
 
 
 async def lock_build_identity(conn: ConnectionLike, *, key: str) -> typing.Any:
@@ -462,8 +465,8 @@ async def mark_attribute_building(conn: ConnectionLike, *, build_id: int, attr: 
     return row[0]
 
 
-async def mark_effects_started(conn: ConnectionLike, *, id_: int) -> int | None:
-    row = await conn.fetchrow(MARK_EFFECTS_STARTED, id_)
+async def mark_effects_started(conn: ConnectionLike, *, commit_sha: str, branch: str, pr_number: int | None, id_: int) -> int | None:
+    row = await conn.fetchrow(MARK_EFFECTS_STARTED, commit_sha, branch, pr_number, id_)
     if row is None:
         return None
     return row[0]

--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -172,7 +172,7 @@ WHERE status = 'running' AND started_at < $1
 """
 
 FIND_UNFINISHED_BUILDS: typing.Final[str] = """-- name: FindUnfinishedBuilds :many
-SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed FROM builds WHERE status = ANY($1::text[])
+SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds WHERE status = ANY($1::text[])
 AND ($2::bigint IS NULL OR id = $2)
 ORDER BY id
 """
@@ -363,7 +363,7 @@ async def fail_interrupted_scheduled_runs(conn: ConnectionLike, *, started_befor
 
 def find_unfinished_builds(conn: ConnectionLike, *, statuses: collections.abc.Sequence[str], build_id: int | None) -> QueryResults[models.Build]:
     def _decode_hook(row: asyncpg.Record) -> models.Build:
-        return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16])
+        return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
     return QueryResults[models.Build](conn, FIND_UNFINISHED_BUILDS, _decode_hook, statuses, build_id)
 
 

--- a/nixbot/nixbot/db_gen/models.py
+++ b/nixbot/nixbot/db_gen/models.py
@@ -38,6 +38,9 @@ class Build:
     finished_at: datetime.datetime | None
     eval_warnings: str | None
     eval_completed: bool
+    effects_commit_sha: str | None
+    effects_branch: str | None
+    effects_pr_number: int | None
 
 
 @dataclasses.dataclass()

--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -178,6 +178,9 @@ class WebQueueRow:
     finished_at: datetime.datetime | None
     eval_warnings: str | None
     eval_completed: bool
+    effects_commit_sha: str | None
+    effects_branch: str | None
+    effects_pr_number: int | None
     owner: str
     project_name: str
     forge: str
@@ -204,6 +207,9 @@ class WebRecentBuildsRow:
     finished_at: datetime.datetime | None
     eval_warnings: str | None
     eval_completed: bool
+    effects_commit_sha: str | None
+    effects_branch: str | None
+    effects_pr_number: int | None
     owner: str
     project_name: str
     forge: str
@@ -331,11 +337,11 @@ END, a.attr
 """
 
 WEB_BUILD_BY_NUMBER: typing.Final[str] = """-- name: WebBuildByNumber :one
-SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed FROM builds WHERE project_id = $1 AND number = $2
+SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds WHERE project_id = $1 AND number = $2
 """
 
 WEB_BUILDS_FOR_REPO: typing.Final[str] = """-- name: WebBuildsForRepo :many
-SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed FROM builds
+SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds
 WHERE project_id = $1
   AND ($2::text IS NULL OR status = $2)
   AND ($3::text IS NULL OR branch = $3)
@@ -365,7 +371,7 @@ ORDER BY owner, name
 """
 
 WEB_QUEUE: typing.Final[str] = """-- name: WebQueue :many
-SELECT b.id, b.project_id, b.number, b.tree_hash, b.commit_sha, b.branch, b.pr_number, b.pr_author, b.status, b.status_generation, b.effects_started, b.error, b.created_at, b.started_at, b.finished_at, b.eval_warnings, b.eval_completed, p.owner, p.name AS project_name, p.forge, p.url,
+SELECT b.id, b.project_id, b.number, b.tree_hash, b.commit_sha, b.branch, b.pr_number, b.pr_author, b.status, b.status_generation, b.effects_started, b.error, b.created_at, b.started_at, b.finished_at, b.eval_warnings, b.eval_completed, b.effects_commit_sha, b.effects_branch, b.effects_pr_number, p.owner, p.name AS project_name, p.forge, p.url,
        q.queue_position
 FROM builds b
 JOIN projects p ON p.id = b.project_id
@@ -379,7 +385,7 @@ ORDER BY b.status = 'pending', b.id
 """
 
 WEB_RECENT_BUILDS: typing.Final[str] = """-- name: WebRecentBuilds :many
-SELECT b.id, b.project_id, b.number, b.tree_hash, b.commit_sha, b.branch, b.pr_number, b.pr_author, b.status, b.status_generation, b.effects_started, b.error, b.created_at, b.started_at, b.finished_at, b.eval_warnings, b.eval_completed, p.owner, p.name AS project_name, p.forge, p.url
+SELECT b.id, b.project_id, b.number, b.tree_hash, b.commit_sha, b.branch, b.pr_number, b.pr_author, b.status, b.status_generation, b.effects_started, b.error, b.created_at, b.started_at, b.finished_at, b.eval_warnings, b.eval_completed, b.effects_commit_sha, b.effects_branch, b.effects_pr_number, p.owner, p.name AS project_name, p.forge, p.url
 FROM builds b JOIN projects p ON p.id = b.project_id
 WHERE ($1::bigint[] IS NULL OR b.project_id = ANY($1))
   AND ($2::bigint IS NULL OR b.id < $2)
@@ -408,7 +414,7 @@ SELECT p.id, p.forge, p.forge_repo_id, p.owner, p.name, p.default_branch, p.url,
        h.history, m.median_secs, m.pass_rate
 FROM projects p
 LEFT JOIN LATERAL (
-    SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed FROM builds b WHERE b.project_id = p.id
+    SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds b WHERE b.project_id = p.id
     ORDER BY b.number DESC LIMIT 1
 ) lb ON true
 LEFT JOIN LATERAL (
@@ -593,12 +599,12 @@ async def web_build_by_number(conn: ConnectionLike, *, project_id: int, number: 
     row = await conn.fetchrow(WEB_BUILD_BY_NUMBER, project_id, number)
     if row is None:
         return None
-    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16])
+    return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
 
 
 def web_builds_for_repo(conn: ConnectionLike, *, project_id: int, status: str | None, branch: str | None, pr_number: int | None, commit_prefix: str | None, before: int | None, offset: int, limit: int) -> QueryResults[models.Build]:
     def _decode_hook(row: asyncpg.Record) -> models.Build:
-        return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16])
+        return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
     return QueryResults[models.Build](conn, WEB_BUILDS_FOR_REPO, _decode_hook, project_id, status, branch, pr_number, commit_prefix, before, offset, limit)
 
 
@@ -623,13 +629,13 @@ def web_projects(conn: ConnectionLike, *, enabled: bool | None, pattern: str | N
 
 def web_queue(conn: ConnectionLike, *, project_ids: collections.abc.Sequence[int] | None) -> QueryResults[WebQueueRow]:
     def _decode_hook(row: asyncpg.Record) -> WebQueueRow:
-        return WebQueueRow(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], owner=row[17], project_name=row[18], forge=row[19], url=row[20], queue_position=row[21])
+        return WebQueueRow(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19], owner=row[20], project_name=row[21], forge=row[22], url=row[23], queue_position=row[24])
     return QueryResults[WebQueueRow](conn, WEB_QUEUE, _decode_hook, project_ids)
 
 
 def web_recent_builds(conn: ConnectionLike, *, project_ids: collections.abc.Sequence[int] | None, before: int | None, limit_: int) -> QueryResults[WebRecentBuildsRow]:
     def _decode_hook(row: asyncpg.Record) -> WebRecentBuildsRow:
-        return WebRecentBuildsRow(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], owner=row[17], project_name=row[18], forge=row[19], url=row[20])
+        return WebRecentBuildsRow(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19], owner=row[20], project_name=row[21], forge=row[22], url=row[23])
     return QueryResults[WebRecentBuildsRow](conn, WEB_RECENT_BUILDS, _decode_hook, project_ids, before, limit_)
 
 

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -9,6 +9,7 @@ keeps the module dependency graph acyclic.
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
@@ -66,9 +67,20 @@ async def maybe_run_effects(
         is_pull_request=event.pr_number is not None,
     ):
         return
-    # The started-flag guards against auto-re-running effects on
-    # crash recovery (deploys are not idempotent).
-    if await builds_q.mark_effects_started(o.pool, id_=build.id) is None:
+    # The started-flag guards against auto-re-running effects on crash
+    # recovery (deploys are not idempotent). Record the triggering ref:
+    # effect items carry only build_id and must report on this commit,
+    # not the build's stored commit_sha (a reused PR head).
+    if (
+        await builds_q.mark_effects_started(
+            o.pool,
+            id_=build.id,
+            commit_sha=event.commit_sha,
+            branch=event.branch,
+            pr_number=event.pr_number,
+        )
+        is None
+    ):
         return
     task_token = o.task_tokens.issue(build.project_id)
     ctx = effects_context(
@@ -129,9 +141,14 @@ async def run_effect_item(
         # effects never auto-re-run (deploys are not idempotent).
         return
     async with o.rerun_worktree(info, build, "effect", credentials) as (
-        event,
+        worktree_event,
         worktree_path,
     ):
+        # rerun_worktree rebuilds the event from the build's stored
+        # commit (the right tree to check out), but effects report on
+        # the commit that triggered them (e.g. the default-branch merge
+        # that reused a PR build), recorded at mark_effects_started.
+        event = _effects_event(build, worktree_event)
         task_token = o.task_tokens.issue(build.project_id)
         try:
             ctx = effects_context(
@@ -147,6 +164,19 @@ async def run_effect_item(
             await _maybe_post_effects_summary(o, event, build)
         finally:
             o.task_tokens.revoke(task_token)
+
+
+def _effects_event(build: BuildRecord, fallback: ChangeEvent) -> ChangeEvent:
+    """The ref that triggered the effects run, recorded on the build;
+    pre-0018 builds have no record and fall back to the build commit."""
+    if build.effects_commit_sha is None:
+        return fallback
+    return replace(
+        fallback,
+        commit_sha=build.effects_commit_sha,
+        branch=build.effects_branch or fallback.branch,
+        pr_number=build.effects_pr_number,
+    )
 
 
 async def _maybe_post_effects_summary(

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -9,7 +9,6 @@ keeps the module dependency graph acyclic.
 from __future__ import annotations
 
 import logging
-from dataclasses import replace
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
@@ -107,12 +106,7 @@ async def _enqueue_effects(
     if not names:
         return
     await builds_q.start_pending_effects(o.pool, build_id=build.id, names=names)
-    # Effect items report against build.commit_sha; match it here so a
-    # reuse with a different trigger commit does not strand the pending
-    # summary on the wrong SHA.
-    await o.reporter.effects_started(
-        replace(event, commit_sha=build.commit_sha), build, len(names)
-    )
+    await o.reporter.effects_started(event, build, len(names))
     await wq.enqueue_effect_items(
         o.pool,
         dedup_key=f"build-{build.id}",

--- a/nixbot/nixbot/migrations/0018_effects_commit.sql
+++ b/nixbot/nixbot/migrations/0018_effects_commit.sql
@@ -1,0 +1,9 @@
+-- The commit that triggers an effects run can differ from the build's
+-- stored commit_sha: a default-branch push routinely reuses a PR build
+-- whose commit_sha is the PR head. Effects then run on behalf of the
+-- default-branch commit, so their statuses must land there, not on the
+-- PR head. Record the triggering ref when effects start; effect items
+-- only carry build_id and would otherwise fall back to commit_sha.
+ALTER TABLE builds ADD COLUMN effects_commit_sha TEXT;
+ALTER TABLE builds ADD COLUMN effects_branch TEXT;
+ALTER TABLE builds ADD COLUMN effects_pr_number BIGINT;

--- a/nixbot/nixbot/queries/builds.sql
+++ b/nixbot/nixbot/queries/builds.sql
@@ -123,8 +123,14 @@ WHERE build_id = $1;
 SELECT * FROM builds WHERE id = $1;
 
 -- name: MarkEffectsStarted :one
-UPDATE builds SET effects_started = TRUE
-WHERE id = $1 AND effects_started = FALSE RETURNING id;
+-- Records the triggering ref alongside the flag so the effect items
+-- (which only carry build_id) report on the commit that ran them
+-- rather than the build's stored commit_sha.
+UPDATE builds SET effects_started = TRUE,
+    effects_commit_sha = sqlc.arg(commit_sha)::text,
+    effects_branch = sqlc.arg(branch)::text,
+    effects_pr_number = sqlc.narg(pr_number)::bigint
+WHERE id = sqlc.arg(id)::bigint AND effects_started = FALSE RETURNING id;
 
 -- name: SettleUnfinishedAttributes :exec
 UPDATE build_attributes

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -148,7 +148,7 @@ class RecordingReporter:
     async def effect_started(
         self, event: ChangeEvent, build: BuildRecord, name: str
     ) -> None:
-        self.events.append(("effect-started", build.id, name))
+        self.events.append(("effect-started", build.id, name, event.commit_sha))
 
     async def effect_finished(
         self,
@@ -164,7 +164,7 @@ class RecordingReporter:
     async def effects_started(
         self, event: ChangeEvent, build: BuildRecord, total: int
     ) -> None:
-        self.events.append(("effects-started", build.id, total))
+        self.events.append(("effects-started", build.id, total, event.commit_sha))
 
     async def effects_finished(
         self,
@@ -174,7 +174,9 @@ class RecordingReporter:
         failed: int,
         succeeded: int,
     ) -> None:
-        self.events.append(("effects-finished", build.id, failed, succeeded))
+        self.events.append(
+            ("effects-finished", build.id, failed, succeeded, event.commit_sha)
+        )
 
 
 # --- helpers --------------------------------------------------------------------
@@ -599,9 +601,19 @@ async def test_effects_started_flag(pool: asyncpg.Pool, tmp_path: Path) -> None:
     build, _ = await db.get_or_create_build(
         pool, project.id, "tree-flag", "sha", "main"
     )
-    assert await builds_q.mark_effects_started(pool, id_=build.id) is not None
+    assert (
+        await builds_q.mark_effects_started(
+            pool, id_=build.id, commit_sha="sha", branch="main", pr_number=None
+        )
+        is not None
+    )
     # Second attempt (e.g. crash recovery) must not re-run.
-    assert await builds_q.mark_effects_started(pool, id_=build.id) is None
+    assert (
+        await builds_q.mark_effects_started(
+            pool, id_=build.id, commit_sha="sha", branch="main", pr_number=None
+        )
+        is None
+    )
 
 
 async def test_aggregation_generation_monotonic(
@@ -1382,11 +1394,11 @@ async def test_failed_effect_reports_failure_status(
     await drain_effect_items(orchestrator, project, pool)
 
     effect_events = [e for e in reporter.events if e[0].startswith("effect")]
-    assert ("effect-started", build.id, "deploy") in effect_events
+    assert ("effect-started", build.id, "deploy", event.commit_sha) in effect_events
     assert ("effect-finished", build.id, "deploy", False) in effect_events
     # Aggregate summary mirrors the nix-build summary.
-    assert ("effects-started", build.id, 1) in effect_events
-    assert ("effects-finished", build.id, 1, 0) in effect_events
+    assert any(e[:3] == ("effects-started", build.id, 1) for e in effect_events)
+    assert any(e[:4] == ("effects-finished", build.id, 1, 0) for e in effect_events)
 
 
 async def test_post_process_error_does_not_wedge_build(
@@ -1533,30 +1545,42 @@ async def test_reuse_for_default_branch_push_runs_effects(
     upstream: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A main push reusing a succeeded PR build must still deploy:
-    the PR run never started effects."""
+    """A main push reusing a succeeded PR build must still deploy (the
+    PR run never started effects) and report the effects on the main
+    commit, not the build's stored PR-head commit."""
 
     ran = patch_effects(monkeypatch)
     add_commit(upstream, "reuse-deploy")
-    sha = git(upstream, "rev-parse", "HEAD")
-    orchestrator, _, project = await make_env(
+    pr_sha = git(upstream, "rev-parse", "HEAD")
+    orchestrator, reporter, project = await make_env(
         FakeEvalRunner([mk_job("a")]),
         FakeExecutor(),
         name="reuse-deploy",
     )
     pr_build = await orchestrator.handle_change_event(
-        ChangeEvent(repo=project, branch="main", commit_sha=sha, pr_number=9)
+        ChangeEvent(repo=project, branch="main", commit_sha=pr_sha, pr_number=9)
     )
     assert pr_build is not None
     await drain_effect_items(orchestrator, project, pool)
     assert ran == []
+
+    # Squash-merge: an identical tree under a new SHA reuses the build.
+    git(upstream, "commit", "--allow-empty", "-m", "reuse-deploy-merge")
+    main_sha = git(upstream, "rev-parse", "HEAD")
+    assert main_sha != pr_sha
+    reporter.events.clear()
     main_build = await orchestrator.handle_change_event(
-        ChangeEvent(repo=project, branch="main", commit_sha=sha)
+        ChangeEvent(repo=project, branch="main", commit_sha=main_sha)
     )
     assert main_build is not None
     assert main_build.id == pr_build.id
     await drain_effect_items(orchestrator, project, pool)
     assert ran == ["deploy"]
+    # Effects ran for the main merge, so their statuses belong on the
+    # main commit -- not the build's stored PR-head commit (pr_sha).
+    sha_events = ("effect-started", "effects-started", "effects-finished")
+    effect_shas = {e[-1] for e in reporter.events if e[0] in sha_events}
+    assert effect_shas == {main_sha}
 
 
 async def test_reuse_replays_effect_statuses_to_new_commit(
@@ -1597,7 +1621,7 @@ async def test_reuse_replays_effect_statuses_to_new_commit(
     assert reused.id == first.id
     replayed = [e for e in reporter.events if e[0].startswith("effect")]
     assert ("effect-finished", first.id, "deploy", False) in replayed
-    assert ("effects-finished", first.id, 1, 0) in replayed
+    assert any(e[:4] == ("effects-finished", first.id, 1, 0) for e in replayed)
 
 
 async def test_attach_to_already_terminal_build_replays_status(

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -164,7 +164,7 @@ class RecordingReporter:
     async def effects_started(
         self, event: ChangeEvent, build: BuildRecord, total: int
     ) -> None:
-        self.events.append(("effects-started", build.id, total, event.commit_sha))
+        self.events.append(("effects-started", build.id, total))
 
     async def effects_finished(
         self,
@@ -174,9 +174,7 @@ class RecordingReporter:
         failed: int,
         succeeded: int,
     ) -> None:
-        self.events.append(
-            ("effects-finished", build.id, failed, succeeded, event.commit_sha)
-        )
+        self.events.append(("effects-finished", build.id, failed, succeeded))
 
 
 # --- helpers --------------------------------------------------------------------
@@ -1387,8 +1385,8 @@ async def test_failed_effect_reports_failure_status(
     assert ("effect-started", build.id, "deploy") in effect_events
     assert ("effect-finished", build.id, "deploy", False) in effect_events
     # Aggregate summary mirrors the nix-build summary.
-    assert any(e[:3] == ("effects-started", build.id, 1) for e in effect_events)
-    assert any(e[:4] == ("effects-finished", build.id, 1, 0) for e in effect_events)
+    assert ("effects-started", build.id, 1) in effect_events
+    assert ("effects-finished", build.id, 1, 0) in effect_events
 
 
 async def test_post_process_error_does_not_wedge_build(
@@ -1561,50 +1559,6 @@ async def test_reuse_for_default_branch_push_runs_effects(
     assert ran == ["deploy"]
 
 
-async def test_effect_summary_sha_consistent_on_reuse(
-    pool: asyncpg.Pool,
-    make_env: EnvFactory,
-    upstream: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A push reusing a PR build (different commit, same tree) must post
-    the pending and final effect summaries on the same SHA, or the
-    pending check never resolves."""
-
-    ran = patch_effects(monkeypatch)
-    add_commit(upstream, "summary-sha")
-    pr_sha = git(upstream, "rev-parse", "HEAD")
-    orchestrator, reporter, project = await make_env(
-        FakeEvalRunner([mk_job("a")]),
-        FakeExecutor(),
-        name="summary-sha",
-    )
-    pr_build = await orchestrator.handle_change_event(
-        ChangeEvent(repo=project, branch="main", commit_sha=pr_sha, pr_number=7)
-    )
-    assert pr_build is not None
-    await drain_effect_items(orchestrator, project, pool)
-    assert ran == []  # PR did not run effects
-
-    # Empty commit: identical tree reuses the build, but a different SHA.
-    git(upstream, "commit", "--allow-empty", "-m", "summary-sha-push")
-    push_sha = git(upstream, "rev-parse", "HEAD")
-    assert push_sha != pr_sha
-    reporter.events.clear()
-    reused = await orchestrator.handle_change_event(
-        ChangeEvent(repo=project, branch="main", commit_sha=push_sha)
-    )
-    assert reused is not None
-    assert reused.id == pr_build.id
-    await drain_effect_items(orchestrator, project, pool)
-    assert ran == ["deploy"]
-
-    summaries = [
-        e for e in reporter.events if e[0] in ("effects-started", "effects-finished")
-    ]
-    assert {e[-1] for e in summaries} == {pr_build.commit_sha}
-
-
 async def test_reuse_replays_effect_statuses_to_new_commit(
     pool: asyncpg.Pool,
     make_env: EnvFactory,
@@ -1643,7 +1597,7 @@ async def test_reuse_replays_effect_statuses_to_new_commit(
     assert reused.id == first.id
     replayed = [e for e in reporter.events if e[0].startswith("effect")]
     assert ("effect-finished", first.id, "deploy", False) in replayed
-    assert any(e[:4] == ("effects-finished", first.id, 1, 0) for e in replayed)
+    assert ("effects-finished", first.id, 1, 0) in replayed
 
 
 async def test_attach_to_already_terminal_build_replays_status(

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -111,6 +111,9 @@ BUILD = BuildRecord(
     finished_at=None,
     eval_warnings=None,
     eval_completed=False,
+    effects_commit_sha=None,
+    effects_branch=None,
+    effects_pr_number=None,
 )
 
 


### PR DESCRIPTION

Effects only carry build_id through the work queue, so the runner
rebuilt their event from build.commit_sha. When a default-branch push
reuses a PR build (DetachBuildFromPr clears pr_number, effects run for
main), build.commit_sha is still the PR head, so the deploy's statuses
landed on the PR instead of main.

Record the triggering ref when effects start and report against it; the
worktree still checks out build.commit_sha (same tree).
