### PR TITLE
logs: redact injected secrets from effect logs

### DIFF
--- a/nixbot/nixbot/effects.py
+++ b/nixbot/nixbot/effects.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .proc import ProcessGroup
+from .redact import Redactor, secret_literals
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -277,8 +278,21 @@ async def run_effect_command(
         return path
 
     secrets_file: Path | None = None
+    secret_content: str | None = None
     if ctx.secret_name is not None:
-        secrets_file = _side_file("secrets.json", _read_secret_file(ctx.secret_name))
+        secret_content = _read_secret_file(ctx.secret_name)
+        secrets_file = _side_file("secrets.json", secret_content)
+    # Redact the deploy secrets and the git and task tokens from
+    # anything the effect prints.
+    sink = log_write
+    literals = secret_literals(secret_content, ctx.git_token, ctx.task_token)
+    if literals and sink is not None:
+        redactor = Redactor(literals)
+        raw_sink = sink
+
+        async def sink(data: bytes) -> None:
+            await raw_sink(redactor(data))
+
     extra: list[str] = []
     if ctx.git_token is not None:
         extra += ["--git-token-file", str(_side_file("git-token", ctx.git_token))]
@@ -299,7 +313,7 @@ async def run_effect_command(
                 *targets,
             ],
             ctx.worktree_path,
-            log_write,
+            sink,
             time_limit=ctx.timeout,
         )
         return returncode == 0

--- a/nixbot/nixbot/redact.py
+++ b/nixbot/nixbot/redact.py
@@ -1,0 +1,60 @@
+"""Strip the secrets we inject from effect logs before they are stored,
+served in the web UI, or posted to a forge.
+
+We only redact secrets we control (deploy secret values, git and task
+tokens): matching them literally catches any forge's token by value and
+never touches unrelated output. Token-shape patterns are deliberately
+avoided; they cannot cover Gitea's prefix-less tokens and risk masking
+commit SHAs and other legitimate text.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import re
+
+REDACTED = b"***"
+
+# Below this length a literal is too generic to redact safely (it would
+# blank out ordinary words that happen to appear in the secret file).
+_MIN_LITERAL_LEN = 6
+
+
+def secret_literals(*values: str | None) -> list[bytes]:
+    """Literal secrets to redact, including the leaf string values of
+    any JSON secret payload; too-short values are dropped."""
+    found: set[str] = set()
+    for value in values:
+        if value is None:
+            continue
+        found.add(value)
+        with contextlib.suppress(ValueError):
+            _collect_json_strings(json.loads(value), found)
+    return [v.encode() for v in found if len(v) >= _MIN_LITERAL_LEN]
+
+
+def _collect_json_strings(value: object, out: set[str]) -> None:
+    if isinstance(value, str):
+        out.add(value)
+    elif isinstance(value, dict):
+        for item in value.values():
+            _collect_json_strings(item, out)
+    elif isinstance(value, list):
+        for item in value:
+            _collect_json_strings(item, out)
+
+
+class Redactor:
+    """Masks a fixed set of literal secrets in a single regex pass."""
+
+    def __init__(self, literals: list[bytes]) -> None:
+        # Longest first: a literal containing another is masked whole,
+        # since alternation matches left to right at each position. An
+        # empty alternation would match the empty string everywhere, so
+        # keep the pattern None and pass data through untouched.
+        alternatives = sorted(map(re.escape, set(literals)), key=len, reverse=True)
+        self._pattern = re.compile(b"|".join(alternatives)) if alternatives else None
+
+    def __call__(self, data: bytes) -> bytes:
+        return self._pattern.sub(REDACTED, data) if self._pattern else data

--- a/nixbot/nixbot/tests/test_effects.py
+++ b/nixbot/nixbot/tests/test_effects.py
@@ -151,7 +151,7 @@ async def test_run_effect_with_secrets(
 ) -> None:
     creds = tmp_path / "creds"
     creds.mkdir()
-    (creds / "widget-secret").write_text('{"token": "s3"}')
+    (creds / "widget-secret").write_text('{"token": "s3-longsecret"}')
     monkeypatch.setenv("CREDENTIALS_DIRECTORY", str(creds))
 
     chunks: list[bytes] = []
@@ -163,7 +163,10 @@ async def test_run_effect_with_secrets(
     ok = await run_effect(ctx, "deploy", log_write)
     assert ok
     output = b"".join(chunks).decode()
-    assert '{"token": "s3"}' in output  # secrets file content reached the CLI
+    # The effect echoes the secrets file; the deploy secret must be
+    # masked in the log even though the CLI received the real file.
+    assert "s3-longsecret" not in output
+    assert "***" in output
     # Deploy credentials must not be world/group readable while on disk.
     assert "mode=600" in output
     assert "running effect" in output

--- a/nixbot/nixbot/tests/test_redact.py
+++ b/nixbot/nixbot/tests/test_redact.py
@@ -1,0 +1,29 @@
+"""Log secret redaction: literal deploy secrets and tokens we inject."""
+
+from __future__ import annotations
+
+from nixbot.redact import Redactor, secret_literals
+
+
+def test_secret_literals_extracts_json_values_over_threshold() -> None:
+    literals = secret_literals('{"token": "supersecret", "n": 1, "x": "ab"}')
+    # Full payload plus the long leaf value; short "ab" and non-strings
+    # are dropped.
+    assert b"supersecret" in literals
+    assert b"ab" not in literals
+
+
+def test_redactor_masks_literals() -> None:
+    redactor = Redactor(secret_literals("deploytoken123", None))
+    assert redactor(b"key=deploytoken123 end") == b"key=*** end"
+
+
+def test_redactor_masks_longest_overlapping_literal() -> None:
+    redactor = Redactor([b"secretvalue", b"secretvalue-extended"])
+    assert redactor(b"x=secretvalue-extended") == b"x=***"
+
+
+def test_redactor_without_literals_is_a_noop() -> None:
+    # An empty alternation would otherwise match the empty string
+    # between every byte.
+    assert Redactor([])(b"hello world") == b"hello world"


### PR DESCRIPTION
Effect logs are stored on disk, served in the web UI, and their failure
tails posted to the forge; none of these masked secrets, so an effect
echoing its deploy credentials leaked them everywhere.

Redact the secrets we inject into effects (deploy secret values, git and
task tokens) by matching them literally. Matching by value catches any
forge's token regardless of shape (Gitea's are prefix-less) and never
masks unrelated text. Builds and evaluation receive none of these
secrets, so their logs are untouched.