### PR TITLE
status: flip checks to pending on restart

### DIFF
--- a/nixbot/nixbot/events.py
+++ b/nixbot/nixbot/events.py
@@ -109,6 +109,10 @@ class StatusReporter(Protocol):
         self, event: ChangeEvent, build: BuildRecord, result: BuildResult
     ) -> None: ...
 
+    async def build_restarted(
+        self, event: ChangeEvent, build: BuildRecord, attr: str | None
+    ) -> None: ...
+
     async def effect_started(
         self, event: ChangeEvent, build: BuildRecord, name: str
     ) -> None: ...
@@ -151,6 +155,11 @@ class NullStatusReporter:
 
     async def build_finished(
         self, event: ChangeEvent, build: BuildRecord, result: BuildResult
+    ) -> None:
+        pass
+
+    async def build_restarted(
+        self, event: ChangeEvent, build: BuildRecord, attr: str | None
     ) -> None:
         pass
 

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -131,6 +131,11 @@ class RetryingReporter:
     async def eval_cancelled(self, event: ChangeEvent, build: BuildRecord) -> None:
         await self.inner.eval_cancelled(event, build)
 
+    async def build_restarted(
+        self, event: ChangeEvent, build: BuildRecord, attr: str | None
+    ) -> None:
+        await self.inner.build_restarted(event, build, attr)
+
     async def effect_started(
         self, event: ChangeEvent, build: BuildRecord, name: str
     ) -> None:
@@ -343,6 +348,15 @@ class CIService:
         # show stale output until the rebuild starts.
         await q.reset_build_for_restart(self.pool, build_id=build_id, attr=attr)
         self.orchestrator.reset_build_logs(build_id, attr)
+        # Flip the forge checks to pending now; the async rerun only
+        # posts the terminal status, possibly much later.
+        build = await builds_q.get_build(self.pool, id_=build_id)
+        project = (
+            await self.repo_store.by_id(build.project_id) if build is not None else None
+        )
+        if build is not None and project is not None:
+            event = event_for_build(repo_info(project), build)
+            await self.orchestrator.reporter.build_restarted(event, build, attr)
         await self.enqueue_work("rerun", f"build-{build_id}", {"build_id": build_id})
 
     async def restart_effects(self, build_id: int) -> None:

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -136,6 +136,7 @@ class CommitStatusPoster(Protocol):
         build_id: int = 0,
         attr: str | None = None,
         text: str | None = None,
+        force_new: bool = False,
     ) -> None: ...
 
 
@@ -225,6 +226,7 @@ class GitHubCheckRunPoster:
         build_id: int = 0,
         attr: str | None = None,
         text: str | None = None,
+        force_new: bool = False,
     ) -> None:
         installation_id = await self.client.installation_for_repo(f"{owner}/{repo}")
         if installation_id is None:
@@ -247,7 +249,10 @@ class GitHubCheckRunPoster:
             body["conclusion"] = conclusion
 
         base = f"{self.client.api_url}/repos/{owner}/{repo}/check-runs"
-        run_id = await self.store.get(project_id, sha, context)
+        # GitHub only renders a check as re-running for a *new* run of
+        # the same name, so a restart creates one instead of patching
+        # (community discussion 38288).
+        run_id = None if force_new else await self.store.get(project_id, sha, context)
         if run_id is not None:
             response = await self.client.http.patch(
                 f"{base}/{run_id}", headers=headers, json=body
@@ -442,6 +447,7 @@ class ForgeStatusReporter:
         attr: str | None = None,
         text: str | None = None,
         propagate: bool = False,
+        force_new: bool = False,
     ) -> None:
         poster = self.posters.get(event.repo.forge)
         if poster is None:
@@ -461,6 +467,7 @@ class ForgeStatusReporter:
                 build_id=build.id,
                 attr=attr,
                 text=text,
+                force_new=force_new,
             )
         except CheckPermissionError:
             # Per-org and not transient: log the hint and move on, never
@@ -627,6 +634,45 @@ class ForgeStatusReporter:
                 counts[_count_key(attr_status)] += 1
         table_statuses = attr_statuses or {r.attr: r.status.value for r in results}
         await self._post_summary(event, build, result.status, counts, table_statuses)
