### PR TITLE
logs: report eval failures and fix stale logs on restart

### DIFF
--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -14,7 +14,6 @@ import logging
 import shutil
 import time
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote
 
 from . import db
 from .build_scheduler import (
@@ -568,12 +567,8 @@ class _OrchestratorExecutor:
             attr_cancel.set()
 
         mirror = asyncio.create_task(_mirror_build_cancel())
-        # Attribute names come from untrusted flakes; percent-encode
-        # so the log file cannot escape the log directory.
         try:
-            async with self.o.open_log(
-                self.build_record.id, job.attr, f"{quote(job.attr, safe='')}.zst"
-            ) as writer:
+            async with self.o.open_log(self.build_record.id, job.attr) as writer:
                 outcome = await self.o.executor.build_attribute(
                     self.build_record.id,
                     job,
@@ -626,7 +621,6 @@ class _OrchestratorExecutor:
             self.o.pool,
             self.build_record.id,
             result,
-            log_path=str(writer.path.relative_to(self.o.config.state_dir)),
             log_size=writer.bytes_seen,
             log_truncated=writer.truncated,
         )

--- a/nixbot/nixbot/db.py
+++ b/nixbot/nixbot/db.py
@@ -146,7 +146,6 @@ async def complete_attribute(  # noqa: PLR0913
     build_id: int,
     result: AttributeResult,
     *,
-    log_path: str | None = None,
     log_size: int = 0,
     log_truncated: bool = False,
     if_unfinished: bool = False,
@@ -172,7 +171,6 @@ async def complete_attribute(  # noqa: PLR0913
             and isinstance(result.job, NixEvalJobSuccess)
             and result.job.cache_status == CacheStatus.cached
         ),
-        log_path=log_path,
         log_size=log_size,
         log_truncated=log_truncated,
         if_unfinished=if_unfinished,

--- a/nixbot/nixbot/db_gen/builds.py
+++ b/nixbot/nixbot/db_gen/builds.py
@@ -101,39 +101,30 @@ RETURNING status_generation
 """
 
 COMPLETE_ATTRIBUTE: typing.Final[str] = """-- name: CompleteAttribute :exec
-WITH attr AS (
-    INSERT INTO build_attributes
-        (build_id, attr, system, drv_path, outputs, status, error,
-         cached, finished_at)
-    VALUES ($1, $2, $3, $4, $11::jsonb, $5, $6, $7, now())
-    ON CONFLICT (build_id, attr) DO UPDATE SET
-        status = EXCLUDED.status,
-        -- Eval recorded the full outputs map (multi-output drvs);
-        -- merge the freshly-known "out" path into it instead of
-        -- replacing it, and never NULL an existing map when no out
-        -- path is known.
-        outputs = CASE
-            WHEN EXCLUDED.outputs IS NULL
-                THEN build_attributes.outputs
-            ELSE COALESCE(build_attributes.outputs, '{}'::jsonb)
-                || EXCLUDED.outputs
-        END,
-        error = EXCLUDED.error,
-        cached = EXCLUDED.cached,
-        finished_at = now()
-    WHERE NOT $12::boolean
-        OR build_attributes.status IN ('pending', 'building')
-    RETURNING build_attributes.id
-), dropped AS (
-    -- Reruns rewrite the same log file; replace the metadata row
-    -- instead of accumulating duplicates.
-    DELETE FROM logs WHERE attribute_id IN (SELECT attr.id FROM attr)
-      AND $8::text IS NOT NULL
-)
-INSERT INTO logs (attribute_id, path, size_bytes, truncated)
-SELECT attr.id, $8, $9::bigint,
-       $10::boolean
-FROM attr WHERE $8::text IS NOT NULL
+INSERT INTO build_attributes
+    (build_id, attr, system, drv_path, outputs, status, error,
+     cached, log_size, log_truncated, finished_at)
+VALUES ($1, $2, $3, $4, $8::jsonb, $5, $6, $7,
+        $9::bigint, $10::boolean, now())
+ON CONFLICT (build_id, attr) DO UPDATE SET
+    status = EXCLUDED.status,
+    -- Eval recorded the full outputs map (multi-output drvs);
+    -- merge the freshly-known "out" path into it instead of
+    -- replacing it, and never NULL an existing map when no out
+    -- path is known.
+    outputs = CASE
+        WHEN EXCLUDED.outputs IS NULL
+            THEN build_attributes.outputs
+        ELSE COALESCE(build_attributes.outputs, '{}'::jsonb)
+            || EXCLUDED.outputs
+    END,
+    error = EXCLUDED.error,
+    cached = EXCLUDED.cached,
+    log_size = EXCLUDED.log_size,
+    log_truncated = EXCLUDED.log_truncated,
+    finished_at = now()
+WHERE NOT $11::boolean
+    OR build_attributes.status IN ('pending', 'building')
 """
 
 CREATE_BUILD: typing.Final[str] = """-- name: CreateBuild :one
@@ -174,7 +165,7 @@ WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, p
 """
 
 EFFECTS_FOR_BUILD: typing.Final[str] = """-- name: EffectsForBuild :many
-SELECT id, build_id, name, status, error, log_path, log_size, log_truncated, started_at, finished_at FROM build_effects WHERE build_id = $1 ORDER BY name
+SELECT id, build_id, name, status, error, log_size, log_truncated, started_at, finished_at FROM build_effects WHERE build_id = $1 ORDER BY name
 """
 
 EVAL_JOB_ROWS: typing.Final[str] = """-- name: EvalJobRows :many
@@ -195,7 +186,7 @@ AND status <> 'cancelled' ORDER BY id DESC LIMIT 1
 
 FINISH_EFFECT: typing.Final[str] = """-- name: FinishEffect :exec
 UPDATE build_effects SET
-    status = $3, error = $6, log_path = $7,
+    status = $3, error = $6,
     log_size = $4, log_truncated = $5, finished_at = now()
 WHERE build_id = $1 AND name = $2
 """
@@ -296,7 +287,7 @@ WHERE build_id = $1 AND status IN ('pending', 'building')
 START_EFFECT: typing.Final[str] = """-- name: StartEffect :exec
 INSERT INTO build_effects (build_id, name, status) VALUES ($1, $2, $3)
 ON CONFLICT (build_id, name) DO UPDATE SET
-    status = $3, error = NULL, log_path = NULL, log_size = 0,
+    status = $3, error = NULL, log_size = 0,
     log_truncated = FALSE, started_at = now(), finished_at = NULL
 """
 
@@ -305,7 +296,7 @@ INSERT INTO build_effects (build_id, name, status)
 SELECT $1::bigint, u.name, 'pending'
 FROM unnest($2::text[]) AS u(name)
 ON CONFLICT (build_id, name) DO UPDATE SET
-    status = 'pending', error = NULL, log_path = NULL, log_size = 0,
+    status = 'pending', error = NULL, log_size = 0,
     log_truncated = FALSE, started_at = now(), finished_at = NULL
 """
 
@@ -385,8 +376,8 @@ async def bump_build_status(conn: ConnectionLike, *, id_: int, status: str) -> i
     return row[0]
 
 
-async def complete_attribute(conn: ConnectionLike, *, build_id: int, attr: str, system: str | None, drv_path: str | None, status: str, error: str | None, cached: bool, log_path: str | None, log_size: int, log_truncated: bool, outputs: str | None, if_unfinished: bool) -> None:
-    await conn.execute(COMPLETE_ATTRIBUTE, build_id, attr, system, drv_path, status, error, cached, log_path, log_size, log_truncated, outputs, if_unfinished)
+async def complete_attribute(conn: ConnectionLike, *, build_id: int, attr: str, system: str | None, drv_path: str | None, status: str, error: str | None, cached: bool, outputs: str | None, log_size: int, log_truncated: bool, if_unfinished: bool) -> None:
+    await conn.execute(COMPLETE_ATTRIBUTE, build_id, attr, system, drv_path, status, error, cached, outputs, log_size, log_truncated, if_unfinished)
 
 
 async def create_build(conn: ConnectionLike, *, project_id: int, tree_hash: str | None, commit_sha: str, branch: str, pr_number: int | None, pr_author: str | None) -> models.Build | None:
@@ -412,7 +403,7 @@ async def detach_build_from_pr(conn: ConnectionLike, *, id_: int, pr_number: int
 
 def effects_for_build(conn: ConnectionLike, *, build_id: int) -> QueryResults[models.BuildEffect]:
     def _decode_hook(row: asyncpg.Record) -> models.BuildEffect:
-        return models.BuildEffect(id=row[0], build_id=row[1], name=row[2], status=row[3], error=row[4], log_path=row[5], log_size=row[6], log_truncated=row[7], started_at=row[8], finished_at=row[9])
+        return models.BuildEffect(id=row[0], build_id=row[1], name=row[2], status=row[3], error=row[4], log_size=row[5], log_truncated=row[6], started_at=row[7], finished_at=row[8])
     return QueryResults[models.BuildEffect](conn, EFFECTS_FOR_BUILD, _decode_hook, build_id)
 
 
@@ -436,8 +427,8 @@ async def find_reusable_build(conn: ConnectionLike, *, project_id: int, tree_has
     return models.Build(id=row[0], project_id=row[1], number=row[2], tree_hash=row[3], commit_sha=row[4], branch=row[5], pr_number=row[6], pr_author=row[7], status=row[8], status_generation=row[9], effects_started=row[10], error=row[11], created_at=row[12], started_at=row[13], finished_at=row[14], eval_warnings=row[15], eval_completed=row[16], effects_commit_sha=row[17], effects_branch=row[18], effects_pr_number=row[19])
 
 
-async def finish_effect(conn: ConnectionLike, *, build_id: int, name: str, status: str, log_size: int, log_truncated: bool, error: str | None, log_path: str | None) -> None:
-    await conn.execute(FINISH_EFFECT, build_id, name, status, log_size, log_truncated, error, log_path)
+async def finish_effect(conn: ConnectionLike, *, build_id: int, name: str, status: str, log_size: int, log_truncated: bool, error: str | None) -> None:
+    await conn.execute(FINISH_EFFECT, build_id, name, status, log_size, log_truncated, error)
 
 
 async def get_build(conn: ConnectionLike, *, id_: int) -> models.Build | None:

--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -193,13 +193,13 @@ WITH cleared_failures AS (
            AND ($1::text IS NULL OR attr = $1))
 ), reset_attrs AS (
     UPDATE build_attributes SET status = 'pending', error = NULL,
-        started_at = NULL, finished_at = NULL
+        started_at = NULL, finished_at = NULL, log_size = 0,
+        log_truncated = FALSE
     WHERE build_id = $2::bigint
       AND ($1::text IS NULL OR attr = $1)
 ), reset_effect_rows AS (
     UPDATE build_effects SET status = 'pending', error = NULL,
-        finished_at = NULL, log_path = NULL, log_size = 0,
-        log_truncated = FALSE
+        finished_at = NULL, log_size = 0, log_truncated = FALSE
     WHERE build_id = $2::bigint
       AND $1::text IS NULL
 )
@@ -215,7 +215,7 @@ WITH flag AS (
     UPDATE builds SET effects_started = FALSE WHERE id = $1
 )
 UPDATE build_effects SET status = 'pending', error = NULL,
-    finished_at = NULL, log_path = NULL, log_size = 0,
+    finished_at = NULL, log_size = 0,
     log_truncated = FALSE WHERE build_id = $1
 """
 

--- a/nixbot/nixbot/db_gen/models.py
+++ b/nixbot/nixbot/db_gen/models.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 __all__: collections.abc.Sequence[str] = (
     "Build",
+    "BuildAttribute",
     "BuildEffect",
     "Project",
     "ScheduledEffect",
@@ -44,13 +45,29 @@ class Build:
 
 
 @dataclasses.dataclass()
+class BuildAttribute:
+    id: int
+    build_id: int
+    attr: str
+    system: str | None
+    drv_path: str | None
+    outputs: str | None
+    status: str
+    cached: bool
+    error: str | None
+    started_at: datetime.datetime | None
+    finished_at: datetime.datetime | None
+    log_size: int
+    log_truncated: bool
+
+
+@dataclasses.dataclass()
 class BuildEffect:
     id: int
     build_id: int
     name: str
     status: str
     error: str | None
-    log_path: str | None
     log_size: int
     log_truncated: bool
     started_at: datetime.datetime

--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -13,15 +13,11 @@ __all__: collections.abc.Sequence[str] = (
     "WebAttributeCountsRow",
     "WebAttributeHistoryRow",
     "WebAttributeNeighborNumbersRow",
-    "WebAttributePageRow",
-    "WebAttributesRow",
     "WebNeighborNumbersRow",
     "WebQueueRow",
     "WebRecentBuildsRow",
     "WebRepoOverviewRow",
-    "attribute_log_path",
     "attribute_status",
-    "effect_log_path",
     "metrics_attribute_counts",
     "metrics_build_counts",
     "metrics_build_duration",
@@ -104,6 +100,8 @@ class WebAttributeHistoryRow:
     error: str | None
     started_at: datetime.datetime | None
     finished_at: datetime.datetime | None
+    log_size: int
+    log_truncated: bool
     build_number: int
     branch: str
     commit_sha: str
@@ -114,40 +112,6 @@ class WebAttributeHistoryRow:
 class WebAttributeNeighborNumbersRow:
     prev: int
     next: int
-
-
-@dataclasses.dataclass()
-class WebAttributePageRow:
-    id: int
-    build_id: int
-    attr: str
-    system: str | None
-    drv_path: str | None
-    outputs: str | None
-    status: str
-    cached: bool
-    error: str | None
-    started_at: datetime.datetime | None
-    finished_at: datetime.datetime | None
-    log_path: str | None
-    log_size: int | None
-
-
-@dataclasses.dataclass()
-class WebAttributesRow:
-    id: int
-    build_id: int
-    attr: str
-    system: str | None
-    drv_path: str | None
-    outputs: str | None
-    status: str
-    cached: bool
-    error: str | None
-    started_at: datetime.datetime | None
-    finished_at: datetime.datetime | None
-    log_path: str | None
-    log_size: int | None
 
 
 @dataclasses.dataclass()
@@ -239,19 +203,8 @@ class WebRepoOverviewRow:
     pass_rate: int
 
 
-ATTRIBUTE_LOG_PATH: typing.Final[str] = """-- name: AttributeLogPath :one
-SELECT l.path FROM logs l
-JOIN build_attributes a ON a.id = l.attribute_id
-WHERE a.build_id = $1 AND a.attr = $2
-"""
-
 ATTRIBUTE_STATUS: typing.Final[str] = """-- name: AttributeStatus :one
 SELECT status FROM build_attributes WHERE build_id = $1 AND attr = $2
-"""
-
-EFFECT_LOG_PATH: typing.Final[str] = """-- name: EffectLogPath :one
-SELECT log_path AS path FROM build_effects
-WHERE build_id = $1 AND name = $2 AND log_path IS NOT NULL
 """
 
 METRICS_ATTRIBUTE_COUNTS: typing.Final[str] = """-- name: MetricsAttributeCounts :many
@@ -287,7 +240,7 @@ GROUP BY status
 """
 
 WEB_ATTRIBUTE_HISTORY: typing.Final[str] = """-- name: WebAttributeHistory :many
-SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, b.number AS build_number, b.branch, b.commit_sha,
+SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated, b.number AS build_number, b.branch, b.commit_sha,
        b.created_at AS build_created_at
 FROM build_attributes a
 JOIN builds b ON b.id = a.build_id
@@ -304,18 +257,14 @@ WHERE b.project_id = $1 AND a.attr = $2
 """
 
 WEB_ATTRIBUTE_PAGE: typing.Final[str] = """-- name: WebAttributePage :many
-SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, l.path AS log_path, l.size_bytes AS log_size
-FROM build_attributes a
-LEFT JOIN logs l ON l.attribute_id = a.id
+SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated FROM build_attributes a
 WHERE a.build_id = $1 AND a.status = ANY($2::text[])
   AND ($3::text IS NULL OR a.attr ILIKE $3)
 ORDER BY a.attr LIMIT $5::bigint OFFSET $4::bigint
 """
 
 WEB_ATTRIBUTES: typing.Final[str] = """-- name: WebAttributes :many
-SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, l.path AS log_path, l.size_bytes AS log_size
-FROM build_attributes a
-LEFT JOIN logs l ON l.attribute_id = a.id
+SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated FROM build_attributes a
 WHERE a.build_id = $1
 ORDER BY CASE
     WHEN a.status IN ('failed', 'failed_eval', 'dependency_failed',
@@ -344,7 +293,7 @@ ORDER BY number DESC LIMIT $8 OFFSET $7
 """
 
 WEB_EFFECTS: typing.Final[str] = """-- name: WebEffects :many
-SELECT id, build_id, name, status, error, log_path, log_size, log_truncated, started_at, finished_at FROM build_effects WHERE build_id = $1 ORDER BY name
+SELECT id, build_id, name, status, error, log_size, log_truncated, started_at, finished_at FROM build_effects WHERE build_id = $1 ORDER BY name
 """
 
 WEB_NEIGHBOR_NUMBERS: typing.Final[str] = """-- name: WebNeighborNumbers :one
@@ -489,22 +438,8 @@ class QueryResults(typing.Generic[T]):
         return self._decode_hook(record)
 
 
-async def attribute_log_path(conn: ConnectionLike, *, build_id: int, attr: str) -> str | None:
-    row = await conn.fetchrow(ATTRIBUTE_LOG_PATH, build_id, attr)
-    if row is None:
-        return None
-    return row[0]
-
-
 async def attribute_status(conn: ConnectionLike, *, build_id: int, attr: str) -> str | None:
     row = await conn.fetchrow(ATTRIBUTE_STATUS, build_id, attr)
-    if row is None:
-        return None
-    return row[0]
-
-
-async def effect_log_path(conn: ConnectionLike, *, build_id: int, name: str) -> str | None:
-    row = await conn.fetchrow(EFFECT_LOG_PATH, build_id, name)
     if row is None:
         return None
     return row[0]
@@ -551,7 +486,7 @@ def web_attribute_counts(conn: ConnectionLike, *, build_id: int, pattern: str | 
 
 def web_attribute_history(conn: ConnectionLike, *, project_id: int, attr: str, limit_: int) -> QueryResults[WebAttributeHistoryRow]:
     def _decode_hook(row: asyncpg.Record) -> WebAttributeHistoryRow:
-        return WebAttributeHistoryRow(id=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], build_number=row[11], branch=row[12], commit_sha=row[13], build_created_at=row[14])
+        return WebAttributeHistoryRow(id=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], log_size=row[11], log_truncated=row[12], build_number=row[13], branch=row[14], commit_sha=row[15], build_created_at=row[16])
     return QueryResults[WebAttributeHistoryRow](conn, WEB_ATTRIBUTE_HISTORY, _decode_hook, project_id, attr, limit_)
 
 
@@ -562,16 +497,16 @@ async def web_attribute_neighbor_numbers(conn: ConnectionLike, *, project_id: in
     return WebAttributeNeighborNumbersRow(prev=row[0], next=row[1])
 
 
-def web_attribute_page(conn: ConnectionLike, *, build_id: int, statuses: collections.abc.Sequence[str], pattern: str | None, offset_: int, limit_: int) -> QueryResults[WebAttributePageRow]:
-    def _decode_hook(row: asyncpg.Record) -> WebAttributePageRow:
-        return WebAttributePageRow(id=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], log_path=row[11], log_size=row[12])
-    return QueryResults[WebAttributePageRow](conn, WEB_ATTRIBUTE_PAGE, _decode_hook, build_id, statuses, pattern, offset_, limit_)
+def web_attribute_page(conn: ConnectionLike, *, build_id: int, statuses: collections.abc.Sequence[str], pattern: str | None, offset_: int, limit_: int) -> QueryResults[models.BuildAttribute]:
+    def _decode_hook(row: asyncpg.Record) -> models.BuildAttribute:
+        return models.BuildAttribute(id=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], log_size=row[11], log_truncated=row[12])
+    return QueryResults[models.BuildAttribute](conn, WEB_ATTRIBUTE_PAGE, _decode_hook, build_id, statuses, pattern, offset_, limit_)
 
 
-def web_attributes(conn: ConnectionLike, *, build_id: int) -> QueryResults[WebAttributesRow]:
-    def _decode_hook(row: asyncpg.Record) -> WebAttributesRow:
-        return WebAttributesRow(id=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], log_path=row[11], log_size=row[12])
-    return QueryResults[WebAttributesRow](conn, WEB_ATTRIBUTES, _decode_hook, build_id)
+def web_attributes(conn: ConnectionLike, *, build_id: int) -> QueryResults[models.BuildAttribute]:
+    def _decode_hook(row: asyncpg.Record) -> models.BuildAttribute:
+        return models.BuildAttribute(id=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], log_size=row[11], log_truncated=row[12])
+    return QueryResults[models.BuildAttribute](conn, WEB_ATTRIBUTES, _decode_hook, build_id)
 
 
 async def web_build_by_number(conn: ConnectionLike, *, project_id: int, number: int) -> models.Build | None:
@@ -589,7 +524,7 @@ def web_builds_for_repo(conn: ConnectionLike, *, project_id: int, status: str | 
 
 def web_effects(conn: ConnectionLike, *, build_id: int) -> QueryResults[models.BuildEffect]:
     def _decode_hook(row: asyncpg.Record) -> models.BuildEffect:
-        return models.BuildEffect(id=row[0], build_id=row[1], name=row[2], status=row[3], error=row[4], log_path=row[5], log_size=row[6], log_truncated=row[7], started_at=row[8], finished_at=row[9])
+        return models.BuildEffect(id=row[0], build_id=row[1], name=row[2], status=row[3], error=row[4], log_size=row[5], log_truncated=row[6], started_at=row[7], finished_at=row[8])
     return QueryResults[models.BuildEffect](conn, WEB_EFFECTS, _decode_hook, build_id)
 
 

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import logging
 from dataclasses import replace
 from typing import TYPE_CHECKING
-from urllib.parse import quote
 
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
@@ -208,13 +207,7 @@ async def _run_one_effect(
     # A green commit status on a failed deploy hides the failure; report
     # per-effect status so the forge reflects the real outcome.
     await o.reporter.effect_started(event, build, name)
-    # Effect names come from untrusted flakes; percent-encode so
-    # the log file cannot escape the log directory. The "effects/"
-    # subdirectory keeps them apart from attribute logs (a flat
-    # prefix would collide with an attribute named "effect-X").
-    async with o.open_log(
-        build.id, f"effect:{name}", f"effects/{quote(name, safe='')}.zst"
-    ) as writer:
+    async with o.open_log(build.id, f"effect:{name}") as writer:
         try:
             success = await run_effect(ctx, name, writer.write)
         except Exception as e:
@@ -237,7 +230,6 @@ async def _run_one_effect(
         name=name,
         status="succeeded" if success else "failed",
         error=error,
-        log_path=str(writer.path.relative_to(o.config.state_dir)),
         log_size=writer.bytes_seen,
         log_truncated=writer.truncated,
     )

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -31,6 +31,7 @@ import re
 from collections import OrderedDict, deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
 import zstandard
 
@@ -59,6 +60,34 @@ RECENT_BUFFER_SIZE = 4096
 # Batch log output into zstd frames of at least this size; one frame
 # per output line would make "compressed" logs larger than plaintext.
 FRAME_FLUSH_THRESHOLD = 64 * 1024
+
+
+# Log path is derived from (build_id, name), not stored. Names come from
+# untrusted flakes: percent-encode so a log cannot escape its build
+# directory, and keep effects in a subdirectory so an attribute named
+# "effect-X" cannot collide with an effect log.
+
+
+def build_log_dir(state_dir: Path, build_id: int) -> Path:
+    return state_dir / "logs" / str(build_id)
+
+
+def attribute_log_path(state_dir: Path, build_id: int, attr: str) -> Path:
+    return build_log_dir(state_dir, build_id) / f"{quote(attr, safe='')}.zst"
+
+
+def effect_log_path(state_dir: Path, build_id: int, name: str) -> Path:
+    return (
+        build_log_dir(state_dir, build_id) / "effects" / f"{quote(name, safe='')}.zst"
+    )
+
+
+def log_path_for_key(state_dir: Path, build_id: int, key: str) -> Path:
+    """Path for a log-registry key: "effect:<name>" for effects, the
+    attribute name otherwise."""
+    if key.startswith("effect:"):
+        return effect_log_path(state_dir, build_id, key.removeprefix("effect:"))
+    return attribute_log_path(state_dir, build_id, key)
 
 
 async def iter_lines(

--- a/nixbot/nixbot/migrations/0020_log_metadata.sql
+++ b/nixbot/nixbot/migrations/0020_log_metadata.sql
@@ -1,0 +1,18 @@
+-- Log storage refactor: a log's path is fully determined by
+-- (build_id, attr/effect name), so storing it invited drift between the
+-- DB row and the file on disk (stale logs after a restart, orphaned
+-- files). Keep only the display metadata (size/truncated), inline on
+-- the owning row like build_effects already does, and compute the path
+-- from the name everywhere else.
+
+ALTER TABLE build_attributes
+    ADD COLUMN log_size BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN log_truncated BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE build_attributes a
+SET log_size = l.size_bytes, log_truncated = l.truncated
+FROM logs l WHERE l.attribute_id = a.id;
+
+DROP TABLE logs;
+
+ALTER TABLE build_effects DROP COLUMN log_path;

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import shutil
 import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -43,7 +44,12 @@ from .events import (
     RepoInfo,
     StatusReporter,
 )
-from .executor import LogWriter
+from .executor import (
+    LogWriter,
+    attribute_log_path,
+    build_log_dir,
+    log_path_for_key,
+)
 from .gitrepo import MergeConflictError, pr_refspec
 from .web.logs import LogRegistry
 from .work_queue import WorkQueue
@@ -134,7 +140,23 @@ class Orchestrator:
     linked_events: dict[int, list[ChangeEvent]] = field(default_factory=dict)
 
     def _log_dir(self, build_id: int) -> Path:
-        return self.config.state_dir / "logs" / str(build_id)
+        return build_log_dir(self.config.state_dir, build_id)
+
+    def reset_build_logs(self, build_id: int, attr: str | None) -> None:
+        """Drop the previous run's log files when a build is reset to
+        pending. A full restart (attr None) also re-runs effects, so it
+        clears the whole build log directory; a single-attribute restart
+        removes only that attribute's log."""
+        if attr is None:
+            shutil.rmtree(self._log_dir(build_id), ignore_errors=True)
+        else:
+            attribute_log_path(self.config.state_dir, build_id, attr).unlink(
+                missing_ok=True
+            )
+
+    def reset_effect_logs(self, build_id: int) -> None:
+        """Drop all effect log files when a build's effects are reset."""
+        shutil.rmtree(self._log_dir(build_id) / "effects", ignore_errors=True)
 
     def gcroots_dir(self, build: BuildRecord) -> Path:
         return self.config.state_dir / "eval-gcroots" / str(build.id)
@@ -373,13 +395,11 @@ class Orchestrator:
         await effects_run.run_effect_item(self, info, build, name, credentials)
 
     @asynccontextmanager
-    async def open_log(
-        self, build_id: int, key: str, filename: str
-    ) -> AsyncIterator[LogWriter]:
+    async def open_log(self, build_id: int, key: str) -> AsyncIterator[LogWriter]:
         """LogWriter registered for live streaming; closed and
         unregistered on exit. Shared by attribute and effect runs."""
-        log_path = self._log_dir(build_id) / filename
-        writer = LogWriter(path=log_path, size_limit=self.config.log_size_limit)
+        path = log_path_for_key(self.config.state_dir, build_id, key)
+        writer = LogWriter(path=path, size_limit=self.config.log_size_limit)
         self.log_registry.register(build_id, key, writer)
         try:
             yield writer

--- a/nixbot/nixbot/queries/builds.sql
+++ b/nixbot/nixbot/queries/builds.sql
@@ -151,46 +151,36 @@ RETURNING attr;
 -- name: CompleteAttribute :exec
 -- Status, outputs, error and log metadata in one atomic statement
 -- (crash-recovery invariant). With if_unfinished, already-terminal
--- rows are left untouched (the upsert returns no row, so the log
--- CTEs become no-ops as well).
-WITH attr AS (
-    INSERT INTO build_attributes
-        (build_id, attr, system, drv_path, outputs, status, error,
-         cached, finished_at)
-    VALUES ($1, $2, $3, $4, sqlc.narg(outputs)::jsonb, $5, $6, $7, now())
-    ON CONFLICT (build_id, attr) DO UPDATE SET
-        status = EXCLUDED.status,
-        -- Eval recorded the full outputs map (multi-output drvs);
-        -- merge the freshly-known "out" path into it instead of
-        -- replacing it, and never NULL an existing map when no out
-        -- path is known.
-        outputs = CASE
-            WHEN EXCLUDED.outputs IS NULL
-                THEN build_attributes.outputs
-            ELSE COALESCE(build_attributes.outputs, '{}'::jsonb)
-                || EXCLUDED.outputs
-        END,
-        error = EXCLUDED.error,
-        cached = EXCLUDED.cached,
-        finished_at = now()
-    WHERE NOT sqlc.arg(if_unfinished)::boolean
-        OR build_attributes.status IN ('pending', 'building')
-    RETURNING build_attributes.id
-), dropped AS (
-    -- Reruns rewrite the same log file; replace the metadata row
-    -- instead of accumulating duplicates.
-    DELETE FROM logs WHERE attribute_id IN (SELECT attr.id FROM attr)
-      AND sqlc.narg(log_path)::text IS NOT NULL
-)
-INSERT INTO logs (attribute_id, path, size_bytes, truncated)
-SELECT attr.id, sqlc.narg(log_path), sqlc.arg(log_size)::bigint,
-       sqlc.arg(log_truncated)::boolean
-FROM attr WHERE sqlc.narg(log_path)::text IS NOT NULL;
+-- rows are left untouched (the upsert returns no row).
+INSERT INTO build_attributes
+    (build_id, attr, system, drv_path, outputs, status, error,
+     cached, log_size, log_truncated, finished_at)
+VALUES ($1, $2, $3, $4, sqlc.narg(outputs)::jsonb, $5, $6, $7,
+        sqlc.arg(log_size)::bigint, sqlc.arg(log_truncated)::boolean, now())
+ON CONFLICT (build_id, attr) DO UPDATE SET
+    status = EXCLUDED.status,
+    -- Eval recorded the full outputs map (multi-output drvs);
+    -- merge the freshly-known "out" path into it instead of
+    -- replacing it, and never NULL an existing map when no out
+    -- path is known.
+    outputs = CASE
+        WHEN EXCLUDED.outputs IS NULL
+            THEN build_attributes.outputs
+        ELSE COALESCE(build_attributes.outputs, '{}'::jsonb)
+            || EXCLUDED.outputs
+    END,
+    error = EXCLUDED.error,
+    cached = EXCLUDED.cached,
+    log_size = EXCLUDED.log_size,
+    log_truncated = EXCLUDED.log_truncated,
+    finished_at = now()
+WHERE NOT sqlc.arg(if_unfinished)::boolean
+    OR build_attributes.status IN ('pending', 'building');
 
 -- name: StartEffect :exec
 INSERT INTO build_effects (build_id, name, status) VALUES ($1, $2, $3)
 ON CONFLICT (build_id, name) DO UPDATE SET
-    status = $3, error = NULL, log_path = NULL, log_size = 0,
+    status = $3, error = NULL, log_size = 0,
     log_truncated = FALSE, started_at = now(), finished_at = NULL;
 
 -- name: StartPendingEffects :exec
@@ -199,12 +189,12 @@ INSERT INTO build_effects (build_id, name, status)
 SELECT sqlc.arg(build_id)::bigint, u.name, 'pending'
 FROM unnest(sqlc.arg(names)::text[]) AS u(name)
 ON CONFLICT (build_id, name) DO UPDATE SET
-    status = 'pending', error = NULL, log_path = NULL, log_size = 0,
+    status = 'pending', error = NULL, log_size = 0,
     log_truncated = FALSE, started_at = now(), finished_at = NULL;
 
 -- name: FinishEffect :exec
 UPDATE build_effects SET
-    status = $3, error = sqlc.narg(error), log_path = sqlc.narg(log_path),
+    status = $3, error = sqlc.narg(error),
     log_size = $4, log_truncated = $5, finished_at = now()
 WHERE build_id = $1 AND name = $2;
 

--- a/nixbot/nixbot/queries/maintenance.sql
+++ b/nixbot/nixbot/queries/maintenance.sql
@@ -26,13 +26,13 @@ WITH cleared_failures AS (
            AND (sqlc.narg(attr)::text IS NULL OR attr = sqlc.narg(attr)))
 ), reset_attrs AS (
     UPDATE build_attributes SET status = 'pending', error = NULL,
-        started_at = NULL, finished_at = NULL
+        started_at = NULL, finished_at = NULL, log_size = 0,
+        log_truncated = FALSE
     WHERE build_id = sqlc.arg(build_id)::bigint
       AND (sqlc.narg(attr)::text IS NULL OR attr = sqlc.narg(attr))
 ), reset_effect_rows AS (
     UPDATE build_effects SET status = 'pending', error = NULL,
-        finished_at = NULL, log_path = NULL, log_size = 0,
-        log_truncated = FALSE
+        finished_at = NULL, log_size = 0, log_truncated = FALSE
     WHERE build_id = sqlc.arg(build_id)::bigint
       AND sqlc.narg(attr)::text IS NULL
 )
@@ -50,7 +50,7 @@ WITH flag AS (
     UPDATE builds SET effects_started = FALSE WHERE id = sqlc.arg(build_id)
 )
 UPDATE build_effects SET status = 'pending', error = NULL,
-    finished_at = NULL, log_path = NULL, log_size = 0,
+    finished_at = NULL, log_size = 0,
     log_truncated = FALSE WHERE build_id = sqlc.arg(build_id);
 
 -- name: CountUnfinishedAttributes :one

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -94,9 +94,7 @@ SELECT (max(number) FILTER (WHERE number < sqlc.arg(number)))::bigint AS prev,
 FROM builds WHERE project_id = $1;
 
 -- name: WebAttributes :many
-SELECT a.*, l.path AS log_path, l.size_bytes AS log_size
-FROM build_attributes a
-LEFT JOIN logs l ON l.attribute_id = a.id
+SELECT a.* FROM build_attributes a
 WHERE a.build_id = $1
 -- Display order: failures first, then running, then the rest.
 ORDER BY CASE
@@ -117,9 +115,7 @@ WHERE build_id = $1 AND (sqlc.narg(pattern)::text IS NULL OR attr ILIKE sqlc.nar
 GROUP BY status;
 
 -- name: WebAttributePage :many
-SELECT a.*, l.path AS log_path, l.size_bytes AS log_size
-FROM build_attributes a
-LEFT JOIN logs l ON l.attribute_id = a.id
+SELECT a.* FROM build_attributes a
 WHERE a.build_id = $1 AND a.status = ANY(sqlc.arg(statuses)::text[])
   AND (sqlc.narg(pattern)::text IS NULL OR a.attr ILIKE sqlc.narg(pattern))
 ORDER BY a.attr LIMIT sqlc.arg(limit_)::bigint OFFSET sqlc.arg(offset_)::bigint;
@@ -155,15 +151,6 @@ WHERE b.status IN ('pending', 'evaluating', 'building')
   AND (sqlc.narg(project_ids)::bigint[] IS NULL OR p.id = ANY(sqlc.narg(project_ids)))
 -- Active builds first; queue_position stays FIFO.
 ORDER BY b.status = 'pending', b.id;
-
--- name: EffectLogPath :one
-SELECT log_path AS path FROM build_effects
-WHERE build_id = $1 AND name = $2 AND log_path IS NOT NULL;
-
--- name: AttributeLogPath :one
-SELECT l.path FROM logs l
-JOIN build_attributes a ON a.id = l.attribute_id
-WHERE a.build_id = $1 AND a.attr = $2;
 
 -- name: AttributeStatus :one
 SELECT status FROM build_attributes WHERE build_id = $1 AND attr = $2;

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -152,8 +152,11 @@ async def rerun_effects(
     o.cancel_events[build.id] = asyncio.Event()
     try:
         # Reset under the claim: resetting earlier (e.g. in the
-        # service) could clobber a rerun already in flight.
+        # service) could clobber a rerun already in flight. Drop the
+        # previous run's logs here too, so pending rows show no stale
+        # output.
         await q.reset_effects_state(o.pool, build_id=build.id)
+        o.reset_effect_logs(build.id)
         async with rerun_worktree(o, info, build, "effects", credentials) as (
             event,
             worktree_path,

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -331,8 +331,11 @@ class CIService:
 
     async def _restart(self, build_id: int, *, attr: str | None) -> None:
         # Reset synchronously so the build row is the source of truth
-        # for the UI/recovery; the queue item is only a wake-up.
+        # for the UI/recovery; the queue item is only a wake-up. Drop
+        # the previous run's logs here too, so the pending row does not
+        # show stale output until the rebuild starts.
         await q.reset_build_for_restart(self.pool, build_id=build_id, attr=attr)
+        self.orchestrator.reset_build_logs(build_id, attr)
         await self.enqueue_work("rerun", f"build-{build_id}", {"build_id": build_id})
 
     async def restart_effects(self, build_id: int) -> None:
@@ -513,7 +516,6 @@ class CIService:
                 name=name,
                 status="failed",
                 error=str(e) or type(e).__name__,
-                log_path=None,
                 log_size=0,
                 log_truncated=False,
             )

--- a/nixbot/nixbot/tests/e2e/support.py
+++ b/nixbot/nixbot/tests/e2e/support.py
@@ -16,6 +16,7 @@ import asyncpg
 import uvicorn
 import zstandard
 
+from nixbot.executor import attribute_log_path
 from nixbot.tests.support import insert_build, insert_project
 from nixbot.web.app import create_app
 from nixbot.web.logs import LogRegistry
@@ -65,22 +66,16 @@ async def seed(dsn: str, state_dir: Path | None = None) -> None:
             )
             # Finished builds get a log for the prev/next navigation.
             if state_dir is not None and status != "building":
-                attr_id = await pool.fetchval(
-                    "SELECT id FROM build_attributes"
-                    " WHERE build_id = $1 AND attr = 'x86_64-linux.bad'",
-                    build_id,
-                )
-                rel_path = f"logs/{number}/x86_64-linux.bad.zst"
-                log_file = state_dir / rel_path
+                log_file = attribute_log_path(state_dir, build_id, "x86_64-linux.bad")
                 log_file.parent.mkdir(parents=True, exist_ok=True)
                 log_file.write_bytes(
                     zstandard.ZstdCompressor().compress(f"log #{number}\n".encode())
                 )
                 await pool.execute(
-                    "INSERT INTO logs (attribute_id, path, size_bytes)"
-                    " VALUES ($1, $2, $3)",
-                    attr_id,
-                    rel_path,
+                    "UPDATE build_attributes SET log_size = $3"
+                    " WHERE build_id = $1 AND attr = $2",
+                    build_id,
+                    "x86_64-linux.bad",
                     log_file.stat().st_size,
                 )
     finally:

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -19,6 +19,7 @@ from nixbot.bootstrap import build_service
 from nixbot.config import Config
 from nixbot.db_gen import builds as builds_q
 from nixbot.events import BuildResult, ChangeEvent, NullStatusReporter
+from nixbot.executor import attribute_log_path
 from nixbot.forge_tokens import ForgeTokenStore
 from nixbot.service import (
     MAX_REPORT_ATTEMPTS,
@@ -574,6 +575,44 @@ async def test_build_service_composition(postgres_dsn: str, tmp_path: Path) -> N
         await service.pool.close()
 
 
+async def test_restart_removes_stale_logs(postgres_dsn: str, tmp_path: Path) -> None:
+    """A restart drops the previous run's log metadata and on-disk file
+    at reset time, so the pending row does not show stale output."""
+    config = Config(
+        db_url=postgres_dsn,
+        build_systems=["x86_64-linux"],
+        url="http://ci.test",
+        state_dir=tmp_path / "state",
+    )
+    service, _app = await build_service(config)
+    pool = service.pool
+    try:
+        project_id = await insert_project(pool, forge_repo_id="78", url="http://x")
+        build_id = await insert_build(
+            pool, project_id, commit_sha="c1", tree_hash="t1", status="failed"
+        )
+        await pool.execute(
+            "INSERT INTO build_attributes (build_id, attr, status, log_size) "
+            "VALUES ($1, 'x86_64-linux.a', 'failed', 9)",
+            build_id,
+        )
+        log_file = attribute_log_path(config.state_dir, build_id, "x86_64-linux.a")
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        log_file.write_bytes(b"stale log")
+
+        await service.restart_build(build_id)
+
+        assert (
+            await pool.fetchval(
+                "SELECT log_size FROM build_attributes WHERE build_id = $1", build_id
+            )
+            == 0
+        )
+        assert not log_file.exists()
+    finally:
+        await pool.close()
+
+
 async def test_restart_clears_failed_cache_immediately(
     postgres_dsn: str, tmp_path: Path
 ) -> None:
@@ -892,7 +931,7 @@ async def test_restart_resets_effects(postgres_dsn: str, tmp_path: Path) -> None
         )
         await pool.execute(
             "INSERT INTO build_effects (build_id, name, status, finished_at, "
-            "log_path) VALUES ($1, 'deploy', 'failed', now(), 'old.zst')",
+            "log_size) VALUES ($1, 'deploy', 'failed', now(), 42)",
             build_id,
         )
 
@@ -904,13 +943,13 @@ async def test_restart_resets_effects(postgres_dsn: str, tmp_path: Path) -> None
         # Stale log cleared by the reset; the failed rerun
         # (unfetchable URL) settled the row.
         row = await pool.fetchrow(
-            "SELECT status, error, log_path FROM build_effects WHERE build_id = $1",
+            "SELECT status, error, log_size FROM build_effects WHERE build_id = $1",
             build_id,
         )
         assert dict(row) == {
             "status": "failed",
             "error": "build did not succeed",
-            "log_path": None,
+            "log_size": 0,
         }
 
         # Single-attribute restart keeps the guard: a partial

--- a/nixbot/nixbot/tests/test_db.py
+++ b/nixbot/nixbot/tests/test_db.py
@@ -120,25 +120,19 @@ async def test_schema_constraints(postgres_dsn: str) -> None:
                 """,
             project_id,
         )
-        attr_id = await conn.fetchval(
+        await conn.execute(
             """
                 INSERT INTO build_attributes (build_id, attr, system, drv_path)
                 VALUES ($1, 'checks.x86_64-linux.foo', 'x86_64-linux',
                         '/nix/store/foo.drv')
-                RETURNING id
                 """,
             build_id,
-        )
-        await conn.execute(
-            "INSERT INTO logs (attribute_id, path, size_bytes) "
-            "VALUES ($1, 'a/b.zst', 42)",
-            attr_id,
         )
 
         # Cascade delete: removing the project removes everything.
         await conn.execute("DELETE FROM projects WHERE id = $1", project_id)
         assert await conn.fetchval("SELECT count(*) FROM builds") == 0
-        assert await conn.fetchval("SELECT count(*) FROM logs") == 0
+        assert await conn.fetchval("SELECT count(*) FROM build_attributes") == 0
     finally:
         await conn.close()
 
@@ -447,9 +441,9 @@ async def test_complete_attribute_marks_substituted_as_cached(
     assert await cached("built") is False
 
 
-async def test_complete_attribute_replaces_log_row(pool: asyncpg.Pool) -> None:
-    # Attribute restarts rewrite the same log file; the metadata row
-    # must be replaced, not duplicated with stale sizes.
+async def test_complete_attribute_replaces_log_metadata(pool: asyncpg.Pool) -> None:
+    # Attribute restarts rewrite the same log file; the inline size
+    # metadata must reflect the latest run, not the first.
     project_id = await insert_project(pool, "log-dup")
     build, _ = await db.get_or_create_build(pool, project_id, "tree-l", "sha", "main")
     job = mk_job("foo")
@@ -465,19 +459,14 @@ async def test_complete_attribute_replaces_log_row(pool: asyncpg.Pool) -> None:
                 drv_path=job.drv_path,
                 system=job.system,
             ),
-            log_path="logs/x/foo.zst",
             log_size=size,
         )
     rows = await pool.fetch(
-        """
-            SELECT l.size_bytes FROM logs l
-            JOIN build_attributes a ON a.id = l.attribute_id
-            WHERE a.build_id = $1 AND a.attr = 'foo'
-            """,
+        "SELECT log_size FROM build_attributes WHERE build_id = $1 AND attr = 'foo'",
         build.id,
     )
     assert len(rows) == 1
-    assert rows[0]["size_bytes"] == 20
+    assert rows[0]["log_size"] == 20
 
 
 async def test_record_attributes_persists_pending_rows_with_outputs(

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -25,6 +25,7 @@ from nixbot.config import Config
 from nixbot.db import BuildStatus
 from nixbot.db_gen import builds as builds_q
 from nixbot.events import BuildResult, ChangeEvent, EvalReport, RepoInfo
+from nixbot.executor import attribute_log_path, effect_log_path
 from nixbot.gitrepo import FetchCredentials, RepoManager
 from nixbot.memory import EvalWorkerConfig
 from nixbot.models import CacheStatus
@@ -369,8 +370,7 @@ async def test_full_lifecycle(pool: asyncpg.Pool, run_event: EventRunner) -> Non
     }
     # Log metadata written in the same transaction as completion.
     logs = await pool.fetch(
-        "SELECT l.path FROM logs l JOIN build_attributes a "
-        "ON l.attribute_id = a.id WHERE a.build_id = $1",
+        "SELECT log_size FROM build_attributes WHERE build_id = $1 AND log_size > 0",
         build.id,
     )
     assert len(logs) == 2
@@ -690,13 +690,9 @@ async def test_log_path_attribute_name_sanitized(
     assert len(files) == 1
     assert files[0].parent == log_dir
     assert not (tmp_path / 'evil".attr.zst').exists()
-    log_path = await pool.fetchval(
-        "SELECT l.path FROM logs l JOIN build_attributes a "
-        "ON l.attribute_id = a.id WHERE a.build_id = $1",
-        build.id,
-    )
     state_dir = (tmp_path / "state").resolve()
-    assert (state_dir / log_path).resolve().is_relative_to(state_dir / "logs")
+    path = attribute_log_path(state_dir, build.id, evil)
+    assert path.resolve().is_relative_to(state_dir / "logs")
 
 
 async def test_cancel_interrupts_evaluation(
@@ -1273,7 +1269,6 @@ async def test_effect_rows_roundtrip(pool: asyncpg.Pool, tmp_path: Path) -> None
         name="deploy",
         status="failed",
         error="ssh: connection refused",
-        log_path="logs/1/effect-deploy.zst",
         log_size=123,
         log_truncated=False,
     )
@@ -1717,18 +1712,12 @@ async def test_effect_log_does_not_collide_with_attribute_log(
     )
     assert build is not None
     await drain_effect_items(orchestrator, project, pool)
-    attr_log = await pool.fetchval(
-        "SELECT l.path FROM logs l JOIN build_attributes a "
-        "ON l.attribute_id = a.id WHERE a.build_id = $1",
-        build.id,
-    )
-    effect_log = await pool.fetchval(
-        "SELECT log_path FROM build_effects WHERE build_id = $1",
-        build.id,
-    )
-    assert attr_log is not None
-    assert effect_log is not None
+    state_dir = orchestrator.config.state_dir
+    attr_log = attribute_log_path(state_dir, build.id, "effect-deploy")
+    effect_log = effect_log_path(state_dir, build.id, "deploy")
     assert attr_log != effect_log
+    assert attr_log.exists()
+    assert effect_log.exists()
 
 
 async def test_post_process_paths_are_forge_scoped(

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -22,7 +22,7 @@ from nixbot.auth import User
 from nixbot.build_scheduler import AttributeStatus
 from nixbot.db import BuildStatus
 from nixbot.effects_state import TaskTokens
-from nixbot.executor import LogWriter
+from nixbot.executor import LogWriter, attribute_log_path, effect_log_path
 from nixbot.forge_tokens import ForgeTokenStore
 from nixbot.web import events as events_module
 from nixbot.web.auth_routes import SESSION_COOKIE, create_auth_router
@@ -691,21 +691,13 @@ def seed_log(client: WebHarness, tmp_path: Path) -> None:
     async def run() -> None:
         ctx = client.ctx
         ctx.state_dir = tmp_path
-        attr_id = await ctx.pool.fetchval(
-            """
-            SELECT a.id FROM build_attributes a
-            JOIN builds b ON b.id = a.build_id
-            WHERE b.number = 2 AND a.attr = 'x86_64-linux.bad'
-            """
-        )
-        await ctx.pool.execute("DELETE FROM logs WHERE attribute_id = $1", attr_id)
+        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
         await ctx.pool.execute(
-            "INSERT INTO logs (attribute_id, path, size_bytes) VALUES ($1, $2, $3)",
-            attr_id,
-            "logs/2/x86_64-linux.bad.zst",
-            42,
+            "UPDATE build_attributes SET log_size = 42 "
+            "WHERE build_id = $1 AND attr = 'x86_64-linux.bad'",
+            build_id,
         )
-        log_file = tmp_path / "logs" / "2" / "x86_64-linux.bad.zst"
+        log_file = attribute_log_path(tmp_path, build_id, "x86_64-linux.bad")
         log_file.parent.mkdir(parents=True, exist_ok=True)
         log_file.write_bytes(
             zstandard.ZstdCompressor().compress(b"\x1b[31mbuild exploded\x1b[0m\n")
@@ -748,20 +740,14 @@ def test_attr_named_dot_txt_not_shadowed_by_raw_route(
             ("foo", b"plain foo log\n"),
             ("foo.txt", b"dot txt log\n"),
         ):
-            attr_id = await ctx.pool.fetchval(
-                "INSERT INTO build_attributes (build_id, attr, system, status)"
-                " VALUES ($1, $2, 'x86_64-linux', 'failed') RETURNING id",
-                build_id,
-                attr,
-            )
-            rel = f"logs/2/{attr}.zst"
-            f = tmp_path / rel
+            f = attribute_log_path(tmp_path, build_id, attr)
             f.parent.mkdir(parents=True, exist_ok=True)
             f.write_bytes(zstandard.ZstdCompressor().compress(content))
             await ctx.pool.execute(
-                "INSERT INTO logs (attribute_id, path, size_bytes) VALUES ($1, $2, $3)",
-                attr_id,
-                rel,
+                "INSERT INTO build_attributes (build_id, attr, system, status,"
+                " log_size) VALUES ($1, $2, 'x86_64-linux', 'failed', $3)",
+                build_id,
+                attr,
                 f.stat().st_size,
             )
         return build_id
@@ -797,20 +783,14 @@ def test_attr_names_with_special_characters(client: WebHarness, tmp_path: Path) 
 
     async def setup() -> int:
         build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
-        attr_id = await ctx.pool.fetchval(
-            "INSERT INTO build_attributes (build_id, attr, system, status)"
-            " VALUES ($1, $2, 'x86_64-linux', 'failed') RETURNING id",
-            build_id,
-            attr,
-        )
-        rel = "logs/2/weird.zst"
-        f = tmp_path / rel
+        f = attribute_log_path(tmp_path, build_id, attr)
         f.parent.mkdir(parents=True, exist_ok=True)
         f.write_bytes(zstandard.ZstdCompressor().compress(b"weird log\n"))
         await ctx.pool.execute(
-            "INSERT INTO logs (attribute_id, path, size_bytes) VALUES ($1, $2, $3)",
-            attr_id,
-            rel,
+            "INSERT INTO build_attributes (build_id, attr, system, status, log_size)"
+            " VALUES ($1, $2, 'x86_64-linux', 'failed', $3)",
+            build_id,
+            attr,
             f.stat().st_size,
         )
         return build_id
@@ -1204,7 +1184,10 @@ def test_api_build_failures_rejects_non_positive_tail(
     """splitlines()[-0:] is the WHOLE list: tail=0 must not dump the
     full log of every failed attribute."""
     seed_log(client, tmp_path)
-    log_file = tmp_path / "logs" / "2" / "x86_64-linux.bad.zst"
+    build_id = client.loop.run_until_complete(
+        client.ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
+    )
+    log_file = attribute_log_path(tmp_path, build_id, "x86_64-linux.bad")
     lines = "".join(f"line {i}\n" for i in range(60))
     log_file.write_bytes(zstandard.ZstdCompressor().compress(lines.encode()))
 
@@ -1372,11 +1355,11 @@ def test_build_page_shows_effects(client: WebHarness) -> None:
         build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
         await ctx.pool.execute(
             """
-            INSERT INTO build_effects (build_id, name, status, error, log_path,
+            INSERT INTO build_effects (build_id, name, status, error, log_size,
                                        finished_at)
             VALUES ($1, 'deploy', 'failed', 'ssh: connection refused',
-                    'logs/effect-deploy.zst', now()),
-                   ($1, 'notify', 'running', NULL, NULL, NULL)
+                    42, now()),
+                   ($1, 'notify', 'running', NULL, 0, NULL)
             """,
             build_id,
         )
@@ -1397,16 +1380,15 @@ def test_effect_log_raw_text(client: WebHarness, tmp_path: Path) -> None:
     async def seed_effect_log() -> None:
         ctx = client.ctx
         ctx.state_dir = tmp_path
-        log_dir = tmp_path / "logs"
-        log_dir.mkdir(parents=True, exist_ok=True)
-        (log_dir / "effect-deploy2.zst").write_bytes(
+        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
+        log_file = effect_log_path(tmp_path, build_id, "deploy2")
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        log_file.write_bytes(
             zstandard.ZstdCompressor().compress(b"activating system...\n")
         )
-        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
         await ctx.pool.execute(
-            "INSERT INTO build_effects (build_id, name, status, log_path, "
-            "finished_at) VALUES ($1, 'deploy2', 'succeeded', "
-            "'logs/effect-deploy2.zst', now())",
+            "INSERT INTO build_effects (build_id, name, status, log_size, "
+            "finished_at) VALUES ($1, 'deploy2', 'succeeded', 42, now())",
             build_id,
         )
 

--- a/nixbot/nixbot/web/api_routes.py
+++ b/nixbot/nixbot/web/api_routes.py
@@ -91,8 +91,8 @@ class Attribute(BaseModel):
     error: str | None
     started_at: datetime | None
     finished_at: datetime | None
-    log_path: str | None = None
     log_size: int | None = None
+    log_truncated: bool | None = None
 
 
 class BuildDetail(BaseModel):

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -30,7 +30,7 @@ from ..build_scheduler import TERMINAL_FAILURES  # noqa: TID252
 from ..db_gen import maintenance as maint_gen  # noqa: TID252
 from ..db_gen import scheduled as sched_gen  # noqa: TID252
 from ..db_gen import web as gen  # noqa: TID252
-from ..executor import read_log  # noqa: TID252
+from ..executor import log_path_for_key, read_log  # noqa: TID252
 from ..status import NO_LOG_STATUSES  # noqa: TID252
 from .api_routes import FailureSummary, clean_row
 
@@ -210,28 +210,6 @@ def render_log_lines(text: str) -> str:
     return "".join(lines)
 
 
-async def _log_path(
-    ctx: WebContext, registry: LogRegistry, build: dict, attr: str
-) -> Path | None:
-    if attr.startswith("effect:"):
-        # Effects store log metadata inline (no attribute row).
-        log_rel = await gen.effect_log_path(
-            ctx.pool, build_id=build["id"], name=attr.removeprefix("effect:")
-        )
-    else:
-        log_rel = await gen.attribute_log_path(
-            ctx.pool, build_id=build["id"], attr=attr
-        )
-    path = ctx.state_dir / log_rel if log_rel else None
-    if path is None:
-        # No logs row until completion; running attributes use the
-        # live writer's on-disk file.
-        writer = registry.get(build["id"], attr)
-        if writer is not None:
-            path = writer.path
-    return path
-
-
 async def _log_text(
     registry: LogRegistry, build: dict, attr: str, path: Path | None
 ) -> str | None:
@@ -261,7 +239,9 @@ async def _failure_summary(
     for a in await ctx.queries.attributes(build["id"]):
         if a["status"] not in _FAILURE_STATUSES:
             continue
-        path = await _log_path(ctx, registry, build, a["attr"])
+        # The file may not exist yet (never ran, or pending after a
+        # reset); _log_text handles that.
+        path = log_path_for_key(ctx.state_dir, build["id"], a["attr"])
         text = await _log_text(registry, build, a["attr"], path)
         failures.append(
             {
@@ -316,7 +296,8 @@ class _LogRoutes:
         attr: str,
     ) -> tuple[dict, dict, Path | None]:
         project, build = await self._build_or_404(request, forge, owner, name, number)
-        return project, build, await _log_path(self.ctx, self.registry, build, attr)
+        path = log_path_for_key(self.ctx.state_dir, build["id"], attr)
+        return project, build, path
 
     async def log_raw_text(  # noqa: PLR0913
         self,

--- a/nixbot/nixbot/web/templates/_attr_rows.html
+++ b/nixbot/nixbot/web/templates/_attr_rows.html
@@ -3,7 +3,7 @@
   <tr data-attr="{{ a.attr | lower }}">
     <td class="attr-status">{{ status_icon(a.status) }}</td>
     <td class="attr-name">
-      {% if a.log_path or a.status in RUNNING_STATUSES %}
+      {% if a.log_size or a.status in RUNNING_STATUSES %}
         <a href="{{ build_path(project, build.number) }}/logs/{{ a.attr | urlencode }}"><code>{{ a.attr }}</code></a>
       {% else %}
         <code>{{ a.attr }}</code>

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -145,7 +145,7 @@
             <tr>
               <td class="attr-status">{{ status_icon(e.status) }}</td>
               <td class="attr-name">
-                {% if e.log_path or e.status == "running" %}
+                {% if e.log_size or e.status == "running" %}
                   <a href="{{ build_path(project, build.number) }}/logs/effect:{{ e.name | urlencode }}"><code>{{ e.name }}</code></a>
                 {% else %}
                   <code>{{ e.name }}</code>


### PR DESCRIPTION
Attach the evaluator's error tail to the nix-eval check run so a failed evaluation shows why without a click into the log. This threads through a new EvalReport dataclass, which also tidies the eval_finished signature.

Fix a restart leaving the previous run's log in place: the row went pending but still served stale output until the rebuild reopened the log. Drop the log at reset time.

Stop storing the log path. It is fully determined by (build_id, attr/effect name), so persisting it in logs.path and build_effects.log_path only let the row and the file drift. Compute the path in one place, keep only size/truncated metadata inline on the owning row (folding the logs table into build_attributes), treat file existence as "log exists", and reset by removing the file.