### PR TITLE
nixbot: run onSchedule effects manually from the UI

### DIFF
--- a/nixbot/nixbot/schedule_runner.py
+++ b/nixbot/nixbot/schedule_runner.py
@@ -98,13 +98,21 @@ async def refresh_schedules(s: CIService, project_id: int, rev: str) -> None:
         await s.orchestrator.repos.remove_worktree(worktree)
 
 
-async def run_scheduled(s: CIService, due: DueEffect) -> None:
+async def run_scheduled(
+    s: CIService, due: DueEffect, run_id: int | None = None
+) -> None:
+    store = ScheduledEffectsStore(s.pool)
     project = await s.repo_store.by_id(due.project_id)
     if project is None or not project.enabled:
+        # Manual runs pass a pre-created row; close it instead of
+        # leaving it stuck running.
+        if run_id is not None:
+            await store.finish_run(run_id, success=False, error="project disabled")
         return
     info = repo_info(project)
-    store = ScheduledEffectsStore(s.pool)
-    run_id = await store.start_run(due)
+    # Manual runs pre-create the row; the sweep loop does not.
+    if run_id is None:
+        run_id = await store.start_run(due)
     try:
         success = await _run_scheduled_inner(s, due, info, run_id)
         await store.finish_run(run_id, success=success)

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import dataclasses
+import json
 import logging
 import time
 from dataclasses import dataclass, field
@@ -34,7 +35,7 @@ from .recovery import (
     settle_already_built,
 )
 from .repos import repo_info
-from .schedules import DueEffect
+from .schedules import DueEffect, ScheduledEffectsStore
 from .webhooks import (
     ChangeRequest,
     CheckRerequested,
@@ -346,6 +347,35 @@ class CIService:
     async def restart_effects(self, build_id: int) -> None:
         await self.enqueue_work("effects", f"build-{build_id}", {"build_id": build_id})
 
+    async def run_scheduled_now(
+        self, project_id: int, schedule_name: str, effect: str, when_spec: str
+    ) -> None:
+        """Manually trigger an onSchedule effect from the UI.
+
+        The run row is created synchronously so the UI shows it running
+        before the dispatcher claims the work. The dedup key carries
+        run_id to stay distinct from a sweep-loop due item, and this
+        path never touches last_run, so the regular schedule is
+        unaffected."""
+        due = DueEffect(
+            project_id=project_id,
+            schedule_name=schedule_name,
+            effect=effect,
+            when=ScheduleWhen.model_validate(json.loads(when_spec)),
+        )
+        run_id = await ScheduledEffectsStore(self.pool).start_run(due)
+        await self.enqueue_work(
+            "scheduled",
+            f"manual-{project_id}-{schedule_name}-{effect}-{run_id}",
+            {
+                "project_id": project_id,
+                "schedule_name": schedule_name,
+                "effect": effect,
+                "when": due.when.model_dump(exclude_none=True),
+                "run_id": run_id,
+            },
+        )
+
     async def enqueue_work(
         self, kind: str, dedup_key: str, payload: dict[str, Any]
     ) -> None:
@@ -418,6 +448,7 @@ class CIService:
                     effect=payload["effect"],
                     when=ScheduleWhen.model_validate(payload["when"]),
                 ),
+                run_id=payload.get("run_id"),
             )
         else:
             msg = f"unknown work kind {item.kind!r}"

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -64,6 +64,7 @@ class FakeBackend:
     effect_restarts: list[int] = field(default_factory=list)
     cancelled: list[int] = field(default_factory=list)
     attr_cancels: list[tuple[int, str]] = field(default_factory=list)
+    scheduled_runs: list[tuple[int, str, str, str]] = field(default_factory=list)
     refreshes: int = 0
 
     async def restart_build(self, build_id: int) -> None:
@@ -84,6 +85,11 @@ class FakeBackend:
     async def refresh_projects(self) -> None:
         self.refreshes += 1
 
+    async def run_scheduled_now(
+        self, project_id: int, schedule_name: str, effect: str, when_spec: str
+    ) -> None:
+        self.scheduled_runs.append((project_id, schedule_name, effect, when_spec))
+
 
 @pytest.fixture(scope="module")
 async def postgres_dsn(postgres_dsn: str) -> str:
@@ -100,6 +106,14 @@ async def seed(dsn: str) -> None:
             status="failed",
             pr_number=7,
             pr_author="github:alice",
