### PR TITLE
nixbot: pretty logs and run history for scheduled effects

### DIFF
--- a/nixbot/nixbot/db_gen/scheduled.py
+++ b/nixbot/nixbot/db_gen/scheduled.py
@@ -8,6 +8,8 @@ __all__: collections.abc.Sequence[str] = (
     "LatestScheduledRunsRow",
     "ProjectSchedulesRow",
     "QueryResults",
+    "ScheduledRunDetailRow",
+    "ScheduledRunsForEffectRow",
     "SchedulesForUpdateRow",
     "delete_project_schedules",
     "due_schedule_rows",
@@ -16,7 +18,9 @@ __all__: collections.abc.Sequence[str] = (
     "latest_scheduled_runs",
     "mark_schedule_run",
     "project_schedules",
+    "scheduled_run_detail",
     "scheduled_run_exists",
+    "scheduled_runs_for_effect",
     "schedules_for_update",
     "start_scheduled_run",
 )
@@ -55,6 +59,28 @@ class ProjectSchedulesRow:
     effect: str
     when_spec: str
     last_run: datetime.datetime | None
+
+
+@dataclasses.dataclass()
+class ScheduledRunDetailRow:
+    id: int
+    schedule_name: str
+    effect: str
+    status: str
+    error: str | None
+    started_at: datetime.datetime
+    finished_at: datetime.datetime | None
+
+
+@dataclasses.dataclass()
+class ScheduledRunsForEffectRow:
+    id: int
+    schedule_name: str
+    effect: str
+    status: str
+    error: str | None
+    started_at: datetime.datetime
+    finished_at: datetime.datetime | None
 
 
 @dataclasses.dataclass()
@@ -111,8 +137,23 @@ FROM scheduled_effects WHERE project_id = $1
 ORDER BY schedule_name, effect
 """
 
+SCHEDULED_RUN_DETAIL: typing.Final[str] = """-- name: ScheduledRunDetail :one
+SELECT id, schedule_name, effect, status, error, started_at, finished_at
+FROM scheduled_effect_runs WHERE id = $1 AND project_id = $2
+"""
+
 SCHEDULED_RUN_EXISTS: typing.Final[str] = """-- name: ScheduledRunExists :one
 SELECT id FROM scheduled_effect_runs WHERE id = $1 AND project_id = $2
+"""
+
+SCHEDULED_RUNS_FOR_EFFECT: typing.Final[str] = """-- name: ScheduledRunsForEffect :many
+SELECT id, schedule_name, effect, status, error, started_at, finished_at
+FROM scheduled_effect_runs
+WHERE project_id = $1
+  AND schedule_name = $2
+  AND effect = $3
+  AND ($4::bigint IS NULL OR id < $4)
+ORDER BY id DESC LIMIT $5::bigint
 """
 
 SCHEDULES_FOR_UPDATE: typing.Final[str] = """-- name: SchedulesForUpdate :many
@@ -205,11 +246,24 @@ def project_schedules(conn: ConnectionLike, *, project_id: int) -> QueryResults[
     return QueryResults[ProjectSchedulesRow](conn, PROJECT_SCHEDULES, _decode_hook, project_id)
 
 
+async def scheduled_run_detail(conn: ConnectionLike, *, id_: int, project_id: int) -> ScheduledRunDetailRow | None:
+    row = await conn.fetchrow(SCHEDULED_RUN_DETAIL, id_, project_id)
+    if row is None:
+        return None
+    return ScheduledRunDetailRow(id=row[0], schedule_name=row[1], effect=row[2], status=row[3], error=row[4], started_at=row[5], finished_at=row[6])
+
+
 async def scheduled_run_exists(conn: ConnectionLike, *, id_: int, project_id: int) -> int | None:
     row = await conn.fetchrow(SCHEDULED_RUN_EXISTS, id_, project_id)
     if row is None:
         return None
     return row[0]
+
+
+def scheduled_runs_for_effect(conn: ConnectionLike, *, project_id: int, schedule_name: str, effect: str, before: int | None, limit_: int) -> QueryResults[ScheduledRunsForEffectRow]:
+    def _decode_hook(row: asyncpg.Record) -> ScheduledRunsForEffectRow:
+        return ScheduledRunsForEffectRow(id=row[0], schedule_name=row[1], effect=row[2], status=row[3], error=row[4], started_at=row[5], finished_at=row[6])
+    return QueryResults[ScheduledRunsForEffectRow](conn, SCHEDULED_RUNS_FOR_EFFECT, _decode_hook, project_id, schedule_name, effect, before, limit_)
 
 
 def schedules_for_update(conn: ConnectionLike, *, project_id: int) -> QueryResults[SchedulesForUpdateRow]:

--- a/nixbot/nixbot/migrations/0019_scheduled_run_notify.sql
+++ b/nixbot/nixbot/migrations/0019_scheduled_run_notify.sql
@@ -1,0 +1,25 @@
+-- Scheduled-effect runs have no build row, so the build/attribute
+-- triggers (migration 0005) never fire for them and the repo Schedules
+-- table and run-history list stay stale until a manual refresh. Emit on
+-- the same build_events channel; the payload carries project_id (for
+-- visibility filtering) and run_id, but no build_id, so listeners can
+-- tell run events from build/attribute events. schedule_name/effect are
+-- repo-controlled, so truncate them (cf. migration 0012).
+
+CREATE FUNCTION notify_scheduled_run_status() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'UPDATE' AND OLD.status IS NOT DISTINCT FROM NEW.status THEN
+        RETURN NEW;
+    END IF;
+    PERFORM pg_notify('build_events', json_build_object(
+        'project_id', NEW.project_id,
+        'run_id', NEW.id,
+        'schedule_name', left(NEW.schedule_name, 256),
+        'effect', left(NEW.effect, 256),
+        'status', NEW.status)::text);
+    RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER scheduled_effect_runs_status_notify
+AFTER INSERT OR UPDATE ON scheduled_effect_runs
+FOR EACH ROW EXECUTE FUNCTION notify_scheduled_run_status();

--- a/nixbot/nixbot/queries/scheduled.sql
+++ b/nixbot/nixbot/queries/scheduled.sql
@@ -51,3 +51,18 @@ WHERE project_id = $1 AND schedule_name = $2 AND effect = $3;
 
 -- name: ScheduledRunExists :one
 SELECT id FROM scheduled_effect_runs WHERE id = $1 AND project_id = $2;
+
+-- name: ScheduledRunDetail :one
+SELECT id, schedule_name, effect, status, error, started_at, finished_at
+FROM scheduled_effect_runs WHERE id = $1 AND project_id = $2;
+
+-- name: ScheduledRunsForEffect :many
+-- Run history for one (schedule, effect); cursor on id for infinite
+-- scroll (id order matches started_at order for a single effect).
+SELECT id, schedule_name, effect, status, error, started_at, finished_at
+FROM scheduled_effect_runs
+WHERE project_id = sqlc.arg(project_id)
+  AND schedule_name = sqlc.arg(schedule_name)
+  AND effect = sqlc.arg(effect)
+  AND (sqlc.narg(before)::bigint IS NULL OR id < sqlc.narg(before))
+ORDER BY id DESC LIMIT sqlc.arg(limit_)::bigint;

--- a/nixbot/nixbot/schedule_runner.py
+++ b/nixbot/nixbot/schedule_runner.py
@@ -142,6 +142,8 @@ async def _run_scheduled_inner(
         path=log_dir / f"{run_id}.zst",
         size_limit=s.config.log_size_limit,
     )
+    # Shared registry so the web SSE route can stream this run live.
+    s.orchestrator.log_registry.register_scheduled(run_id, log)
     try:
         ctx = effects_context(
             s.config,
@@ -156,4 +158,5 @@ async def _run_scheduled_inner(
     finally:
         s.orchestrator.task_tokens.revoke(task_token)
         await log.close()
+        s.orchestrator.log_registry.unregister_scheduled(run_id)
         await s.orchestrator.repos.remove_worktree(worktree)

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -1514,3 +1514,237 @@ def test_gitlab_nested_group_routes(client: WebHarness) -> None:
     assert build_page.status_code == 200
     build_api = client.get("/api/repos/gitlab/group/sub/proj/builds/1")
     assert build_api.status_code == 200
+
+
+async def _insert_scheduled_run(  # noqa: PLR0913
+    pool: asyncpg.Pool,
+    project_id: int,
+    *,
+    schedule_name: str = "nightly",
+    effect: str = "deploy",
+    status: str = "succeeded",
+    error: str | None = None,
+) -> int:
+    return await pool.fetchval(
+        "INSERT INTO scheduled_effect_runs "
+        "(project_id, schedule_name, effect, status, error, finished_at) "
+        "VALUES ($1, $2, $3, $4, $5, now()) RETURNING id",
+        project_id,
+        schedule_name,
+        effect,
+        status,
+        error,
+    )
+
+
+def _write_scheduled_log(state_dir: Path, run_id: int, data: bytes) -> None:
+    log_dir = state_dir / "logs" / "scheduled"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / f"{run_id}.zst").write_bytes(zstandard.ZstdCompressor().compress(data))
+
+
+def test_scheduled_run_viewer_renders_ansi(client: WebHarness, tmp_path: Path) -> None:
+    """The scheduled-run viewer renders the log as HTML (ANSI -> spans),
+    not as a raw text dump."""
+    ctx = client.ctx
+    ctx.state_dir = tmp_path
+
+    async def setup() -> int:
+        project_id = await ctx.pool.fetchval(
+            "SELECT id FROM projects WHERE forge_repo_id = 'web-1'"
+        )
+        run_id = await _insert_scheduled_run(ctx.pool, project_id)
+        _write_scheduled_log(tmp_path, run_id, b"\x1b[31;1merror:\x1b[0m boom\n")
+        return run_id
+
+    run_id = client.run(setup())
+    resp = client.get(f"/repos/github/acme/widget/schedules/runs/{run_id}")
+    assert resp.status_code == 200
+    assert "ansi-red" in resp.text
+    assert f"runs/{run_id}.txt" in resp.text  # raw link present
+    # Raw route still works and is not shadowed by the HTML viewer.
+    raw = client.get(f"/repos/github/acme/widget/schedules/runs/{run_id}.txt")
+    assert raw.status_code == 200
+    assert "error: boom" in raw.text
+    assert "\x1b[" not in raw.text
+
+
+def test_scheduled_run_viewer_cross_project_404(client: WebHarness) -> None:
+    """A run belonging to another project must not be reachable through
+    this project's URL."""
+    ctx = client.ctx
+
+    async def setup() -> int:
+        other = await insert_project(
+            ctx.pool, "other", forge_repo_id="sched-other", url="u"
+        )
+        return await _insert_scheduled_run(ctx.pool, other)
+
+    run_id = client.run(setup())
+    assert (
+        client.get(f"/repos/github/acme/widget/schedules/runs/{run_id}").status_code
+        == 404
+    )
+
+
+def test_scheduled_run_log_unavailable_placeholder(
+    client: WebHarness, tmp_path: Path
+) -> None:
+    """A run row that outlives its pruned .zst renders a placeholder
+    (HTTP 200), not a 404 that would break the history link."""
+    ctx = client.ctx
+    ctx.state_dir = tmp_path
+
+    async def setup() -> int:
+        project_id = await ctx.pool.fetchval(
+            "SELECT id FROM projects WHERE forge_repo_id = 'web-1'"
+        )
+        return await _insert_scheduled_run(ctx.pool, project_id, effect="pruned")
+
+    run_id = client.run(setup())
+    resp = client.get(f"/repos/github/acme/widget/schedules/runs/{run_id}")
+    assert resp.status_code == 200
+    assert "log unavailable" in resp.text
+
+
+def test_scheduled_run_viewer_waiting_before_log(client: WebHarness) -> None:
+    """A running run whose writer is not registered yet shows a waiting
+    state, not the pruned-log placeholder."""
+    ctx = client.ctx
+
+    async def setup() -> int:
+        project_id = await ctx.pool.fetchval(
+            "SELECT id FROM projects WHERE forge_repo_id = 'web-1'"
+        )
+        return await _insert_scheduled_run(
+            ctx.pool, project_id, effect="starting", status="running"
+        )
+
+    run_id = client.run(setup())
+    resp = client.get(f"/repos/github/acme/widget/schedules/runs/{run_id}")
+    assert resp.status_code == 200
+    assert "waiting for the run to start" in resp.text
+    assert "log unavailable" not in resp.text
+
+
+def test_scheduled_run_history_lists_runs(client: WebHarness) -> None:
+    """The history page lists previous runs of one (schedule, effect),
+    newest first."""
+    ctx = client.ctx
+
+    async def setup() -> tuple[int, int]:
+        project_id = await ctx.pool.fetchval(
+            "SELECT id FROM projects WHERE forge_repo_id = 'web-1'"
+        )
+        first = await _insert_scheduled_run(
+            ctx.pool, project_id, schedule_name="hist", effect="run"
+        )
+        second = await _insert_scheduled_run(
+            ctx.pool, project_id, schedule_name="hist", effect="run", status="failed"
+        )
+        return first, second
+
+    first, second = client.run(setup())
+    resp = client.get(
+        "/repos/github/acme/widget/schedules/runs?schedule=hist&effect=run"
+    )
+    assert resp.status_code == 200
+    assert f"#{first}" in resp.text
+    assert f"#{second}" in resp.text
+    # Newest first: the later id appears before the earlier one.
+    assert resp.text.index(f"#{second}") < resp.text.index(f"#{first}")
+
+
+def test_scheduled_run_history_special_chars(client: WebHarness) -> None:
+    """schedule/effect names are repo-controlled and may contain
+    slashes; query params route them safely."""
+    ctx = client.ctx
+
+    async def setup() -> int:
+        project_id = await ctx.pool.fetchval(
+            "SELECT id FROM projects WHERE forge_repo_id = 'web-1'"
+        )
+        return await _insert_scheduled_run(
+            ctx.pool, project_id, schedule_name="a/b c", effect="x/y"
+        )
+
+    run_id = client.run(setup())
+    resp = client.run(
+        client.http.get(
+            "/repos/github/acme/widget/schedules/runs",
+            params={"schedule": "a/b c", "effect": "x/y"},
+        )
+    )
+    assert resp.status_code == 200
+    assert f"#{run_id}" in resp.text
+
+
+def test_scheduled_run_stream_replays_history(
+    client: WebHarness, tmp_path: Path
+) -> None:
+    """The scheduled-run stream replays the running writer's history."""
+    ctx = client.ctx
+    ctx.state_dir = tmp_path
+    registry = client.app.state.log_registry
+
+    async def run() -> str:
+        project_id = await ctx.pool.fetchval(
+            "SELECT id FROM projects WHERE forge_repo_id = 'web-1'"
+        )
+        run_id = await _insert_scheduled_run(
+            ctx.pool, project_id, effect="streamed", status="running"
+        )
+        writer = LogWriter(path=tmp_path / "logs" / "scheduled" / f"{run_id}.zst")
+        await writer.write(b"scheduled early\n")
+        registry.register_scheduled(run_id, writer)
+        try:
+            url = f"/repos/github/acme/widget/schedules/runs/{run_id}/stream"
+            task = asyncio.ensure_future(client.http.get(url))
+            await asyncio.sleep(0.1)
+            await writer.write(b"scheduled late\n")
+            await writer.close()
+            return (await task).text
+        finally:
+            registry.unregister_scheduled(run_id)
+
+    stream = client.loop.run_until_complete(run())
+    assert "scheduled early" in stream
+    assert "scheduled late" in stream
+    assert "event: done" in stream
+
+
+def test_scheduled_run_notify_build_events(client: WebHarness) -> None:
+    """Run INSERT (running) and terminal UPDATE both NOTIFY on
+    build_events; an unchanged status does not."""
+
+    async def run() -> list[dict]:
+        ctx = client.ctx
+        project_id = await ctx.pool.fetchval(
+            "SELECT id FROM projects WHERE forge_repo_id = 'web-1'"
+        )
+        received: list[str] = []
+        conn = await ctx.pool.acquire()
+        listener = lambda *args: received.append(args[3])  # noqa: E731
+        try:
+            await conn.add_listener("build_events", listener)
+            run_id = await ctx.pool.fetchval(
+                "INSERT INTO scheduled_effect_runs "
+                "(project_id, schedule_name, effect) VALUES ($1, 'n', 'd') "
+                "RETURNING id",
+                project_id,
+            )
+            await ctx.pool.execute(
+                "UPDATE scheduled_effect_runs SET status = 'succeeded', "
+                "finished_at = now() WHERE id = $1",
+                run_id,
+            )
+            await asyncio.sleep(0.2)
+        finally:
+            await conn.remove_listener("build_events", listener)
+            await ctx.pool.release(conn)
+        return [json.loads(r) for r in received], run_id  # type: ignore[return-value]
+
+    payloads, run_id = client.loop.run_until_complete(run())  # type: ignore[misc]
+    assert [p["status"] for p in payloads] == ["running", "succeeded"]
+    assert all(p["run_id"] == run_id for p in payloads)
+    assert all("build_id" not in p for p in payloads)

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -8,6 +8,7 @@ executor's LogWriter fans out to any number of SSE subscribers.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import html
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -45,6 +46,9 @@ class LogRegistry:
 
     def __init__(self) -> None:
         self._writers: dict[tuple[int, str], LogWriter] = {}
+        # Scheduled-effect runs have no build_id; key them by run id in
+        # a separate map so the namespaces cannot collide.
+        self._scheduled: dict[int, LogWriter] = {}
 
     def register(self, build_id: int, attr: str, writer: LogWriter) -> None:
         self._writers[(build_id, attr)] = writer
@@ -54,6 +58,15 @@ class LogRegistry:
 
     def get(self, build_id: int, attr: str) -> LogWriter | None:
         return self._writers.get((build_id, attr))
+
+    def register_scheduled(self, run_id: int, writer: LogWriter) -> None:
+        self._scheduled[run_id] = writer
+
+    def unregister_scheduled(self, run_id: int) -> None:
+        self._scheduled.pop(run_id, None)
+
+    def get_scheduled(self, run_id: int) -> LogWriter | None:
+        return self._scheduled.get(run_id)
 
 
 _COLOR_CLASSES = {}
@@ -273,6 +286,8 @@ async def _failure_summary(
 # downloads and in the static viewer.
 HISTORY_MAX_LINES = 2000
 
+_HISTORY_PAGE = 50
+
 _FAILURE_STATUSES = {s.value for s in TERMINAL_FAILURES} | {"cancelled"}
 
 
@@ -345,6 +360,22 @@ class _LogRoutes:
             return await self.log_viewer(request, forge, owner, name, number, shadowed)
         return await self.log_raw_text(request, forge, owner, name, number, attr, tail)
 
+    def _scheduled_log_path(self, run_id: int) -> Path:
+        return self.ctx.state_dir / "logs" / "scheduled" / f"{run_id}.zst"
+
+    async def _scheduled_run_text(self, run_id: int) -> str | None:
+        """Decoded log of a scheduled run: live writer snapshot while it
+        runs, otherwise the on-disk file. None when no log exists."""
+        writer = self.registry.get_scheduled(run_id)
+        if writer is not None:
+            data = await writer.snapshot()
+        else:
+            path = self._scheduled_log_path(run_id)
+            if not await asyncio.to_thread(path.exists):
+                return None
+            data = await asyncio.to_thread(read_log, path)
+        return data.decode(errors="replace")
+
     async def scheduled_run_log(
         self,
         request: Request,
@@ -358,12 +389,114 @@ class _LogRoutes:
         row = await sched_gen.scheduled_run_exists(
             self.ctx.pool, id_=run_id, project_id=project["id"]
         )
-        path = self.ctx.state_dir / "logs" / "scheduled" / f"{run_id}.zst"
-        if row is None or not await asyncio.to_thread(path.exists):
+        if row is None:
             raise HTTPException(status_code=404)
-        data = await asyncio.to_thread(read_log, path)
-        return PlainTextResponse(
-            await asyncio.to_thread(strip_ansi, data.decode(errors="replace"))
+        text = await self._scheduled_run_text(run_id)
+        if text is None:
+            raise HTTPException(status_code=404)
+        return PlainTextResponse(await asyncio.to_thread(strip_ansi, text))
+
+    async def scheduled_run_viewer(
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        run_id: int,
+    ) -> HTMLResponse:
+        """ANSI-rendered HTML log of one scheduled-effect run."""
+        project = await self.ctx.repo_or_404(forge, owner, name, request)
+        run = await sched_gen.scheduled_run_detail(
+            self.ctx.pool, id_=run_id, project_id=project["id"]
+        )
+        if run is None:
+            raise HTTPException(status_code=404)
+        # Live page renders no snapshot: the stream replays full history
+        # on connect (mirrors log_viewer).
+        live = self.registry.get_scheduled(run_id) is not None
+        content = ""
+        waiting = False
+        unavailable = False
+        if not live:
+            text = await self._scheduled_run_text(run_id)
+            if text is not None:
+                content = await asyncio.to_thread(render_log_lines, text)
+            elif run.status == "running":
+                # Started but the writer is not registered yet (fetch /
+                # checkout runs before the first log byte); poll until it
+                # appears instead of claiming the log is gone.
+                waiting = True
+            else:
+                # Terminal run whose log was pruned: placeholder, not a
+                # 404, so the history link still resolves.
+                unavailable = True
+        return await self.ctx.render(
+            "scheduled_log.html",
+            request=request,
+            project=project,
+            run=dataclasses.asdict(run),
+            content=content,
+            live=live,
+            waiting=waiting,
+            unavailable=unavailable,
+        )
+
+    async def scheduled_run_stream(
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        run_id: int,
+    ) -> StreamingResponse:
+        """SSE: history from disk, then live chunks until completion."""
+        project = await self.ctx.repo_or_404(forge, owner, name, request)
+        row = await sched_gen.scheduled_run_exists(
+            self.ctx.pool, id_=run_id, project_id=project["id"]
+        )
+        if row is None:
+            raise HTTPException(status_code=404)
+        writer = self.registry.get_scheduled(run_id)
+        path = self._scheduled_log_path(run_id)
+        return StreamingResponse(
+            _stream_events(writer, path), media_type="text/event-stream"
+        )
+
+    async def scheduled_runs_history(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        schedule: str,
+        effect: str,
+        before: int | None = Query(None, ge=1),
+    ) -> HTMLResponse:
+        """Paginated run history for one (schedule, effect). schedule and
+        effect arrive as query params, never path segments, so the
+        repo-controlled names cannot affect routing or filesystem paths;
+        runs are looked up by id only."""
+        project = await self.ctx.repo_or_404(forge, owner, name, request)
+        rows = await sched_gen.scheduled_runs_for_effect(
+            self.ctx.pool,
+            project_id=project["id"],
+            schedule_name=schedule,
+            effect=effect,
+            before=before,
+            limit_=_HISTORY_PAGE + 1,
+        )
+        runs = [dataclasses.asdict(r) for r in rows]
+        has_more = len(runs) > _HISTORY_PAGE
+        runs = runs[:_HISTORY_PAGE]
+        template = "_schedule_run_rows.html" if before else "schedule_runs.html"
+        return await self.ctx.render(
+            template,
+            request=request,
+            project=project,
+            schedule=schedule,
+            effect=effect,
+            runs=runs,
+            has_more=has_more,
         )
 
     async def build_failures(  # noqa: PLR0913
@@ -468,9 +601,18 @@ def create_log_router(ctx: WebContext, registry: LogRegistry) -> APIRouter:
     router.get(f"{_BASE}/logs/{{attr:path}}", response_class=HTMLResponse)(
         routes.log_viewer
     )
-    router.get(
-        "/repos/{forge}/{owner:owner}/{name:segment}/schedules/runs/{run_id}.txt"
-    )(routes.scheduled_run_log)
+    # Same ordering discipline as the attribute routes above: the .txt
+    # and /stream suffixes and the runs list precede the int {run_id}
+    # viewer so it cannot swallow them.
+    sched_base = "/repos/{forge}/{owner:owner}/{name:segment}/schedules"
+    router.get(f"{sched_base}/runs", response_class=HTMLResponse)(
+        routes.scheduled_runs_history
+    )
+    router.get(f"{sched_base}/runs/{{run_id:int}}.txt")(routes.scheduled_run_log)
+    router.get(f"{sched_base}/runs/{{run_id:int}}/stream")(routes.scheduled_run_stream)
+    router.get(f"{sched_base}/runs/{{run_id:int}}", response_class=HTMLResponse)(
+        routes.scheduled_run_viewer
+    )
     return router
 
 

--- a/nixbot/nixbot/web/templates/_schedule_run_rows.html
+++ b/nixbot/nixbot/web/templates/_schedule_run_rows.html
@@ -1,0 +1,21 @@
+{% from "_macros.html" import status_icon %}
+{% for r in runs %}
+  <tr data-id="{{ r.id }}">
+    <td>
+      {{ status_icon(r.status) }}<a href="{{ repo_path(project) }}/schedules/runs/{{ r.id }}">#{{ r.id }}</a>
+    </td>
+    <td class="muted">
+      <time datetime="{{ r.started_at.isoformat() }}" title="{{ r.started_at }}">{{ r.started_at | timeago }}</time>
+    </td>
+    <td>{{ r | duration }}</td>
+  </tr>
+{% endfor %}
+{% if has_more %}
+  {% set more_url = repo_path(project) ~ "/schedules/runs?schedule=" ~ (schedule | urlencode) ~ "&effect=" ~ (effect | urlencode) ~ "&before=" ~ (runs | last).id %}
+  <tr class="scroll-sentinel"
+      hx-get="{{ more_url }}"
+      hx-trigger="revealed"
+      hx-swap="outerHTML">
+    <td colspan="3" class="muted">loading more…</td>
+  </tr>
+{% endif %}

--- a/nixbot/nixbot/web/templates/repo.html
+++ b/nixbot/nixbot/web/templates/repo.html
@@ -99,14 +99,11 @@
           </thead>
           {% for s in schedules %}
             {% set label = s.schedule if s.schedule == s.effect else s.schedule ~ " · " ~ s.effect %}
+            {% set history_url = repo_path(project) ~ "/schedules/runs?schedule=" ~ (s.schedule | urlencode) ~ "&effect=" ~ (s.effect | urlencode) %}
             <tr>
               <td class="status">{{ status_icon(s.run.status if s.run else "pending") }}</td>
               <td class="attr-name">
-                {% if s.run %}
-                  <a href="{{ repo_path(project) }}/schedules/runs/{{ s.run.id }}.txt">{{ label }}</a>
-                {% else %}
-                  {{ label }}
-                {% endif %}
+                <a href="{{ history_url }}">{{ label }}</a>
               </td>
               <td class="muted attr-status">{{ s.when }}</td>
               <td class="muted attr-status">
@@ -118,8 +115,10 @@
               </td>
               <td class="muted attr-status">
                 {% if s.run %}
-                  <time datetime="{{ s.run.started_at.isoformat() }}"
-                        title="{{ s.run.started_at }}">{{ s.run.started_at | timeago }}</time>
+                  <a href="{{ repo_path(project) }}/schedules/runs/{{ s.run.id }}">
+                    <time datetime="{{ s.run.started_at.isoformat() }}"
+                          title="{{ s.run.started_at }}">{{ s.run.started_at | timeago }}</time>
+                  </a>
                 {% else %}
                   never
                 {% endif %}

--- a/nixbot/nixbot/web/templates/schedule_runs.html
+++ b/nixbot/nixbot/web/templates/schedule_runs.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% from "_macros.html" import status_icon %}
+{% set label = schedule if schedule == effect else schedule ~ " · " ~ effect %}
+{% block title %}
+  {{ label }} runs
+{% endblock title %}
+{% block body %}
+  <main id="main">
+    <section class="content">
+      <div class="build-header">
+        <h2>
+          <code>{{ label }}</code>
+          <small>
+            runs · <a href="{{ repo_path(project) }}">{{ project.owner }}/{{ project.name }}</a>
+          </small>
+        </h2>
+      </div>
+      {% if runs %}
+        <div class="table-scroll">
+          <table class="builds">
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">started</th>
+                <th scope="col">took</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% include "_schedule_run_rows.html" %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="muted">no runs yet</p>
+      {% endif %}
+    </section>
+  </main>
+{% endblock body %}

--- a/nixbot/nixbot/web/templates/scheduled_log.html
+++ b/nixbot/nixbot/web/templates/scheduled_log.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+{% from "_macros.html" import status_icon %}
+{% set label = run.schedule_name if run.schedule_name == run.effect else run.schedule_name ~ " · " ~ run.effect %}
+{% set history_url = repo_path(project) ~ "/schedules/runs?schedule=" ~ (run.schedule_name | urlencode) ~ "&effect=" ~ (run.effect | urlencode) %}
+{% block title %}
+  {{ label }} run
+{% endblock title %}
+{% block body %}
+  <main id="main">
+    <section class="content">
+      <div class="build-header">
+        <h2>
+          {{ status_icon(run.status) }}
+          <code>{{ label }}</code>
+          <small>
+            run #{{ run.id }}
+            · <a href="{{ repo_path(project) }}/schedules/runs/{{ run.id }}.txt">raw</a>
+            · <a href="{{ history_url }}">history</a>
+            · <a href="{{ repo_path(project) }}">{{ project.owner }}/{{ project.name }}</a>
+          </small>
+        </h2>
+      </div>
+      {% if live %}
+        <label>
+          <input type="checkbox" id="follow" checked>
+          follow tail
+        </label>
+      {% endif %}
+      {% if waiting %}
+        <p class="muted">waiting for the run to start…</p>
+      {% elif unavailable %}
+        <p class="muted">log unavailable — it was pruned or never written</p>
+      {% elif not content and not live %}
+        <p class="muted">no output</p>
+      {% else %}
+        <pre class="log" id="log">{{ content | safe }}</pre>
+      {% endif %}
+    </section>
+  </main>
+  <script>
+    const LIVE = {{ live | tojson }};
+    const WAITING = {{ waiting | tojson }};
+    const RUN_ID = {{ run.id | tojson }};
+    const log = document.getElementById("log");
+    if (log && !location.hash) log.scrollTop = log.scrollHeight;
+    /* Started but no writer/log yet: reload until it appears, since the
+       running->running INSERT raised no further event to react to. */
+    if (WAITING) setTimeout(() => location.reload(), 2000);
+    /* Status changes for this run (INSERT running / terminal UPDATE)
+       arrive on the shared events channel; reload to re-render the
+       header dot and, once finished, the server-side static log. */
+    const events = new EventSource("/events?project={{ project.id }}");
+    events.onmessage = (ev) => {
+      let e;
+      try { e = JSON.parse(ev.data); } catch { return; }
+      if (e.run_id !== RUN_ID) return;
+      if (!LIVE || !["running"].includes(e.status)) location.reload();
+    };
+    if (LIVE) {
+      const follow = document.getElementById("follow");
+      const atBottom = () =>
+        log.scrollHeight - log.scrollTop - log.clientHeight < 4;
+      log.addEventListener("scroll", () => { follow.checked = atBottom(); });
+      const source = new EventSource(
+        "{{ repo_path(project) }}/schedules/runs/{{ run.id }}/stream");
+      let errors = 0;
+      source.onopen = () => { errors = 0; log.textContent = ""; };
+      source.onerror = () => {
+        if (++errors >= 5) {
+          source.close();
+          setTimeout(() => location.reload(), 3000);
+        }
+      };
+      source.onmessage = (event) => {
+        log.insertAdjacentHTML("beforeend", event.data);
+        if (follow.checked) log.scrollTop = log.scrollHeight;
+      };
+      source.addEventListener("done", () => source.close());
+    }
+  </script>
+{% endblock body %}


### PR DESCRIPTION
onSchedule effects only linked to a raw text file for the last run, unlike the rendered, streamed logs onPush effects get.

Add an ANSI-rendered HTML viewer and a paginated run-history page, reusing the existing log rendering and SSE streaming. Runs stream live by registering their LogWriter on the orchestrator's shared registry under the run id; a NOTIFY trigger on scheduled_effect_runs drives status updates over the existing build_events channel.

History is keyed by run id with schedule/effect as query params, so repo-controlled names cannot affect routing or filesystem paths.