### PR TITLE
nixbot-effects: handle effects gated off by runIf

### DIFF
--- a/nixbot_effects/nixbot_effects/__init__.py
+++ b/nixbot_effects/nixbot_effects/__init__.py
@@ -223,30 +223,68 @@ def _instantiate(expr: str, opts: EffectsOptions, gcroot: Path) -> str:
         expr,
     ]
     proc = run(cmd, stdout=subprocess.PIPE, debug=opts.debug)
-    output = proc.stdout.rstrip()
-    if output == "":
+    paths = proc.stdout.split()
+    if not paths:
         return ""
-    # --add-root prints the symlink path; resolve to the actual store path
-    return str(Path(output).resolve())
+    # nix-instantiate prints one --add-root symlink per derivation; an
+    # effect must be a single one, else `derivation show` gets a bad path.
+    if len(paths) != 1:
+        msg = f"expected effect to be a single derivation, got {len(paths)}: {proc.stdout!r}"
+        raise NixbotEffectsError(msg)
+    return str(Path(paths[0]).resolve())
 
 
-def instantiate_effects(effect: str, opts: EffectsOptions, gcroot: Path) -> str:
-    return _instantiate(
-        f"let e = ({effect_function(opts)}).{effect}; in if e ? run then e.run else e",
-        opts,
-        gcroot,
+def _eval_bool(expr: str, opts: EffectsOptions) -> bool:
+    cmd = nix_command("eval", "--json", "--expr", expr)
+    proc = run(cmd, stdout=subprocess.PIPE, debug=opts.debug)
+    return bool(json.loads(proc.stdout))
+
+
+def _select_effect(
+    binding: str, opts: EffectsOptions, gcroot: Path
+) -> tuple[str, bool]:
+    """Instantiate an effect bound to `e` by `binding`.
+
+    hercules-ci's `runIf false` replaces the effect with a wrapper set
+    `{ dependencies; prebuilt; }` (recurseForDerivations) so nix-instantiate
+    would emit a root per derivation. Select a single derivation: the
+    runnable effect (`e.run`, or a bare effect derivation), otherwise the
+    dependency-only build. Only run in the former case; the latter mirrors
+    the agent, which just builds inputs when the effect is gated off.
+    See https://github.com/Mic92/nixbot/issues/56.
+    """
+    drv_path = _instantiate(f"{binding} e.run or e.dependencies or e", opts, gcroot)
+    if drv_path == "":
+        return "", False
+    should_run = _eval_bool(f"{binding} e ? run || !(e ? dependencies)", opts)
+    return drv_path, should_run
+
+
+def instantiate_effects(
+    effect: str, opts: EffectsOptions, gcroot: Path
+) -> tuple[str, bool]:
+    return _select_effect(
+        f"let e = ({effect_function(opts)}).{effect}; in", opts, gcroot
     )
 
 
 def instantiate_scheduled_effect(
     schedule_name: str, effect: str, opts: EffectsOptions, gcroot: Path
-) -> str:
+) -> tuple[str, bool]:
     """Instantiate a specific effect from a schedule."""