+        )
+        await pool.execute(
+            """
+            INSERT INTO scheduled_effects
+                (project_id, schedule_name, effect, when_spec) VALUES
+              ($1, 'nightly', 'deploy', '{}')
+            """,
+            project_id,
         )
         await pool.execute(
             """
@@ -274,6 +288,29 @@ def test_admin_project_toggle(harness: WebHarness) -> None:
     response = harness.post("/admin/repos/1/toggle", ROOT, data={"q": "wid get"})
     assert response.status_code == 303
     assert response.headers["location"] == "/?q=wid%20get"
+
+
+def test_run_schedule(harness: WebHarness) -> None:
+    url = "/repos/github/acme/widget/schedules/run"
+    data = {"schedule": "nightly", "effect": "deploy"}
+    # Non-admin rejected.
+    assert harness.post(url, ALICE, data=data).status_code == 403
+    assert BACKEND.scheduled_runs == []
+
+    response = harness.post(url, ROOT, data=data)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/repos/github/acme/widget"
+    assert BACKEND.scheduled_runs == [(1, "nightly", "deploy", "{}")]
+
+    # Unknown schedule is a 404, not an enqueue.
+    assert (
+        harness.post(url, ROOT, data={"schedule": "nope", "effect": "x"}).status_code
+        == 404
+    )
+    assert len(BACKEND.scheduled_runs) == 1
+
+    # Cross-origin rejected.
+    assert harness.post(url, ROOT, data=data, origin="http://evil").status_code == 403
 
 
 def test_repo_refresh(harness: WebHarness) -> None:

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -356,7 +356,18 @@ class _PageRoutes:
                 await store.schedules_for_project(project["id"]),
                 await store.latest_runs_for_project(project["id"]),
             ),
+            can_run_schedules=await self._can_run_schedules(request, project["id"]),
         )
+
+    async def _can_run_schedules(self, request: Request, project_id: int) -> bool:
+        """UX only; the run-schedule route re-checks server-side."""
+        ctx = self.ctx
+        if ctx.authz is None:
+            return False
+        if is_admin(await ctx.request_user(request), ctx.authz):
+            return True
+        toggleable = await ctx.toggleable_repo_ids(request) or []
+        return project_id in toggleable
 
     async def _webhook_url(
         self, request: Request, project: dict[str, Any]

--- a/nixbot/nixbot/web/control_routes.py
+++ b/nixbot/nixbot/web/control_routes.py
@@ -22,6 +22,7 @@ from ..auth import can_control_build, is_admin, same_origin  # noqa: TID252
 from ..db_gen import maintenance as maint_gen  # noqa: TID252
 from ..db_gen import projects as proj_gen  # noqa: TID252
 from ..hook_secrets import WebhookSecrets  # noqa: TID252
+from ..schedules import ScheduledEffectsStore  # noqa: TID252
 
 if TYPE_CHECKING:
     from ..auth import AuthzConfig  # noqa: TID252
@@ -40,6 +41,10 @@ class ControlBackend(Protocol):
     async def cancel_attribute(self, build_id: int, attr: str) -> None: ...
 
     async def refresh_projects(self) -> None: ...
+
+    async def run_scheduled_now(
+        self, project_id: int, schedule_name: str, effect: str, when_spec: str
+    ) -> None: ...
 
 
 class ControlAction(BaseModel):
@@ -227,6 +232,36 @@ class _ControlRoutes:
         # Back to the dashboard with the project filter intact.
         return RedirectResponse(f"/?q={quote(q)}" if q else "/", status_code=303)
 
+    async def run_schedule(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        schedule: Annotated[str, Form()],
+        effect: Annotated[str, Form()],
+    ) -> RedirectResponse:
+        """Trigger an onSchedule effect on demand. Repo admins only; the
+        schedule must already exist so form input cannot run arbitrary
+        effects."""
+        project = await self.ctx.repo_or_404(forge, owner, name, request)
+        await self._require_repo_admin(request, project["id"])
+        store = ScheduledEffectsStore(self.ctx.pool)
+        match = next(
+            (
+                row
+                for row in await store.schedules_for_project(project["id"])
+                if row["schedule_name"] == schedule and row["effect"] == effect
+            ),
+            None,
+        )
+        if match is None:
+            raise HTTPException(status_code=404, detail="unknown schedule")
+        await self.backend.run_scheduled_now(
+            project["id"], schedule, effect, match["when_spec"]
+        )
+        return RedirectResponse(f"/repos/{forge}/{owner}/{name}", status_code=303)
+
     async def regenerate_webhook_secret(
         self, request: Request, project_id: int
     ) -> HTMLResponse:
@@ -259,6 +294,9 @@ def create_control_router(
     router.post("/admin/repos/{project_id}/toggle")(routes.toggle_repo)
     router.post("/admin/repos/{project_id}/webhook-secret")(
         routes.regenerate_webhook_secret
+    )
+    router.post("/repos/{forge}/{owner:owner}/{name:segment}/schedules/run")(
+        routes.run_schedule
     )
     return router
 

--- a/nixbot/nixbot/web/templates/repo.html
+++ b/nixbot/nixbot/web/templates/repo.html
@@ -94,6 +94,7 @@
               <th scope="col">when</th>
               <th scope="col">next run</th>
               <th scope="col">last run</th>
+              <th scope="col">actions</th>
             </tr>
           </thead>
           {% for s in schedules %}
@@ -121,6 +122,16 @@
                         title="{{ s.run.started_at }}">{{ s.run.started_at | timeago }}</time>
                 {% else %}
                   never
+                {% endif %}
+              </td>
+              <td class="attr-status">
+                {# UX only; the run route enforces authz server-side. #}
+                {% if can_run_schedules %}
+                  <form method="post" action="{{ repo_path(project) }}/schedules/run">
+                    <input type="hidden" name="schedule" value="{{ s.schedule }}">
+                    <input type="hidden" name="effect" value="{{ s.effect }}">
+                    <button>run now</button>
+                  </form>
                 {% endif %}
               </td>
             </tr>


### PR DESCRIPTION
onSchedule effects only fired on their schedule, with no way to trigger them on demand. Operators had to wait for the next occurrence to test or re-run an effect.

Add a "run now" button per schedule on the repo page, gated to repo admins. The run row is created synchronously so the UI shows it running before the dispatcher claims the work. The dedup key carries the run id to stay distinct from a sweep-loop due item, and this path never touches last_run, so the regular schedule is unaffected.

Closes #45