### PR TITLE
web: drop homepage summary strip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 result
 result-*
+.direnv/
 
 .nixbot-dev
 # legacy dev state dir from before the buildbot-nix -> nixbot rename

--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -19,7 +19,6 @@ __all__: collections.abc.Sequence[str] = (
     "WebQueueRow",
     "WebRecentBuildsRow",
     "WebRepoOverviewRow",
-    "WebStatusCountsRow",
     "attribute_log_path",
     "attribute_status",
     "effect_log_path",
@@ -42,9 +41,7 @@ __all__: collections.abc.Sequence[str] = (
     "web_recent_builds",
     "web_repo",
     "web_repo_candidates",
-    "web_repo_count",
     "web_repo_overview",
-    "web_status_counts",
 )
 
 import dataclasses
@@ -242,12 +239,6 @@ class WebRepoOverviewRow:
     pass_rate: int
 
 
-@dataclasses.dataclass()
-class WebStatusCountsRow:
-    status: str
-    n: int
-
-
 ATTRIBUTE_LOG_PATH: typing.Final[str] = """-- name: AttributeLogPath :one
 SELECT l.path FROM logs l
 JOIN build_attributes a ON a.id = l.attribute_id
@@ -401,11 +392,6 @@ SELECT id, forge, forge_repo_id, owner, name, default_branch, url, private, enab
 ORDER BY forge, id
 """
 
-WEB_REPO_COUNT: typing.Final[str] = """-- name: WebRepoCount :one
-SELECT count(*) AS count FROM projects
-WHERE enabled AND ($1::bigint[] IS NULL OR id = ANY($1))
-"""
-
 WEB_REPO_OVERVIEW: typing.Final[str] = """-- name: WebRepoOverview :many
 SELECT p.id, p.forge, p.forge_repo_id, p.owner, p.name, p.default_branch, p.url, p.private, p.enabled, p.next_build_number, p.created_at, p.updated_at, p.reconcile_watermark,
        lb.number AS last_number, lb.status AS last_status,
@@ -456,13 +442,6 @@ LEFT JOIN LATERAL (
 WHERE p.enabled AND ($1::bigint[] IS NULL OR p.id = ANY($1))
   AND ($2::text IS NULL OR p.owner || '/' || p.name ILIKE $2)
 ORDER BY p.owner, p.name
-"""
-
-WEB_STATUS_COUNTS: typing.Final[str] = """-- name: WebStatusCounts :many
-SELECT status, count(*) AS n FROM builds
-WHERE status IN ('pending', 'evaluating', 'building')
-  AND ($1::bigint[] IS NULL OR project_id = ANY($1))
-GROUP BY status
 """
 
 
@@ -652,20 +631,7 @@ def web_repo_candidates(conn: ConnectionLike, *, owner: str, name: str) -> Query
     return QueryResults[models.Project](conn, WEB_REPO_CANDIDATES, _decode_hook, owner, name)
 
 
-async def web_repo_count(conn: ConnectionLike, *, project_ids: collections.abc.Sequence[int] | None) -> int | None:
-    row = await conn.fetchrow(WEB_REPO_COUNT, project_ids)
-    if row is None:
-        return None
-    return row[0]
-
-
 def web_repo_overview(conn: ConnectionLike, *, project_ids: collections.abc.Sequence[int] | None, pattern: str | None) -> QueryResults[WebRepoOverviewRow]:
     def _decode_hook(row: asyncpg.Record) -> WebRepoOverviewRow:
         return WebRepoOverviewRow(id=row[0], forge=row[1], forge_repo_id=row[2], owner=row[3], name=row[4], default_branch=row[5], url=row[6], private=row[7], enabled=row[8], next_build_number=row[9], created_at=row[10], updated_at=row[11], reconcile_watermark=row[12], last_number=row[13], last_status=row[14], last_branch=row[15], last_created_at=row[16], started_at=row[17], finished_at=row[18], history=row[19], median_secs=row[20], pass_rate=row[21])
     return QueryResults[WebRepoOverviewRow](conn, WEB_REPO_OVERVIEW, _decode_hook, project_ids, pattern)
-
-
-def web_status_counts(conn: ConnectionLike, *, project_ids: collections.abc.Sequence[int] | None) -> QueryResults[WebStatusCountsRow]:
-    def _decode_hook(row: asyncpg.Record) -> WebStatusCountsRow:
-        return WebStatusCountsRow(status=row[0], n=row[1])
-    return QueryResults[WebStatusCountsRow](conn, WEB_STATUS_COUNTS, _decode_hook, project_ids)

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -66,16 +66,6 @@ WHERE p.enabled AND (sqlc.narg(project_ids)::bigint[] IS NULL OR p.id = ANY(sqlc
   AND (sqlc.narg(pattern)::text IS NULL OR p.owner || '/' || p.name ILIKE sqlc.narg(pattern))
 ORDER BY p.owner, p.name;
 
--- name: WebRepoCount :one
-SELECT count(*) AS count FROM projects
-WHERE enabled AND (sqlc.narg(project_ids)::bigint[] IS NULL OR id = ANY(sqlc.narg(project_ids)));
-
--- name: WebStatusCounts :many
-SELECT status, count(*) AS n FROM builds
-WHERE status IN ('pending', 'evaluating', 'building')
-  AND (sqlc.narg(project_ids)::bigint[] IS NULL OR project_id = ANY(sqlc.narg(project_ids)))
-GROUP BY status;
-
 -- name: WebRecentBuilds :many
 SELECT b.*, p.owner, p.name AS project_name, p.forge, p.url
 FROM builds b JOIN projects p ON p.id = b.project_id

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -269,8 +269,6 @@ class _PageRoutes:
             q=q,
             toggleable=toggleable,
             projects=await ctx.queries.repo_overview(project_ids=visible, q=q or None),
-            counts=await ctx.queries.status_counts(project_ids=visible),
-            repo_count=await ctx.queries.repo_count(project_ids=visible),
             disabled_projects=disabled,
         )
 

--- a/nixbot/nixbot/web/queries.py
+++ b/nixbot/nixbot/web/queries.py
@@ -91,17 +91,6 @@ class WebQueries:
             row["history"] = json.loads(row["history"]) if row["history"] else []
         return overview
 
-    async def repo_count(self, project_ids: list[int] | None = None) -> int:
-        count = await gen.web_repo_count(self.pool, project_ids=project_ids)
-        return count or 0
-
-    async def status_counts(
-        self, project_ids: list[int] | None = None
-    ) -> dict[str, int]:
-        """Running/queued counts for the homepage summary strip."""
-        rows = await gen.web_status_counts(self.pool, project_ids=project_ids)
-        return {r.status: r.n for r in rows}
-
     async def recent_builds(
         self,
         limit: int = 50,

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -83,6 +83,14 @@ header > a {
 	color: var(--muted);
 	font-size: 0.9rem;
 }
+.site-footer {
+	padding: 1.5rem 1.25rem;
+	text-align: center;
+	font-size: 0.85rem;
+}
+.site-footer a {
+	color: var(--muted);
+}
 main {
 	display: flex;
 	gap: 2rem;

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -134,7 +134,6 @@ th {
    dots and pill labels. Shared by attribute and build tables. */
 table.attrs,
 table.builds,
-.summary-strip,
 .webhook-panel,
 .pipeline {
 	background: var(--card);
@@ -275,9 +274,6 @@ h2 .status-icon {
 .status-icon.evaluating,
 .status-icon.running {
 	animation: ping 1.6s cubic-bezier(0, 0, 0.2, 1) infinite;
-}
-.status-icon.idle {
-	animation: none;
 }
 @media (prefers-reduced-motion: reduce) {
 	.status-icon.building,
@@ -711,18 +707,6 @@ pre.log {
 }
 
 /* Dashboard (homepage) */
-.summary-strip {
-	display: flex;
-	gap: 1.5rem;
-	align-items: center;
-	margin: 0.5rem 0 1.5rem;
-	padding: 0.75rem 1rem;
-}
-.summary-item {
-	display: inline-flex;
-	align-items: center;
-	font-size: 0.9rem;
-}
 .pipelines {
 	display: flex;
 	flex-direction: column;

--- a/nixbot/nixbot/web/templates/base.html
+++ b/nixbot/nixbot/web/templates/base.html
@@ -76,6 +76,9 @@
     </header>
     {% block body %}
     {% endblock body %}
+    <footer class="site-footer muted">
+      <a href="https://github.com/Mic92/nixbot" target="_blank" rel="noopener">github.com/Mic92/nixbot</a>
+    </footer>
     <script src="/static/vendor/htmx.min.js?v={{ static_v }}"></script>
     <script src="/static/vendor/sse.min.js?v={{ static_v }}"></script>
     <script src="/static/vendor/idiomorph-ext.min.js?v={{ static_v }}"></script>

--- a/nixbot/nixbot/web/templates/index.html
+++ b/nixbot/nixbot/web/templates/index.html
@@ -12,20 +12,6 @@
         hx-swap="morph:outerHTML"
         hx-trigger="sse:message delay:300ms">
     <section class="content dashboard">
-      <div class="summary-strip">
-        {% set running = (counts.building | default(0)) + (counts.evaluating | default(0)) %}
-        <span class="summary-item">
-          {# Only pulse the icon while builds are actually running. #}
-          <span class="status-icon building{% if running == 0 %} idle{% endif %}"
-                aria-hidden="true"></span>
-          {{ running }} running
-        </span>
-        <span class="summary-item">
-          {{ status_icon("pending", labelled=false) }}
-          {{ counts.pending | default(0) }} queued
-        </span>
-        <span class="summary-item muted">{{ repo_count }} repositories</span>
-      </div>
       <h2 class="section">Repositories</h2>
       <p class="filters">
         <input type="search"


### PR DESCRIPTION

The "N running / N queued / N repositories" bar on the dashboard
restated information already visible in the repo list and rarely
showed anything other than zeroes. Remove it together with the
backing queries and CSS.