-    return _instantiate(
-        f"({scheduled_effect_function(opts)}).{schedule_name}.outputs.effects.{effect}",
+    return _select_effect(
+        f"let e = ({scheduled_effect_function(opts)})"
+        f".{schedule_name}.outputs.effects.{effect}; in",
         opts,
         gcroot,
     )
+
+
+def build_derivation(drv_path: str, opts: EffectsOptions) -> None:
+    """Realise a derivation without running it (gated-off effects only build
+    their dependencies, matching hercules-ci-agent)."""
+    cmd = nix_command("build", "--no-link", f"{drv_path}^*")
+    run(cmd, debug=opts.debug)
 
 
 def parse_derivation(path: str, *, debug: bool = False) -> dict[str, Any]:

--- a/nixbot_effects/nixbot_effects/cli.py
+++ b/nixbot_effects/nixbot_effects/cli.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from . import (
     NixbotEffectsError,
+    build_derivation,
     instantiate_effects,
     instantiate_scheduled_effect,
     list_effects,
@@ -141,13 +142,21 @@ def run_command(args: argparse.Namespace) -> None:
 
     with tempfile.TemporaryDirectory() as tmpdir:
         gcroot = Path(tmpdir) / "result"
-        drv_path = instantiate_effects(effect, options, gcroot)
+        drv_path, should_run = instantiate_effects(effect, options, gcroot)
         if drv_path == "":
             print(
                 f"Effect {effect} not found or not runnable for {options}",
                 file=sys.stderr,
             )
             sys.exit(1)
+        if not should_run:
+            print(
+                f"Effect {effect} is gated off for {options}; building"
+                " dependencies only",
+                file=sys.stderr,
+            )
+            build_derivation(drv_path, options)
+            return
         _run_effect_derivation(drv_path, options)
 
 
@@ -171,7 +180,9 @@ def run_scheduled_command(args: argparse.Namespace) -> None:
 
     with tempfile.TemporaryDirectory() as tmpdir:
         gcroot = Path(tmpdir) / "result"
-        drv_path = instantiate_scheduled_effect(schedule_name, effect, options, gcroot)
+        drv_path, should_run = instantiate_scheduled_effect(
+            schedule_name, effect, options, gcroot
+        )
         if drv_path == "":
             print(
                 f"Scheduled effect {schedule_name}/{effect} not found or not runnable"
@@ -179,6 +190,14 @@ def run_scheduled_command(args: argparse.Namespace) -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
+        if not should_run:
+            print(
+                f"Scheduled effect {schedule_name}/{effect} is gated off for"
+                f" {options}; building dependencies only",
+                file=sys.stderr,
+            )
+            build_derivation(drv_path, options)
+            return
         _run_effect_derivation(drv_path, options)
 
 

--- a/nixbot_effects/nixbot_effects/tests/test_gated_effect.py
+++ b/nixbot_effects/nixbot_effects/tests/test_gated_effect.py
@@ -1,0 +1,69 @@
+"""Effects gated off by hercules-ci's `runIf false` become a wrapper set
+`{ dependencies; prebuilt; }` (recurseForDerivations) instead of a single
+derivation. nixbot must pick one derivation and not try to run it.
+
+https://github.com/Mic92/nixbot/issues/56
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nixbot_effects import instantiate_effects
+from nixbot_effects.options import EffectsOptions
+from nixbot_effects.tests.support import init_repo
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# derivation {} instantiates without building, enough to exercise selection.
+FLAKE_NIX = """\
+{
+  outputs = { self, ... }:
+    let
+      drv = name: derivation {
+        inherit name;
+        system = builtins.currentSystem;
+        builder = "/bin/sh";
+        args = [ "-c" "echo ${name} > $out" ];
+      };
+    in {
+      herculesCI = args: {
+        onPush.default.outputs.effects = {
+          # runIf true
+          runnable = { run = drv "runnable"; };
+          # bare effect derivation (no runIf)
+          bare = drv "bare";
+          # runIf false: recurseForDerivations wrapper with multiple drvs
+          gated = {
+            recurseForDerivations = true;
+            dependencies = drv "dependencies";
+            prebuilt = drv "prebuilt";
+          };
+        };
+      };
+    };
+}
+"""
+
+
+def _instantiate(effect: str, repo: Path, tmp_path: Path) -> tuple[str, bool]:
+    opts = EffectsOptions(path=repo)
+    return instantiate_effects(effect, opts, tmp_path / f"result-{effect}")
+
+
+def test_gated_effect_selects_dependencies_and_skips_run(tmp_path: Path) -> None:
+    repo, _rev = init_repo(tmp_path, {"flake.nix": FLAKE_NIX})
+
+    drv_path, should_run = _instantiate("gated", repo, tmp_path)
+    assert drv_path.endswith("-dependencies.drv")
+    assert should_run is False
+
+
+def test_runnable_and_bare_effects_run(tmp_path: Path) -> None:
+    repo, _rev = init_repo(tmp_path, {"flake.nix": FLAKE_NIX})
+
+    for effect in ("runnable", "bare"):
+        drv_path, should_run = _instantiate(effect, repo, tmp_path)
+        assert drv_path.endswith(f"-{effect}.drv")
+        assert should_run is True


### PR DESCRIPTION
runIf false replaces an effect with a recurseForDerivations set `{ dependencies; prebuilt; }` instead of `{ run = <drv>; }`. The `else e` fallback passed that set to `nix-instantiate`, which wrote one `--add-root` symlink per derivation (`result`, `result-2`). Both paths were then joined and handed to `nix derivation show` as one argument, which fails.

Fix: pick one derivation — `e.run` when present, else `e.dependencies`. Run the former; for a gated-off effect only build its dependencies.

Closes: https://github.com/Mic92/nixbot/issues/56