### PR TITLE
status: post evaluator error tail on failed evals

### DIFF
--- a/nixbot/nixbot/build_reuse.py
+++ b/nixbot/nixbot/build_reuse.py
@@ -19,7 +19,7 @@ from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
 from .db_gen import web as web_q
-from .events import BuildResult
+from .events import BuildResult, EvalReport
 from .gitrepo import GitError, run_git
 
 if TYPE_CHECKING:
@@ -64,7 +64,7 @@ async def replay_terminal_status(
         eval_success = build.status == BuildStatus.SUCCEEDED or bool(
             await builds_q.attribute_statuses(o.pool, build_id=build.id)
         )
-        await o.reporter.eval_finished(event, build, success=eval_success, warnings=[])
+        await o.reporter.eval_finished(event, build, EvalReport(success=eval_success))
     await o.reporter.build_finished(
         event, build, BuildResult(build.status, build.status_generation, [])
     )
@@ -110,7 +110,7 @@ async def finish_linked(
     for linked in o.linked_events.pop(build.id, []):
         if eval_success is not None:
             await o.reporter.eval_finished(
-                linked, build, success=eval_success, warnings=[]
+                linked, build, EvalReport(success=eval_success)
             )
         elif result.status == BuildStatus.CANCELLED:
             # Cancel during eval: the linked contexts' nix-eval

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -25,7 +25,7 @@ from .build_scheduler import (
 )
 from .db import BuildStatus
 from .db_gen import builds as q
-from .events import BuildResult
+from .events import BuildResult, EvalReport
 from .executor import failure_excerpt
 from .live_warnings import LiveWarningAggregator
 from .memory import calculate_eval_workers
@@ -191,7 +191,9 @@ async def _settle_aborted(
     if status == BuildStatus.CANCELLED:
         await o.reporter.eval_cancelled(event, build)
     else:
-        await o.reporter.eval_finished(event, build, success=False, warnings=[])
+        await o.reporter.eval_finished(
+            event, build, EvalReport(success=False, error=error)
+        )
     await o.reporter.build_finished(
         event, build, BuildResult(status, build.status_generation, [])
     )
@@ -316,9 +318,11 @@ async def _run_build_inner(
         await o.reporter.eval_finished(
             event,
             build,
-            success=True,
-            warnings=[str(g["message"]) for g in live_warnings.snapshot()],
-            jobs=buildable,
+            EvalReport(
+                success=True,
+                warnings=[str(g["message"]) for g in live_warnings.snapshot()],
+                jobs=buildable,
+            ),
         )
 
         # Re-send the complete eval result: the scheduler dedupes
@@ -384,7 +388,7 @@ async def _try_reuse_eval(
     await record_attributes(o.pool, build.id, reused)
     await q.mark_eval_completed(o.pool, id_=build.id)
     await db.set_build_status(o.pool, build.id, BuildStatus.BUILDING)
-    await o.reporter.eval_finished(event, build, success=True, warnings=[], jobs=reused)
+    await o.reporter.eval_finished(event, build, EvalReport(success=True, jobs=reused))
     # cache_failures=False: see _ReadOnlyFailedBuildCache.
     status = await build_attributes(
         o, event, build, worktree_path, reused, cache_failures=False

--- a/nixbot/nixbot/events.py
+++ b/nixbot/nixbot/events.py
@@ -7,7 +7,7 @@ build pipeline.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
@@ -47,6 +47,18 @@ class ChangeEvent:
 
 
 @dataclass(frozen=True)
+class EvalReport:
+    """Evaluation-phase outcome reported to a forge. warnings and jobs
+    are populated on success; error carries the evaluator's log tail on
+    failure."""
+
+    success: bool
+    warnings: list[str] = field(default_factory=list)
+    jobs: Sequence[NixEvalJobSuccess] | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
 class BuildResult:
     """The final outcome of a build, as reported to a forge."""
 
@@ -63,13 +75,7 @@ class StatusReporter(Protocol):
     async def build_started(self, event: ChangeEvent, build: BuildRecord) -> None: ...
 
     async def eval_finished(
-        self,
-        event: ChangeEvent,
-        build: BuildRecord,
-        *,
-        success: bool,
-        warnings: list[str],
-        jobs: Sequence[NixEvalJobSuccess] | None = None,
+        self, event: ChangeEvent, build: BuildRecord, report: EvalReport
     ) -> None: ...
 
     async def eval_cancelled(self, event: ChangeEvent, build: BuildRecord) -> None: ...
@@ -111,13 +117,7 @@ class NullStatusReporter:
         pass
 
     async def eval_finished(
-        self,
-        event: ChangeEvent,
-        build: BuildRecord,
-        *,
-        success: bool,
-        warnings: list[str],
-        jobs: Sequence[NixEvalJobSuccess] | None = None,
+        self, event: ChangeEvent, build: BuildRecord, report: EvalReport
     ) -> None:
         pass
 

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -38,6 +38,7 @@ from .effects_state import TaskTokens
 from .events import (
     BuildResult,
     ChangeEvent,
+    EvalReport,
     NullStatusReporter,
     RepoInfo,
     StatusReporter,
@@ -179,7 +180,9 @@ class Orchestrator:
                 pr_number=event.pr_number,
                 pr_author=event.pr_author,
             )
-            await self.reporter.eval_finished(event, build, success=False, warnings=[])
+            await self.reporter.eval_finished(
+                event, build, EvalReport(success=False, error=str(e))
+            )
             await self.reporter.build_finished(
                 event, build, BuildResult(BuildStatus.FAILED, 0, [])
             )

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -16,7 +16,7 @@ from .canceller import branch_key
 from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
-from .events import ChangeEvent
+from .events import ChangeEvent, EvalReport
 from .gitrepo import pr_refspec
 
 if TYPE_CHECKING:
@@ -117,7 +117,7 @@ async def rerun_pending_attributes(
         ):
             # No re-eval on this path: re-post the eval context green,
             # the previous run may have left it red or pending.
-            await o.reporter.eval_finished(event, build, success=True, warnings=[])
+            await o.reporter.eval_finished(event, build, EvalReport(success=True))
             # cache_failures=False: see _ReadOnlyFailedBuildCache.
             status = await build_run.build_attributes(
                 o,

--- a/nixbot/nixbot/restart_dispatch.py
+++ b/nixbot/nixbot/restart_dispatch.py
@@ -14,7 +14,7 @@ from . import db
 from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
-from .events import BuildResult, ChangeEvent
+from .events import BuildResult, ChangeEvent, EvalReport
 from .recovery import check_store_paths, find_unfinished_builds
 from .repos import repo_info
 
@@ -167,9 +167,7 @@ async def _report_interrupted(s: CIService, resumable: ResumableBuild) -> None:
     event = await change_event_for(s, resumable)
     if build is None or event is None:
         return
-    await s.orchestrator.reporter.eval_finished(
-        event, build, success=False, warnings=[]
-    )
+    await s.orchestrator.reporter.eval_finished(event, build, EvalReport(success=False))
     await s.orchestrator.reporter.build_finished(
         event, build, BuildResult(BuildStatus.FAILED, build.status_generation, [])
     )

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -21,7 +21,7 @@ from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import failed as failed_q
 from .db_gen import maintenance as q
-from .events import BuildResult, ChangeEvent, StatusReporter
+from .events import BuildResult, ChangeEvent, EvalReport, StatusReporter
 from .gitrepo import (
     CredentialsProvider,
     FetchCredentials,
@@ -46,14 +46,13 @@ from .webhooks import (
 from .work_queue import WorkItem, WorkQueue
 
 if TYPE_CHECKING:
-    from collections.abc import Coroutine, Sequence
+    from collections.abc import Coroutine
 
     import asyncpg
 
     from .config import Config
     from .db import BuildRecord
     from .forge import GiteaClient, GitHubAppClient, GitlabClient
-    from .models import NixEvalJobSuccess
     from .orchestrator import Orchestrator
     from .polling import PolledRepository
     from .repos import RepoStore
@@ -118,17 +117,9 @@ class RetryingReporter:
         await self.inner.build_started(event, build)
 
     async def eval_finished(
-        self,
-        event: ChangeEvent,
-        build: BuildRecord,
-        *,
-        success: bool,
-        warnings: list[str],
-        jobs: Sequence[NixEvalJobSuccess] | None = None,
+        self, event: ChangeEvent, build: BuildRecord, report: EvalReport
     ) -> None:
-        await self.inner.eval_finished(
-            event, build, success=success, warnings=warnings, jobs=jobs
-        )
+        await self.inner.eval_finished(event, build, report)
 
     async def eval_cancelled(self, event: ChangeEvent, build: BuildRecord) -> None:
         await self.inner.eval_cancelled(event, build)

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -51,9 +51,8 @@ if TYPE_CHECKING:
 
     from .build_scheduler import AttributeResult
     from .db import BuildRecord
-    from .events import BuildResult, ChangeEvent
+    from .events import BuildResult, ChangeEvent, EvalReport
     from .forge import GiteaClient, GitHubAppClient, GitlabClient
-    from .models import NixEvalJobSuccess
 
 # GitHub caps output.text at 65535 chars.
 CHECK_RUN_TEXT_LIMIT = 60_000
@@ -491,31 +490,34 @@ class ForgeStatusReporter:
         )
 
     async def eval_finished(
-        self,
-        event: ChangeEvent,
-        build: BuildRecord,
-        *,
-        success: bool,
-        warnings: list[str],
-        jobs: Sequence[NixEvalJobSuccess] | None = None,
+        self, event: ChangeEvent, build: BuildRecord, report: EvalReport
     ) -> None:
+        # Failed evals show the error tail; successful ones the warnings.
+        if not report.success and report.error:
+            text: str | None = _fence(report.error)
+        elif report.warnings:
+            text = _fence("\n".join(report.warnings))
+        else:
+            text = None
         await self._post(
             event,
             build,
             f"{self.context_prefix}/nix-eval",
-            StatusState.success if success else StatusState.failure,
-            eval_description(success, warnings),
-            text=_fence("\n".join(warnings)) if warnings else None,
+            StatusState.success if report.success else StatusState.failure,
+            eval_description(report.success, report.warnings),
+            text=text,
         )
-        if success:
+        if report.success:
             await self._post(
                 event,
                 build,
                 f"{self.context_prefix}/nix-build",
                 StatusState.pending,
                 "building attributes",
-                text=_build_plan([j.attr for j in jobs], self.build_url(event, build))
-                if jobs
+                text=_build_plan(
+                    [j.attr for j in report.jobs], self.build_url(event, build)
+                )
+                if report.jobs
                 else None,
             )
 

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -24,7 +24,7 @@ from nixbot.build_scheduler import (
 from nixbot.config import Config
 from nixbot.db import BuildStatus
 from nixbot.db_gen import builds as builds_q
-from nixbot.events import BuildResult, ChangeEvent, RepoInfo
+from nixbot.events import BuildResult, ChangeEvent, EvalReport, RepoInfo
 from nixbot.gitrepo import FetchCredentials, RepoManager
 from nixbot.memory import EvalWorkerConfig
 from nixbot.models import CacheStatus
@@ -127,15 +127,9 @@ class RecordingReporter:
         self.events.append(("started", build.id))
 
     async def eval_finished(
-        self,
-        event: ChangeEvent,
-        build: BuildRecord,
-        *,
-        success: bool,
-        warnings: list[str],
-        jobs: object = None,
+        self, event: ChangeEvent, build: BuildRecord, report: EvalReport
     ) -> None:
-        self.events.append(("eval", build.id, success, tuple(warnings)))
+        self.events.append(("eval", build.id, report.success, tuple(report.warnings)))
 
     async def eval_cancelled(self, event: ChangeEvent, build: BuildRecord) -> None:
         self.events.append(("eval-cancelled", build.id))

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -18,7 +18,7 @@ import pytest
 
 from nixbot.build_scheduler import AttributeResult, AttributeStatus
 from nixbot.db_gen.models import Build as BuildRecord
-from nixbot.events import BuildResult, ChangeEvent, RepoInfo
+from nixbot.events import BuildResult, ChangeEvent, EvalReport, RepoInfo
 from nixbot.forge import GitlabClient
 from nixbot.models import NixEvalJobError
 from nixbot.status import (
@@ -199,7 +199,7 @@ async def test_phase_statuses_and_target_url() -> None:
     reporter, poster, _ = make_reporter()
 
     await reporter.build_started(EVENT, BUILD)
-    await reporter.eval_finished(EVENT, BUILD, success=True, warnings=["w"])
+    await reporter.eval_finished(EVENT, BUILD, EvalReport(success=True, warnings=["w"]))
     await reporter.build_finished(EVENT, BUILD, BuildResult("succeeded", 1, []))
     contexts = [(p.context, p.state) for p in poster.posts]
     assert contexts == [
@@ -215,6 +215,24 @@ async def test_phase_statuses_and_target_url() -> None:
     assert "(1 warning)" in poster.posts[1].description
 
 
+async def test_eval_finished_failure_posts_error_tail() -> None:
+    """A failed eval carries the error tail as check-run text."""
+    reporter, poster, _ = make_reporter()
+
+    await reporter.eval_finished(
+        EVENT,
+        BUILD,
+        EvalReport(
+            success=False,
+            error="nix-eval-jobs failed with exit code 1:\nerror: syntax error",
+        ),
+    )
+    eval_post = next(p for p in poster.posts if p.context.endswith("nix-eval"))
+    assert eval_post.state == StatusState.failure
+    idx = poster.posts.index(eval_post)
+    assert "error: syntax error" in poster.extras[idx]["text"]
+
+
 async def test_eval_finished_build_plan_in_nix_build_body() -> None:
     """Pending nix-build run lists the attributes to build, each
     linking to its raw log."""
@@ -223,7 +241,7 @@ async def test_eval_finished_build_plan_in_nix_build_body() -> None:
         mk_job("checks.x86_64-linux.b"),
         mk_job("checks.x86_64-linux.a"),
     ]
-    await reporter.eval_finished(EVENT, BUILD, success=True, warnings=[], jobs=jobs)
+    await reporter.eval_finished(EVENT, BUILD, EvalReport(success=True, jobs=jobs))
 
     build_post = next(
         i for i, p in enumerate(poster.posts) if p.context.endswith("nix-build")
@@ -586,7 +604,9 @@ async def test_reporter_forwards_attr_and_text() -> None:
     run carries the warnings."""
     reporter, poster, _ = make_reporter()
 
-    await reporter.eval_finished(EVENT, BUILD, success=True, warnings=["w1", "w2"])
+    await reporter.eval_finished(
+        EVENT, BUILD, EvalReport(success=True, warnings=["w1", "w2"])
+    )
     eval_extra = poster.extras[0]
     assert eval_extra["text"] == "```\nw1\nw2\n```"
     assert eval_extra["project_id"] == PROJECT.id

--- a/nixbot/nixbot/tests/test_visibility.py
+++ b/nixbot/nixbot/tests/test_visibility.py
@@ -70,6 +70,7 @@ async def seed(dsn: str) -> None:
         for repo_id, name, private in [
             ("pub-1", "public", False),
             ("priv-1", "secret", True),
+            ("pending-1", "pending", True),
         ]:
             project_id = await insert_project(
                 pool, name, forge_repo_id=repo_id, private=private
@@ -80,6 +81,11 @@ async def seed(dsn: str) -> None:
                 "VALUES ($1, 'a.x', 'x86_64-linux', 'succeeded')",
                 build_id,
             )
+        # A discovered-but-disabled repo: only admins should see it, and
+        # without needing a search query.
+        await pool.execute(
+            "UPDATE projects SET enabled = FALSE WHERE forge_repo_id = 'pending-1'"
+        )
 
 
 FETCHER = FakeFetcher({"github:carol:tok-carol": frozenset({"github:priv-1"})})
@@ -143,6 +149,19 @@ def test_authorized_user_sees_private(harness: WebHarness) -> None:
 
 def test_admin_sees_everything(harness: WebHarness) -> None:
     assert harness.get("/repos/github/acme/secret", ROOT).status_code == 200
+
+
+def test_admin_sees_disabled_repos_without_search(harness: WebHarness) -> None:
+    home = harness.get("/", ROOT).text
+    assert "Disabled" in home
+    assert "acme/pending" in home
+
+
+def test_non_admin_does_not_see_disabled_repos(harness: WebHarness) -> None:
+    # Anonymous and unauthorized users have an empty toggleable set, so
+    # the disabled list stays hidden.
+    assert "acme/pending" not in harness.get("/").text
+    assert "acme/pending" not in harness.get("/", MALLORY, "tok-mallory").text
 
 
 def test_admin_api_token_sees_private(harness: WebHarness) -> None:

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -269,12 +269,14 @@ class _PageRoutes:
     async def index(self, request: Request, q: str = "") -> HTMLResponse:
         ctx = self.ctx
         visible = await ctx.visible_repo_ids(request)
-        # Discovery inserts repos disabled; admins enable them via
-        # search, which is the only place disabled projects appear.
+        # Discovery inserts repos disabled. Admins see the disabled repos
+        # they may toggle so a fresh instance is not a blank page; the
+        # search box filters the list. Non-admins have an empty
+        # toggleable set and see nothing here.
         toggleable = await ctx.toggleable_repo_ids(request)
         disabled = [
             p
-            for p in (await ctx.queries.projects(enabled=False, q=q) if q else [])
+            for p in await ctx.queries.projects(enabled=False, q=q)
             if toggleable is None or p["id"] in toggleable
         ]
         return await ctx.render(

--- a/nixbot/nixbot/web/templates/index.html
+++ b/nixbot/nixbot/web/templates/index.html
@@ -90,8 +90,8 @@
         {% else %}
           {% if q %}
             <p class="muted">no matching repositories</p>
-          {% elif toggleable is none or toggleable %}
-            <p class="muted">no repositories enabled yet — search above to find yours</p>
+          {% elif disabled_projects %}
+            <p class="muted">no repositories enabled yet — enable one from the list below</p>
           {% else %}
             <p class="muted">no repositories enabled yet</p>
           {% endif %}


### PR DESCRIPTION

A failed evaluation only posted "evaluation failed" to the forge check
run, forcing a click into the log to see why. Per-attribute build
failures already carry a log tail; eval failures did not.

Thread the error tail through to the nix-eval check-run text. Bundle the
eval_finished arguments into an EvalReport dataclass so the added error
field stays under the argument-count limit.