+
+    async def build_restarted(
+        self, event: ChangeEvent, build: BuildRecord, attr: str | None
+    ) -> None:
+        """Flip the restarted checks to pending before the async rebuild
+        starts; force_new so GitHub renders them as re-running."""
+        if attr is None:
+            await self._post(
+                event,
+                build,
+                f"{self.context_prefix}/nix-eval",
+                StatusState.pending,
+                "restarting",
+                force_new=True,
+            )
+        else:
+            context = attr_status_context(
+                event.repo.forge,
+                event.repo.name,
+                attr,
+                context_prefix=self.context_prefix,
+            )
+            await self._post(
+                event,
+                build,
+                context,
+                StatusState.pending,
+                "rebuilding",
+                attr=attr,
+                force_new=True,
+            )
+        await self._post(
+            event,
+            build,
+            f"{self.context_prefix}/nix-build",
+            StatusState.pending,
+            "rebuilding",
+            force_new=True,
+        )
 
     async def _post_attribute_statuses(
         self,

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -863,6 +863,48 @@ async def test_effect_item_setup_failure_settles_row(
         await pool.close()
 
 
+async def test_restart_attribute_posts_pending(
+    postgres_dsn: str, tmp_path: Path
+) -> None:
+    """Re-run on the forge must flip the check to pending immediately,
+    not only when the async rebuild finishes."""
+    config = Config(
+        db_url=postgres_dsn,
+        build_systems=["x86_64-linux"],
+        url="http://ci.test",
+        state_dir=tmp_path / "state",
+    )
+    service, _app = await build_service(config)
+    pool = service.pool
+    try:
+        project_id = await insert_project(pool, forge_repo_id="84", url="http://x")
+        build_id = await insert_build(
+            pool, project_id, commit_sha="c1", tree_hash="t1", status="failed"
+        )
+        await pool.execute(
+            "INSERT INTO build_attributes (build_id, attr, status) "
+            "VALUES ($1, 'x86_64-linux.a', 'failed')",
+            build_id,
+        )
+
+        restarts: list[tuple[int, str | None]] = []
+
+        class FakeReporter(NullStatusReporter):
+            async def build_restarted(
+                self, event: ChangeEvent, build: Any, attr: str | None
+            ) -> None:
+                del event
+                restarts.append((build.id, attr))
+
+        service.orchestrator.reporter = FakeReporter()
+
+        await service.restart_attribute(build_id, "x86_64-linux.a")
+
+        assert restarts == [(build_id, "x86_64-linux.a")]
+    finally:
+        await pool.close()
+
+
 async def test_recovery_reports_interrupted_effects(
     postgres_dsn: str, tmp_path: Path
 ) -> None:

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -140,6 +140,11 @@ class RecordingReporter:
     ) -> None:
         self.events.append(("finished", build.id, result.status, result.generation))
 
+    async def build_restarted(
+        self, event: ChangeEvent, build: BuildRecord, attr: str | None
+    ) -> None:
+        self.events.append(("restarted", build.id, attr))
+
     async def effect_started(
         self, event: ChangeEvent, build: BuildRecord, name: str
     ) -> None:

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -189,6 +189,30 @@ async def test_context_prefix_configurable() -> None:
     }
 
 
+async def test_build_restarted_posts_pending_new_runs() -> None:
+    """Re-run must flip the checks to pending immediately and, on
+    GitHub, force a new check run so it renders as re-running."""
+    reporter, poster, _ = make_reporter()
+
+    await reporter.build_restarted(EVENT, BUILD, "x86_64-linux.foo")
+    contexts = [(p.context, p.state) for p in poster.posts]
+    assert contexts == [
+        (
+            "nixbot/nix-build github:acme/widget#checks.x86_64-linux.foo",
+            StatusState.pending,
+        ),
+        ("nixbot/nix-build", StatusState.pending),
+    ]
+    assert all(extra["force_new"] for extra in poster.extras)
+
+    poster.posts.clear()
+    await reporter.build_restarted(EVENT, BUILD, None)
+    assert [(p.context, p.state) for p in poster.posts] == [
+        ("nixbot/nix-eval", StatusState.pending),
+        ("nixbot/nix-build", StatusState.pending),
+    ]
+
+
 def test_eval_description_warning_count() -> None:
     assert eval_description(True, []) == "evaluation succeeded"
     assert eval_description(True, ["w"]) == "evaluation succeeded (1 warning)"
@@ -778,6 +802,35 @@ async def test_github_check_run_patch_404_recreates() -> None:
     )
     assert methods == ["PATCH", "POST"]
     assert store.ids[(1, "sha1", "ctx")] == (None, 777)
+
+
+async def test_github_check_run_force_new_ignores_stored_id() -> None:
+    """A restart must create a fresh run so GitHub renders it as
+    re-running, even though a run id for the context is stored."""
+    methods: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        methods.append(request.method)
+        return httpx.Response(201, json={"id": 999})
+
+    store = _MemoryCheckRunIds()
+    store.ids[(1, "sha1", "ctx")] = (None, 1)
+    poster = _check_run_poster(httpx.MockTransport(handler), store)
+
+    await poster.post(
+        "acme",
+        "widget",
+        "sha1",
+        "ctx",
+        StatusState.pending,
+        "d",
+        "u",
+        project_id=1,
+        build_id=10,
+        force_new=True,
+    )
+    assert methods == ["POST"]
+    assert store.ids[(1, "sha1", "ctx")] == (None, 999)
 
 
 async def test_github_check_run_403_is_permission_error() -> None:


### PR DESCRIPTION
Re-run reset the build row to pending but posted nothing to the forge until the async rerun finished, so the check kept its old failed conclusion until then.

Post the affected checks as pending at restart time. GitHub only renders a check as re-running for a new run of the same name, so force a fresh run instead of patching the stale one (community discussion 38288, like garnix-ci).