### PR TITLE
nixbot: re-evaluate when resuming a build whose eval was cancelled

### DIFF
--- a/nixbot/nixbot/restart_dispatch.py
+++ b/nixbot/nixbot/restart_dispatch.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from .db import BuildRecord
     from .events import RepoInfo
     from .gitrepo import FetchCredentials
+    from .models import NixEvalJobSuccess
     from .recovery import ResumableBuild
     from .service import CIService
 
@@ -69,31 +70,12 @@ async def rerun(s: CIService, build_id: int) -> bool:
     resumable = results[0] if results else None
     if resumable is None:
         return False
-    unfinished_count = await q.count_unfinished_attributes(s.pool, build_id=build_id)
-    if (
-        # A crash mid-eval leaves a partial attribute set; resuming
-        # it would report success for an incomplete build.
-        build.status != "evaluating"
-        and resumable.has_attributes
-        and len(resumable.pending_jobs) == unfinished_count
-    ):
-        # Stored drv paths may have been garbage-collected since
-        # the eval; rerunning them would fail with "path does not
-        # exist" instead of rebuilding.
-        drvs = [job.drv_path for job in resumable.pending_jobs]
-        valid = await check_store_paths(drvs)
-        if all(drv in valid for drv in drvs):
-            await s.orchestrator.rerun_pending_attributes(
-                info, build, resumable.pending_jobs, credentials
-            )
-            return False
-        logger.info(
-            "stored derivations missing from the store; re-evaluating",
-            extra={"build_id": build_id},
-        )
-    # No resumable eval results (no attribute rows, or unfinished
-    # rows without drv_path): an empty rerun would aggregate to
-    # "succeeded" without building anything; re-evaluate instead.
+    jobs = await _resumable_eval_jobs(s, build, resumable)
+    if jobs is not None:
+        await s.orchestrator.rerun_pending_attributes(info, build, jobs, credentials)
+        return False
+    # No usable stored eval: re-evaluate rather than rerun an empty set
+    # that would aggregate straight to "succeeded".
     try:
         await _reeval(s, info, build, credentials)
     except Exception:
@@ -106,6 +88,38 @@ async def rerun(s: CIService, build_id: int) -> bool:
         )
         await _report_interrupted(s, resumable)
     return False
