### PR TITLE
recovery: report effects interrupted by a service restart

### DIFF
--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 __all__: collections.abc.Sequence[str] = (
     "AttributesForBuildsRow",
     "CleanupOldRowsRow",
+    "FailInterruptedEffectsRow",
     "QueryResults",
     "SucceededAttributeOutputsRow",
     "all_build_ids",
@@ -63,6 +64,12 @@ class AttributesForBuildsRow:
 class CleanupOldRowsRow:
     kind: str
     id: int
+
+
+@dataclasses.dataclass()
+class FailInterruptedEffectsRow:
+    build_id: int
+    name: str
 
 
 @dataclasses.dataclass()
@@ -159,10 +166,11 @@ EFFECT_STATUS: typing.Final[str] = """-- name: EffectStatus :one
 SELECT status FROM build_effects WHERE build_id = $1 AND name = $2
 """
 
-FAIL_INTERRUPTED_EFFECTS: typing.Final[str] = """-- name: FailInterruptedEffects :exec
+FAIL_INTERRUPTED_EFFECTS: typing.Final[str] = """-- name: FailInterruptedEffects :many
 UPDATE build_effects SET status = 'failed',
     error = 'interrupted by a service restart', finished_at = now()
 WHERE status = 'running' AND started_at < $1
+RETURNING build_id, name
 """
 
 FAIL_INTERRUPTED_SCHEDULED_RUNS: typing.Final[str] = """-- name: FailInterruptedScheduledRuns :exec
@@ -353,8 +361,10 @@ async def effect_status(conn: ConnectionLike, *, build_id: int, name: str) -> st
     return row[0]
 
 
-async def fail_interrupted_effects(conn: ConnectionLike, *, started_before: datetime.datetime) -> None:
-    await conn.execute(FAIL_INTERRUPTED_EFFECTS, started_before)
+def fail_interrupted_effects(conn: ConnectionLike, *, started_before: datetime.datetime) -> QueryResults[FailInterruptedEffectsRow]:
+    def _decode_hook(row: asyncpg.Record) -> FailInterruptedEffectsRow:
+        return FailInterruptedEffectsRow(build_id=row[0], name=row[1])
+    return QueryResults[FailInterruptedEffectsRow](conn, FAIL_INTERRUPTED_EFFECTS, _decode_hook, started_before)
 
 
 async def fail_interrupted_scheduled_runs(conn: ConnectionLike, *, started_before: datetime.datetime) -> None:

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -9,7 +9,6 @@ keeps the module dependency graph acyclic.
 from __future__ import annotations
 
 import logging
-from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from .db_gen import builds as builds_q
@@ -24,6 +23,7 @@ from .effects import (
     run_effect,
     should_run_effects,
 )
+from .events import effects_event_for_build
 from .executor import failure_excerpt
 from .repo_config import CONFIG_FILENAMES, BranchConfig
 
@@ -143,11 +143,9 @@ async def run_effect_item(
         worktree_event,
         worktree_path,
     ):
-        # rerun_worktree rebuilds the event from the build's stored
-        # commit (the right tree to check out), but effects report on
-        # the commit that triggered them (e.g. the default-branch merge
-        # that reused a PR build), recorded at mark_effects_started.
-        event = _effects_event(build, worktree_event)
+        # The checkout ref (build commit) differs from the report ref
+        # (see effects_event_for_build).
+        event = effects_event_for_build(worktree_event.repo, build)
         task_token = o.task_tokens.issue(build.project_id)
         try:
             ctx = effects_context(
@@ -160,25 +158,12 @@ async def run_effect_item(
                 task_token=task_token,
             )
             await _run_one_effect(o, event, ctx, build, name)
-            await _maybe_post_effects_summary(o, event, build)
+            await post_effects_summary(o, event, build)
         finally:
             o.task_tokens.revoke(task_token)
 
 
-def _effects_event(build: BuildRecord, fallback: ChangeEvent) -> ChangeEvent:
-    """The ref that triggered the effects run, recorded on the build;
-    pre-0018 builds have no record and fall back to the build commit."""
-    if build.effects_commit_sha is None:
-        return fallback
-    return replace(
-        fallback,
-        commit_sha=build.effects_commit_sha,
-        branch=build.effects_branch or fallback.branch,
-        pr_number=build.effects_pr_number,
-    )
-
-
-async def _maybe_post_effects_summary(
+async def post_effects_summary(
     o: Orchestrator, event: ChangeEvent, build: BuildRecord
 ) -> None:
     """Post the aggregate status once all effects settle; the items run

--- a/nixbot/nixbot/events.py
+++ b/nixbot/nixbot/events.py
@@ -46,6 +46,31 @@ class ChangeEvent:
     commit_message: str = ""
 
 
+def event_for_build(repo: RepoInfo, build: BuildRecord) -> ChangeEvent:
+    """The triggering event of a build, reconstructed from its stored
+    fields; used by rerun and out-of-band reporting paths."""
+    return ChangeEvent(
+        repo=repo,
+        branch=build.branch,
+        commit_sha=build.commit_sha,
+        pr_number=build.pr_number,
+    )
+
+
+def effects_event_for_build(repo: RepoInfo, build: BuildRecord) -> ChangeEvent:
+    """Effects report on the ref that triggered them (e.g. a
+    default-branch merge that reused a PR build), recorded at
+    mark_effects_started; pre-0018 builds fall back to the build ref."""
+    if build.effects_commit_sha is None:
+        return event_for_build(repo, build)
+    return ChangeEvent(
+        repo=repo,
+        branch=build.effects_branch or build.branch,
+        commit_sha=build.effects_commit_sha,
+        pr_number=build.effects_pr_number,
+    )
+
+
 @dataclass(frozen=True)
 class EvalReport:
     """Evaluation-phase outcome reported to a forge. warnings and jobs

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -394,6 +394,13 @@ class Orchestrator:
         """Dispatcher entry for one queued effect."""
         await effects_run.run_effect_item(self, info, build, name, credentials)
 
+    async def post_effects_summary(
+        self, event: ChangeEvent, build: BuildRecord
+    ) -> None:
+        """Post the aggregate effects status once none is still pending;
+        the last settled effect (or crash recovery) reports it."""
+        await effects_run.post_effects_summary(self, event, build)
+
     @asynccontextmanager
     async def open_log(self, build_id: int, key: str) -> AsyncIterator[LogWriter]:
         """LogWriter registered for live streaming; closed and

--- a/nixbot/nixbot/queries/maintenance.sql
+++ b/nixbot/nixbot/queries/maintenance.sql
@@ -84,10 +84,11 @@ ORDER BY id;
 SELECT build_id, attr, system, drv_path, outputs, status
 FROM build_attributes WHERE build_id = ANY(sqlc.arg(build_ids)::bigint[]);
 
--- name: FailInterruptedEffects :exec
+-- name: FailInterruptedEffects :many
 UPDATE build_effects SET status = 'failed',
     error = 'interrupted by a service restart', finished_at = now()
-WHERE status = 'running' AND started_at < sqlc.arg(started_before);
+WHERE status = 'running' AND started_at < sqlc.arg(started_before)
+RETURNING build_id, name;
 
 -- name: FailInterruptedScheduledRuns :exec
 UPDATE scheduled_effect_runs SET status = 'failed',

--- a/nixbot/nixbot/recovery.py
+++ b/nixbot/nixbot/recovery.py
@@ -40,7 +40,7 @@ from .db_gen import maintenance as q
 from .models import CacheStatus, NixEvalJobSuccess
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Sequence
     from datetime import datetime
 
 
@@ -155,14 +155,16 @@ def _valid_paths_from_db(paths: list[str], nix_db: Path) -> set[str]:
 
 async def fail_interrupted_effects(
     pool: asyncpg.Pool, started_before: datetime
-) -> None:
+) -> Sequence[q.FailInterruptedEffectsRow]:
     """Settle effect rows left running by a crash: started effects
     never auto-re-run. Pending rows keep their queued items and run
     after the requeue. Only rows started before `started_before`
     (process start) are swept: the sweep runs concurrently with the
-    work loop, and newer rows are live effects."""
-    await q.fail_interrupted_effects(pool, started_before=started_before)
+    work loop, and newer rows are live effects. Returns the settled
+    rows for the caller to report."""
+    settled = await q.fail_interrupted_effects(pool, started_before=started_before)
     await q.fail_interrupted_scheduled_runs(pool, started_before=started_before)
+    return settled
 
 
 async def check_store_paths(paths: list[str], nix_db: Path = NIX_DB) -> set[str]:

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -16,7 +16,7 @@ from .canceller import branch_key
 from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
-from .events import ChangeEvent, EvalReport
+from .events import ChangeEvent, EvalReport, event_for_build
 from .gitrepo import pr_refspec
 
 if TYPE_CHECKING:
@@ -40,12 +40,7 @@ async def rerun_worktree(
 ) -> AsyncIterator[tuple[ChangeEvent, Path]]:
     """Event reconstruction plus a fresh worktree at the recorded
     commit; shared by the rerun paths."""
-    event = ChangeEvent(
-        repo=info,
-        branch=build.branch,
-        commit_sha=build.commit_sha,
-        pr_number=build.pr_number,
-    )
+    event = event_for_build(info, build)
     # PR head commits are only reachable via the PR refs.
     refspecs = ["+refs/heads/*:refs/heads/*"]
     if build.pr_number is not None:

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -21,8 +21,14 @@ from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import failed as failed_q
 from .db_gen import maintenance as q
-from .db_gen import web as web_q
-from .events import BuildResult, ChangeEvent, EvalReport, StatusReporter
+from .events import (
+    BuildResult,
+    ChangeEvent,
+    EvalReport,
+    StatusReporter,
+    effects_event_for_build,
+    event_for_build,
+)
 from .gitrepo import (
     CredentialsProvider,
     FetchCredentials,
@@ -463,12 +469,7 @@ class CIService:
         project = await self.repo_store.by_id(build.project_id)
         if project is None:
             return
-        event = ChangeEvent(
-            repo=repo_info(project),
-            branch=build.branch,
-            commit_sha=build.commit_sha,
-            pr_number=build.pr_number,
-        )
+        event = event_for_build(repo_info(project), build)
         rows = await builds_q.attribute_statuses(self.pool, build_id=build_id)
         reporter = self.orchestrator.reporter
         if isinstance(reporter, RetryingReporter):
@@ -561,33 +562,16 @@ class CIService:
             project = await self.repo_store.by_id(build.project_id)
             if project is None:
                 continue
-            event = ChangeEvent(
-                repo=repo_info(project),
-                branch=build.effects_branch or build.branch,
-                commit_sha=build.effects_commit_sha or build.commit_sha,
-                pr_number=build.effects_pr_number
-                if build.effects_commit_sha
-                else build.pr_number,
-            )
-            reporter = self.orchestrator.reporter
+            event = effects_event_for_build(repo_info(project), build)
             for name in names:
-                await reporter.effect_finished(
+                await self.orchestrator.reporter.effect_finished(
                     event,
                     build,
                     name,
                     success=False,
                     error="interrupted by a service restart",
                 )
-            statuses = [
-                e.status for e in await web_q.web_effects(self.pool, build_id=build_id)
-            ]
-            if not any(s in ("pending", "running") for s in statuses):
-                await reporter.effects_finished(
-                    event,
-                    build,
-                    failed=sum(1 for s in statuses if s != "succeeded"),
-                    succeeded=sum(1 for s in statuses if s == "succeeded"),
-                )
+            await self.orchestrator.post_effects_summary(event, build)
 
     async def cancel_attribute(self, build_id: int, attr: str) -> None:
         event = self.orchestrator.attr_cancel_events.get((build_id, attr))
@@ -630,12 +614,7 @@ class CIService:
         project = await self.repo_store.by_id(build.project_id)
         if project is None:
             return
-        change = ChangeEvent(
-            repo=repo_info(project),
-            branch=build.branch,
-            commit_sha=build.commit_sha,
-            pr_number=build.pr_number,
-        )
+        change = event_for_build(repo_info(project), build)
         await self.orchestrator.reporter.build_finished(
             change, build, BuildResult(status, generation, [])
         )

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -21,6 +21,7 @@ from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import failed as failed_q
 from .db_gen import maintenance as q
+from .db_gen import web as web_q
 from .events import BuildResult, ChangeEvent, EvalReport, StatusReporter
 from .gitrepo import (
     CredentialsProvider,
@@ -46,7 +47,7 @@ from .webhooks import (
 from .work_queue import WorkItem, WorkQueue
 
 if TYPE_CHECKING:
-    from collections.abc import Coroutine
+    from collections.abc import Coroutine, Sequence
 
     import asyncpg
 
@@ -525,7 +526,8 @@ class CIService:
         """Crash recovery: settle already-built attributes, then queue
         reruns for the rest. Builds interrupted mid-eval (no attribute
         rows) re-evaluate via the rerun path."""
-        await fail_interrupted_effects(self.pool, self._started_at)
+        settled_effects = await fail_interrupted_effects(self.pool, self._started_at)
+        await self._report_interrupted_effects(settled_effects)
         for resumable in await find_unfinished_builds(self.pool):
             remaining, settled = await settle_already_built(self.pool, resumable)
             if settled:
@@ -542,6 +544,50 @@ class CIService:
                 f"build-{resumable.build_id}",
                 {"build_id": resumable.build_id},
             )
+
+    async def _report_interrupted_effects(
+        self, settled: Sequence[q.FailInterruptedEffectsRow]
+    ) -> None:
+        """Post the failure of effects settled by crash recovery: the
+        forge holds the pending status from effect_started, and nothing
+        re-runs a settled effect to clear it."""
+        by_build: dict[int, list[str]] = {}
+        for row in settled:
+            by_build.setdefault(row.build_id, []).append(row.name)
+        for build_id, names in by_build.items():
+            build = await builds_q.get_build(self.pool, id_=build_id)
+            if build is None:
+                continue
+            project = await self.repo_store.by_id(build.project_id)
+            if project is None:
+                continue
+            event = ChangeEvent(
+                repo=repo_info(project),
+                branch=build.effects_branch or build.branch,
+                commit_sha=build.effects_commit_sha or build.commit_sha,
+                pr_number=build.effects_pr_number
+                if build.effects_commit_sha
+                else build.pr_number,
+            )
+            reporter = self.orchestrator.reporter
+            for name in names:
+                await reporter.effect_finished(
+                    event,
+                    build,
+                    name,
+                    success=False,
+                    error="interrupted by a service restart",
+                )
+            statuses = [
+                e.status for e in await web_q.web_effects(self.pool, build_id=build_id)
+            ]
+            if not any(s in ("pending", "running") for s in statuses):
+                await reporter.effects_finished(
+                    event,
+                    build,
+                    failed=sum(1 for s in statuses if s != "succeeded"),
+                    succeeded=sum(1 for s in statuses if s == "succeeded"),
+                )
 
     async def cancel_attribute(self, build_id: int, attr: str) -> None:
         event = self.orchestrator.attr_cancel_events.get((build_id, attr))

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -863,6 +863,69 @@ async def test_effect_item_setup_failure_settles_row(
         await pool.close()
 
 
+async def test_recovery_reports_interrupted_effects(
+    postgres_dsn: str, tmp_path: Path
+) -> None:
+    """An effect left running by a crash is settled failed but never
+    re-runs; recovery must post that failure so the check run does not
+    stay pending forever (issue #58)."""
+    config = Config(
+        db_url=postgres_dsn,
+        build_systems=["x86_64-linux"],
+        url="http://ci.test",
+        state_dir=tmp_path / "state",
+    )
+    service, _app = await build_service(config)
+    pool = service.pool
+    try:
+        project_id = await insert_project(pool, forge_repo_id="82", url="http://x")
+        build_id = await insert_build(
+            pool, project_id, commit_sha="c1", tree_hash="t1", status="succeeded"
+        )
+        # started_at before the service start so the sweep claims it.
+        await pool.execute(
+            "INSERT INTO build_effects (build_id, name, status, started_at) "
+            "VALUES ($1, 'deploy', 'running', now() - interval '1 hour')",
+            build_id,
+        )
+
+        finished: list[tuple[str, bool]] = []
+        summaries: list[tuple[int, int]] = []
+
+        class FakeReporter(NullStatusReporter):
+            async def effect_finished(
+                self,
+                event: ChangeEvent,
+                build: Any,
+                name: str,
+                *,
+                success: bool,
+                error: str | None = None,
+            ) -> None:
+                del event, build, error
+                finished.append((name, success))
+
+            async def effects_finished(
+                self,
+                event: ChangeEvent,
+                build: Any,
+                *,
+                failed: int,
+                succeeded: int,
+            ) -> None:
+                del event, build
+                summaries.append((failed, succeeded))
+
+        service.orchestrator.reporter = FakeReporter()
+
+        await service.recover_unfinished_builds()
+
+        assert finished == [("deploy", False)]
+        assert summaries == [(1, 0)]
+    finally:
+        await pool.close()
+
+
 async def test_work_dispatch(postgres_dsn: str, tmp_path: Path) -> None:
     """The dispatcher reconstructs payloads and fails unknown kinds."""
 


### PR DESCRIPTION

The startup sweep marks effects left running by a crash as failed
(effects never auto-re-run: deploys are not idempotent), but only in the
database. The forge kept the pending status from effect_started, so the
check never went red and only a full service restart cleared it (#58).

Post the failure for each swept effect, plus the aggregate summary once
none is still pending.
