### PR TITLE
forge: retry transient HTTP failures with backoff

### DIFF
--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -35,7 +35,7 @@ from urllib.parse import quote
 
 import zstandard
 
-from .ansi import strip_ansi
+from .ansi import ANSI_TOKEN_RE, strip_ansi
 from .build_scheduler import BuildOutcome
 from .gcroots import safe_attr_filename
 from .proc import ProcessGroup
@@ -402,6 +402,30 @@ _EXCERPT_NOISE = re.compile(
 )
 
 
+_LINE_CHAR_LIMIT = 650
+
+
+def _limit_line(line: str, limit: int = _LINE_CHAR_LIMIT) -> str:
+    """Cap a line at `limit` visible characters, escapes not counted and
+    never severed; a dropped tail's SGR reset is re-appended so color
+    does not bleed into later lines."""
+    visible = 0
+    pos = 0
+    # ANSI_TOKEN_RE spans are escapes; the gaps between them are text.
+    for start, end in [(m.start(), m.end()) for m in ANSI_TOKEN_RE.finditer(line)] + [
+        (len(line), len(line))
+    ]:
+        room = limit - visible
+        if start - pos >= room:
+            # Reserve the last slot for the ellipsis.
+            kept = line[: pos + room - 1]
+            reset = "\x1b[0m" if ANSI_TOKEN_RE.search(kept) else ""
+            return kept + "…" + reset
+        visible += start - pos
+        pos = end
+    return line
+
+
 def failure_excerpt(tail: str, max_lines: int = 8) -> str:
     """The interesting part of a failed build's output: the builder's
     log lines (name>-prefixed from internal-json, deduped against
@@ -419,9 +443,9 @@ def failure_excerpt(tail: str, max_lines: int = 8) -> str:
             reason = raw
         elif plain and not _EXCERPT_NOISE.match(plain):
             other.setdefault(plain, raw)
-    lines = list((quoted or other).values())[-max_lines:]
+    lines = [_limit_line(x) for x in list((quoted or other).values())[-max_lines:]]
     if reason:
-        lines.append(reason)
+        lines.append(_limit_line(reason))
     return "\n".join(lines)
 
 

--- a/nixbot/nixbot/forge/base.py
+++ b/nixbot/nixbot/forge/base.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import httpx
 
+from nixbot.forge.retry import make_client
 from nixbot.gitrepo import FetchCredentials
 
 if TYPE_CHECKING:
@@ -85,7 +86,7 @@ class TokenForgeClient:
     ) -> None:
         self.instance_url = instance_url.rstrip("/")
         self.token = token
-        self.http = http or httpx.AsyncClient()
+        self.http = http or make_client()
 
     def auth_headers(self) -> dict[str, str]:
         raise NotImplementedError

--- a/nixbot/nixbot/forge/github.py
+++ b/nixbot/nixbot/forge/github.py
@@ -25,6 +25,7 @@ import httpx
 from nixbot.gitrepo import FetchCredentials
 
 from .base import DiscoveredRepo, ForgeError, paginate_link, paginate_link_pages
+from .retry import make_client
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -94,7 +95,7 @@ class GitHubAppClient:
         self.app_id = app_id
         self.private_key_file = private_key_file
         self.api_url = api_url
-        self.http = http or httpx.AsyncClient()
+        self.http = http or make_client()
         self._jwt: _CachedToken | None = None
         # Keyed by (installation id, repo scope); None = installation-wide.
         self._installation_tokens: dict[

--- a/nixbot/nixbot/forge/retry.py
+++ b/nixbot/nixbot/forge/retry.py
@@ -1,0 +1,96 @@
+"""Transport-level retry for forge HTTP clients.
+
+Wrapping the transport means every forge call (single GETs, paginated
+listings, token minting) inherits retries without changing call sites.
+Network errors and transient 5xx are retried with exponential backoff;
+a Retry-After hint is always honored. Waits are capped by a cumulative
+budget: longer rate-limit hints are handed back to the caller so the
+durable status-poster path can pace them instead of blocking here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import math
+import time
+from email.utils import parsedate_to_datetime
+
+import httpx
+
+_RETRYABLE_STATUS = frozenset(range(500, 600))
+
+
+def retry_after_seconds(response: httpx.Response) -> float | None:
+    """Delay a forge asks us to wait before retrying, from Retry-After
+    (seconds or HTTP-date) or a GitHub rate-limit reset epoch."""
+    value = response.headers.get("Retry-After")
+    if value is not None:
+        try:
+            seconds = float(value)
+            # float() accepts nan/inf; nan would poison every later
+            # min/max comparison down to asyncio.sleep.
+            if math.isfinite(seconds):
+                return max(0.0, seconds)
+        except ValueError:
+            with contextlib.suppress(TypeError, ValueError):
+                dt = parsedate_to_datetime(value)
+                return max(0.0, dt.timestamp() - time.time())
+    # GitHub primary rate limits: no Retry-After, only a reset epoch.
+    if response.headers.get("X-RateLimit-Remaining") == "0":
+        with contextlib.suppress(TypeError, ValueError):
+            reset = int(response.headers["X-RateLimit-Reset"])
+            return max(0.0, reset - time.time())
+    return None
+
+
+class RetryTransport(httpx.AsyncBaseTransport):
+    """Exponential backoff capped by a cumulative delay budget, always
+    honoring a forge's Retry-After hint when present."""
+
+    def __init__(
+        self,
+        wrapped: httpx.AsyncBaseTransport,
+        *,
+        base_delay: float = 0.1,
+        max_cumulative_delay: float = 30.0,
+    ) -> None:
+        self._wrapped = wrapped
+        self._base_delay = base_delay
+        self._max_cumulative_delay = max_cumulative_delay
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        slept = 0.0
+        attempt = 0
+        while True:
+            backoff = self._base_delay * 2**attempt
+            try:
+                response = await self._wrapped.handle_async_request(request)
+            except httpx.TransportError:
+                delay = backoff
+                if slept + delay > self._max_cumulative_delay:
+                    raise
+            else:
+                # A Retry-After hint (on 429 or 503) always wins over the
+                # backoff schedule; otherwise retry only transient 5xx.
+                hint = retry_after_seconds(response)
+                delay = max(backoff, hint or 0.0)
+                retryable = (
+                    hint is not None or response.status_code in _RETRYABLE_STATUS
+                )
+                if not retryable or slept + delay > self._max_cumulative_delay:
+                    return response
+                # Discard the body so the connection can be reused.
+                await response.aread()
+                await response.aclose()
+            await asyncio.sleep(delay)
+            slept += delay
+            attempt += 1
+
+    async def aclose(self) -> None:
+        await self._wrapped.aclose()
+
+
+def make_client() -> httpx.AsyncClient:
+    """An httpx client that retries transient forge failures."""
+    return httpx.AsyncClient(transport=RetryTransport(httpx.AsyncHTTPTransport()))

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -27,13 +27,9 @@ Target URLs point at the service's own URL scheme
 
 from __future__ import annotations
 