+
+
+async def _resumable_eval_jobs(
+    s: CIService, build: BuildRecord, resumable: ResumableBuild
+) -> list[NixEvalJobSuccess] | None:
+    """Return the build's stored pending jobs if they form a complete,
+    runnable eval result, otherwise None so the caller re-evaluates.
+
+    This is the one place that decides whether a build can resume from
+    its stored rows. build_attributes holds both the live eval progress
+    and the cached result, and only eval_completed tells them apart.
+    """
+    if not build.eval_completed:
+        # A partial set (crash or cancellation mid-eval) would resume as
+        # an incomplete build reporting success.
+        return None
+    if not resumable.has_attributes:
+        return None
+    unfinished_count = await q.count_unfinished_attributes(s.pool, build_id=build.id)
+    if len(resumable.pending_jobs) != unfinished_count:
+        return None
+    # Stored drv paths may have been garbage-collected since the eval;
+    # rerunning them would fail with "path does not exist".
+    drvs = [job.drv_path for job in resumable.pending_jobs]
+    valid = await check_store_paths(drvs)
+    if not all(drv in valid for drv in drvs):
+        logger.info(
+            "stored derivations missing from the store; re-evaluating",
+            extra={"build_id": build.id},
+        )
+        return None
+    return resumable.pending_jobs
 
 
 async def _reeval(

--- a/nixbot/nixbot/tests/support.py
+++ b/nixbot/nixbot/tests/support.py
@@ -332,15 +332,22 @@ async def insert_build(  # noqa: PLR0913
     effects_started: bool = False,
     error: str | None = None,
     started: bool = False,
+    eval_completed: bool | None = None,
 ) -> int:
-    """A builds row for the project."""
+    """A builds row for the project.
+
+    eval_completed defaults as in production: set once past
+    pending/evaluating. Pass it explicitly to model a mid-eval crash or
+    cancellation."""
+    if eval_completed is None:
+        eval_completed = status not in ("pending", "evaluating")
     return await pool.fetchval(
         """
         INSERT INTO builds (project_id, number, branch, commit_sha, tree_hash,
                             status, pr_number, pr_author, effects_started,
-                            error, started_at)
+                            error, started_at, eval_completed)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-                CASE WHEN $11 THEN now() END)
+                CASE WHEN $11 THEN now() END, $12)
         RETURNING id
         """,
         project_id,
@@ -354,6 +361,7 @@ async def insert_build(  # noqa: PLR0913
         effects_started,
         error,
         started,
+        eval_completed,
     )
 
 

--- a/nixbot/nixbot/tests/test_service.py
+++ b/nixbot/nixbot/tests/test_service.py
@@ -457,6 +457,58 @@ async def test_restart_cancelled_build_reschedules_attributes(
     assert rescheduled == [["a", "b"]]
 
 
+async def test_restart_cancelled_mid_eval_reevaluates(
+    service: CIService, git_repo: tuple[Path, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A build cancelled mid-eval has a partial attribute set with
+    eval_completed unset. Restarting must re-evaluate, not resume the
+    partial set, even when its derivations are still in the store."""
+    repo, sha = git_repo
+
+    async def all_valid(paths: list[str]) -> set[str]:
+        return set(paths)
+
+    monkeypatch.setattr("nixbot.restart_dispatch.check_store_paths", all_valid)
+
+    pool = service.pool
+    project_id = await seed_project(pool, str(repo))
+    # Post-reset state: status and attrs back to pending, but a mid-eval
+    # cancellation never set eval_completed.
+    build_id = await insert_build(
+        pool,
+        project_id,
+        commit_sha=sha,
+        status="pending",
+        eval_completed=False,
+    )
+    await pool.execute(
+        "INSERT INTO build_attributes (build_id, attr, system, status, "
+        "drv_path) VALUES ($1, 'partial', 'x86_64-linux', 'pending', "
+        "'/nix/store/p.drv')",
+        build_id,
+    )
+
+    reevals: list[int] = []
+    resumes: list[int] = []
+
+    async def fake_run_build(
+        event: Any, build: Any, worktree_path: Path, credentials: Any = None
+    ) -> None:
+        reevals.append(build.id)
+
+    async def fake_resume(
+        info: Any, build: Any, jobs: Any, credentials: Any = None
+    ) -> None:
+        resumes.append(build.id)
+
+    service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
+    service.orchestrator.rerun_pending_attributes = fake_resume  # type: ignore[method-assign, assignment]
+    await restart_dispatch.rerun(service, build_id)
+
+    assert resumes == []
+    assert reevals == [build_id]
+
+
 async def test_restart_while_unwinding_waits_then_runs(
     service: CIService,
     git_repo: tuple[Path, str],

--- a/nixbot_effects/nixbot_effects/cli.py
+++ b/nixbot_effects/nixbot_effects/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from . import (
+    NixbotEffectsError,
     instantiate_effects,
     instantiate_scheduled_effect,
     list_effects,
@@ -354,7 +355,13 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    args.func(args)
+    try:
+        args.func(args)
+    except NixbotEffectsError as e:
+        # The underlying command already printed its own diagnostics; a
+        # Python traceback on top is just noise in the run log.
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nixbot_effects/nixbot_effects/tests/test_cli.py
+++ b/nixbot_effects/nixbot_effects/tests/test_cli.py
@@ -8,7 +8,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from nixbot_effects.cli import _key_value, run_command
+from nixbot_effects import NixbotEffectsError
+from nixbot_effects.cli import _key_value, main, run_command
 
 
 def test_flake_ref_without_fragment_errors() -> None:
@@ -25,6 +26,25 @@ def test_flake_ref_without_fragment_errors() -> None:
 
     with pytest.raises(SystemExit, match="1"):
         run_command(args)
+
+
+def test_main_reports_effects_error_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A failed effect already logged its own diagnostics; main must exit
+    # 1 with a one-line message, not dump a Python traceback into the
+    # run log.
+    msg = "command failed with exit code 1"
+
+    def boom(_args: argparse.Namespace) -> None:
+        raise NixbotEffectsError(msg)
+
+    ns = argparse.Namespace(func=boom)
+    monkeypatch.setattr("nixbot_effects.cli.parse_args", lambda: ns)
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    assert capsys.readouterr().err == "error: command failed with exit code 1\n"
 
 
 def test_extra_nix_option_requires_key_value() -> None:


### PR DESCRIPTION

Cancelling a running evaluation left the partially streamed attribute
set recorded against the build. Restarting took the resume-from-stored-
results path and ran only those attributes, so the build reported
success while missing every attribute the evaluator had not yet emitted.

The resume path keyed off status != "evaluating", which a cancellation
clears, so the partial set looked complete. build_attributes doubles as
live eval progress and the cached result, told apart only by
eval_completed; gate the resume on that flag.


Closes #46
