### PR TITLE
nixbot_effects: handle instantiating non-drvs/paths

### DIFF
--- a/nixbot_effects/nixbot_effects/__init__.py
+++ b/nixbot_effects/nixbot_effects/__init__.py
@@ -223,8 +223,11 @@ def _instantiate(expr: str, opts: EffectsOptions, gcroot: Path) -> str:
         expr,
     ]
     proc = run(cmd, stdout=subprocess.PIPE, debug=opts.debug)
+    output = proc.stdout.rstrip()
+    if output == "":
+        return ""
     # --add-root prints the symlink path; resolve to the actual store path
-    return str(Path(proc.stdout.rstrip()).resolve())
+    return str(Path(output).resolve())
 
 
 def instantiate_effects(effect: str, opts: EffectsOptions, gcroot: Path) -> str:


### PR DESCRIPTION
When we `nix-instantiate` a path that doesn't actually evaluate to a drv, we get back an empty string. When an empty string is passed to `Path`, it returns our cwd, which means we'll ~always get back a path of some form. This results in the strange errors encountered in https://github.com/Mic92/nixbot/issues/30.