-import contextlib
 import logging
-import math
-import time
 from collections import OrderedDict
 from datetime import UTC, datetime
-from email.utils import parsedate_to_datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar, Protocol
 from urllib.parse import quote
@@ -43,6 +39,7 @@ import httpx
 from .ansi import strip_ansi
 from .db_gen import failed as q
 from .forge import ForgeError
+from .forge.retry import retry_after_seconds
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -94,31 +91,10 @@ class CheckPermissionError(ForgeError):
     hammering the API until the operator fixes the permission."""
 
 
-def _retry_after_seconds(response: httpx.Response) -> float | None:
-    value = response.headers.get("Retry-After")
-    if value is not None:
-        try:
-            seconds = float(value)
-            # float() accepts nan/inf; nan would poison every later
-            # min/max comparison down to asyncio.sleep.
-            if math.isfinite(seconds):
-                return max(0.0, seconds)
-        except ValueError:
-            with contextlib.suppress(TypeError, ValueError):
-                dt = parsedate_to_datetime(value)
-                return max(0.0, dt.timestamp() - time.time())
-    # GitHub primary rate limits: no Retry-After, only a reset epoch.
-    if response.headers.get("X-RateLimit-Remaining") == "0":
-        with contextlib.suppress(TypeError, ValueError):
-            reset = int(response.headers["X-RateLimit-Reset"])
-            return max(0.0, reset - time.time())
-    return None
-
-
 def _raise_for_status(response: httpx.Response, repo: str) -> None:
     if response.status_code >= httpx.codes.BAD_REQUEST:
         msg = f"status post for {repo} failed: HTTP {response.status_code}"
-        raise StatusPostError(msg, retry_after=_retry_after_seconds(response))
+        raise StatusPostError(msg, retry_after=retry_after_seconds(response))
 
 
 class CommitStatusPoster(Protocol):

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import nixbot.executor as executor_mod
+from nixbot.ansi import strip_ansi
 from nixbot.build_scheduler import BuildOutcome
 from nixbot.executor import (
     FRAME_FLUSH_THRESHOLD,
@@ -597,6 +598,34 @@ def test_failure_excerpt_without_log_lines_keeps_filtered_tail() -> None:
     excerpt = failure_excerpt(tail)
     assert "required to build" in excerpt
     assert "3 available machines" in excerpt
+
+
+def test_failure_excerpt_truncates_overlong_lines() -> None:
+    long = "x" * 2000
+    excerpt = failure_excerpt(f"fail-1> {long}\nReason: nope.\n")
+    log_line = excerpt.splitlines()[0]
+    # Visible length capped; ellipsis marks the cut.
+    assert log_line.endswith("…")
+    assert len(strip_ansi(log_line)) <= 650
+
+
+def test_failure_excerpt_truncates_overlong_reason() -> None:
+    excerpt = failure_excerpt(f"Reason: {'z' * 2000}\n")
+    assert len(strip_ansi(excerpt)) <= 650
+    assert excerpt.endswith("…")
+
+
+def test_failure_excerpt_keeps_ansi_when_truncating() -> None:
+    # ANSI codes must not count toward the length budget and must
+    # survive truncation intact.
+    body = "\x1b[31m" + "y" * 2000 + "\x1b[0m"
+    excerpt = failure_excerpt(f"fail-1> {body}\n")
+    log_line = excerpt.splitlines()[0]
+    assert "\x1b[31m" in log_line
+    assert len(strip_ansi(log_line)) <= 650
+    # Truncation drops the source line's own reset; a reset is
+    # re-appended so red does not bleed into the following line.
+    assert log_line.endswith("\x1b[0m")
 
 
 async def test_iter_lines_survives_line_over_stream_limit() -> None:

--- a/nixbot/nixbot/tests/test_forge_retry.py
+++ b/nixbot/nixbot/tests/test_forge_retry.py
@@ -1,0 +1,126 @@
+"""RetryTransport: transient forge failures are retried, permanent
+ones and rate limits are passed straight through."""
+
+# ruff: noqa: PLR2004, ARG001 (status codes and unused handler args are fine in tests)
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from nixbot.forge.retry import RetryTransport
+
+
+def _client(handler: httpx.MockTransport) -> httpx.AsyncClient:
+    # Tiny delays keep the test fast while still exercising the budget.
+    transport = RetryTransport(handler, base_delay=0.0, max_cumulative_delay=1.0)
+    return httpx.AsyncClient(transport=transport)
+
+
+async def test_retries_transient_5xx_then_succeeds() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200 if calls >= 3 else 503)
+
+    async with _client(httpx.MockTransport(handler)) as http:
+        response = await http.get("https://forge/x")
+    assert response.status_code == 200
+    assert calls == 3
+
+
+async def test_retries_network_errors() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        msg = "boom"
+        nonlocal calls
+        calls += 1
+        if calls < 2:
+            raise httpx.ConnectError(msg)
+        return httpx.Response(200)
+
+    async with _client(httpx.MockTransport(handler)) as http:
+        response = await http.get("https://forge/x")
+    assert response.status_code == 200
+    assert calls == 2
+
+
+async def test_retries_429_when_retry_after_fits_budget() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(429, headers={"Retry-After": "0"})
+        return httpx.Response(200)
+
+    async with _client(httpx.MockTransport(handler)) as http:
+        response = await http.get("https://forge/x")
+    assert response.status_code == 200
+    assert calls == 2
+
+
+async def test_gives_up_immediately_when_retry_after_exceeds_budget() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        # A long rate-limit hint (over the budget) is handed straight
+        # back so the durable status-poster path can honor it instead.
+        return httpx.Response(429, headers={"Retry-After": "3600"})
+
+    async with _client(httpx.MockTransport(handler)) as http:
+        response = await http.get("https://forge/x")
+    assert response.status_code == 429
+    assert calls == 1
+
+
+async def test_does_not_retry_plain_client_errors() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        # No Retry-After hint: a 4xx is permanent, not retried.
+        return httpx.Response(404)
+
+    async with _client(httpx.MockTransport(handler)) as http:
+        response = await http.get("https://forge/x")
+    assert response.status_code == 404
+    assert calls == 1
+
+
+async def test_gives_up_after_budget_and_returns_last_response() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(500)
+
+    transport = RetryTransport(
+        httpx.MockTransport(handler), base_delay=0.5, max_cumulative_delay=1.0
+    )
+    async with httpx.AsyncClient(transport=transport) as http:
+        response = await http.get("https://forge/x")
+    # 0.5 + 1.0 exceeds the 1.0 budget on the second backoff, so two tries.
+    assert response.status_code == 500
+    assert calls == 2
+
+
+async def test_reraises_when_network_errors_exhaust_budget() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        msg = "boom"
+        raise httpx.ConnectError(msg)
+
+    transport = RetryTransport(
+        httpx.MockTransport(handler), base_delay=0.5, max_cumulative_delay=1.0
+    )
+    async with httpx.AsyncClient(transport=transport) as http:
+        with pytest.raises(httpx.ConnectError):
+            await http.get("https://forge/x")


### PR DESCRIPTION

Only status posting handled forge unavailability; other calls
(discovery, pagination, token minting) raised on the first network
error or 5xx, so a brief GitHub blip failed the whole operation.

Wrap the forge HTTP transport so all calls inherit exponential backoff,
capped by a cumulative delay budget. Network errors and transient 5xx
are retried; a Retry-After hint (429 or 503) is always honored, and
hints over the budget are handed back for the durable status poster to
pace. The Retry-After parser is shared with the status poster.
