### PR TITLE
Fancy logs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "lint": {
+    "exclude": ["nixbot/nixbot/web/static/vendor"]
+  }
+}

--- a/formatter/treefmt.nix
+++ b/formatter/treefmt.nix
@@ -39,6 +39,19 @@
     );
     includes = [ "*.css" ];
   };
+  # Lint + type-check the hand-written browser JS (deno fmt owns formatting).
+  # checkJs + DOM libs come from ./deno.json; vendored code is excluded.
+  settings.formatter.deno-check = {
+    command = lib.getExe (
+      pkgs.writeShellScriptBin "deno-check" ''
+        export DENO_DIR="''${DENO_DIR:-$(mktemp -d)}"
+        ${lib.getExe pkgs.deno} lint "$@"
+        exec ${lib.getExe pkgs.deno} check "$@"
+      ''
+    );
+    includes = [ "nixbot/nixbot/web/static/*.js" ];
+    excludes = [ "nixbot/nixbot/web/static/vendor/*" ];
+  };
   programs.ruff.check = true;
   programs.ruff.format = true;
   settings.formatter.shellcheck.options = [

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -607,7 +607,8 @@ class _OrchestratorExecutor:
         # web layer renders it, the API strips it.
         error = None
         if status == AttributeStatus.failed:
-            error = failure_excerpt(writer.tail_lines()) or None
+            structured = writer.capture.failure_excerpt() if writer.capture else ""
+            error = structured or failure_excerpt(writer.tail_lines()) or None
         result = AttributeResult(
             attr=job.attr,
             status=status,

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -606,14 +606,20 @@ class _OrchestratorExecutor:
         # answers "why" without a click into the log. ANSI stays: the
         # web layer renders it, the API strips it.
         error = None
+        failure = None
         if status == AttributeStatus.failed:
-            structured = writer.capture.failure_excerpt() if writer.capture else ""
-            error = structured or failure_excerpt(writer.tail_lines()) or None
+            failure = writer.capture.build_failure() if writer.capture else None
+            error = (
+                (failure.as_text() if failure else "")
+                or failure_excerpt(writer.tail_lines())
+                or None
+            )
         result = AttributeResult(
             attr=job.attr,
             status=status,
             job=job,
             error=error,
+            failure=failure,
             out_path=job.outputs.get("out"),
             drv_path=job.drv_path,
             system=job.system,

--- a/nixbot/nixbot/build_scheduler.py
+++ b/nixbot/nixbot/build_scheduler.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from datetime import datetime
 
+from .ansi import strip_ansi
 from .models import (
     CacheStatus,
     NixEvalJob,
@@ -41,6 +42,33 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DrvFailure:
+    name: str
+    tail: list[str]
+
+
+@dataclass
+class BuildFailure:
+    drvs: list[DrvFailure]
+    total: int  # includes drvs beyond the cap, for the "… N more" footer
+
+    def as_text(self) -> str:
+        blocks = [f"{d.name}:\n" + "\n".join(d.tail) for d in self.drvs]
+        extra = self.total - len(self.drvs)
+        if extra > 0:
+            blocks.append(f"… and {extra} more failed derivation{'s' * (extra > 1)}")
+        return "\n\n".join(blocks)
+
+    def headline(self, limit: int = 200) -> str:
+        for drv in reversed(self.drvs):
+            for line in reversed(drv.tail):
+                stripped = strip_ansi(line).strip()
+                if stripped:
+                    return stripped[:limit]
+        return ""
 
 
 class BuildOutcome(StrEnum):
@@ -104,6 +132,8 @@ class AttributeResult:
     status: AttributeStatus
     job: NixEvalJob
     error: str | None = None
+    # Structured, in-memory only; None for container-less failures.
+    failure: BuildFailure | None = None
     # Attr of the dependency whose failure propagated here.
     dependency_attr: str | None = None
     # Link to the first failing build for cached failures.

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -471,10 +471,11 @@ class StructuredCapture:
 
     Activity ids map to full drv paths; log lines, phases and stop
     timestamps attach to the owning derivation. Unattributed output (nix's
-    own messages) collects under a synthetic ``driver`` derivation.
+    own evaluation/scheduling/copy messages) collects under a synthetic
+    ``setup`` entry.
     """
 
-    DRIVER = "<driver>"
+    SETUP = "<setup>"
 
     def __init__(
         self, clock: Callable[[], float] = time.time, max_lines: int | None = None
@@ -486,7 +487,7 @@ class StructuredCapture:
         )
         self._clock = clock
         self._act: dict[int, str] = {}
-        self._idx: dict[str, int] = {self.DRIVER: 0}
+        self._idx: dict[str, int] = {self.SETUP: 0}
         # Monotonic per-derivation line counter for live delta numbering:
         # the container's line count stops growing once a drv hits its
         # retention cap, which would repeat delta "from" and collide row
@@ -495,7 +496,7 @@ class StructuredCapture:
         self._running: set[str] = set()
         self._subs: list[asyncio.Queue[dict | None]] = []
         self._closed = False
-        self._w.register(self.DRIVER, "driver")
+        self._w.register(self.SETUP, "setup")
 
     def _ts(self) -> int:
         return int(self._clock() * 1000)
@@ -566,7 +567,7 @@ class StructuredCapture:
         return self._seen[drv]
 
     def log_line(self, act_id: int, text: str) -> None:
-        drv = self._act.get(act_id, self.DRIVER)
+        drv = self._act.get(act_id, self.SETUP)
         self._w.line(drv, text, ts=self._ts())
         self._emit(
             {
@@ -578,7 +579,7 @@ class StructuredCapture:
         )
 
     def phase(self, act_id: int, name: str) -> None:
-        drv = self._act.get(act_id, self.DRIVER)
+        drv = self._act.get(act_id, self.SETUP)
         self._w.phase(drv, name, ts=self._ts())
         self._emit(
             {
@@ -596,10 +597,10 @@ class StructuredCapture:
             self._running.discard(drv)
             self._emit({"t": "status", "idx": self._idx.get(drv, 0), "status": "built"})
 
-    def driver_line(self, text: str) -> None:
-        self._w.line(self.DRIVER, text, ts=self._ts())
+    def setup_line(self, text: str) -> None:
+        self._w.line(self.SETUP, text, ts=self._ts())
         self._emit(
-            {"t": "line", "idx": 0, "from": self._bump(self.DRIVER), "text": text}
+            {"t": "line", "idx": 0, "from": self._bump(self.SETUP), "text": text}
         )
 
     def set_status(self, drv_path: str, status: str) -> None:
@@ -631,7 +632,7 @@ def _feed_capture(event: Any, capture: StructuredCapture) -> None:
     elif action == "stop":
         capture.stop(event.get("id"))
     elif action == "msg" and event.get("msg"):
-        capture.driver_line(event["msg"])
+        capture.setup_line(event["msg"])
 
 
 def _render_event(event: Any, activities: dict[int, str]) -> bytes | None:
@@ -668,7 +669,7 @@ def render_log_event(
     """
     if not line.startswith(b"@nix "):
         if capture is not None and line.strip():
-            capture.driver_line(line.decode(errors="replace").rstrip("\n"))
+            capture.setup_line(line.decode(errors="replace").rstrip("\n"))
         return line  # not an event: pass through (e.g. daemon chatter)
     try:
         event = json.loads(line[len(b"@nix ") :])

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -37,7 +37,7 @@ from urllib.parse import quote
 import zstandard
 
 from .ansi import ANSI_TOKEN_RE, strip_ansi
-from .build_scheduler import BuildOutcome
+from .build_scheduler import BuildFailure, BuildOutcome, DrvFailure
 from .gcroots import safe_attr_filename
 from .logstore import LogContainerWriter
 from .proc import ProcessGroup
@@ -403,6 +403,18 @@ def build_nix_command(
 # nix names failures only in prose: "build of" (remote) / "builder for" (local).
 _BUILD_FAILED = re.compile(r"(?:build of|builder for) '([^']+\.drv)'.*?failed")
 _PHASE_MARKER = re.compile(r"Running phase: ")
+
+
+def _clean_tail(lines: list[str], max_lines: int) -> list[str]:
+    # Phase markers are stdenv chrome already shown in the phase bar.
+    kept = [
+        _limit_line(line)
+        for line in lines
+        if line.strip() and not _PHASE_MARKER.match(strip_ansi(line))
+    ]
+    return kept[-max_lines:]
+
+
 _QUOTED_LINE = re.compile(r"[^\s>]*> +(.*\S)")
 _EXCERPT_NOISE = re.compile(
     r"Output paths:|/nix/store/\S+$|Last \d+ log lines:"
@@ -624,31 +636,22 @@ class StructuredCapture:
         self._running.discard(drv_path)
         self._emit({"t": "status", "idx": self._idx[drv_path], "status": status})
 
-    def failure_excerpt(self, max_lines: int = 8, max_drvs: int = 3) -> str:
-        """Each failed derivation's own tail under a name header, capped
-        to `max_drvs` with the rest counted."""
+    def build_failure(
+        self, max_lines: int = 8, max_drvs: int = 3
+    ) -> BuildFailure | None:
         failing = self._w.failing()
         if not failing:
-            return ""
-        blocks = []
-        for name, lines in failing[-max_drvs:]:
-            # Phase markers are stdenv chrome already shown in the phase
-            # bar; keep the excerpt to real output.
-            kept = [
-                line
-                for line in lines
-                if line.strip() and not _PHASE_MARKER.match(strip_ansi(line))
-            ]
-            tail = kept[-max_lines:]
-            if tail:
-                body = "\n".join(_limit_line(line) for line in tail)
-                blocks.append(f"{name}:\n{body}")
-        dropped = max(0, len(failing) - max_drvs)
-        if dropped:
-            blocks.append(
-                f"… and {dropped} more failed derivation{'s' * (dropped > 1)}"
-            )
-        return "\n\n".join(blocks)
+            return None
+        drvs = [
+            DrvFailure(name, tail)
+            for name, lines in failing[-max_drvs:]
+            if (tail := _clean_tail(lines, max_lines))
+        ]
+        return BuildFailure(drvs=drvs, total=len(failing))
+
+    def failure_excerpt(self, max_lines: int = 8, max_drvs: int = 3) -> str:
+        failure = self.build_failure(max_lines, max_drvs)
+        return failure.as_text() if failure else ""
 
     def finalize(self) -> bytes:
         return self._w.finalize()

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -400,6 +400,9 @@ def build_nix_command(
     ]
 
 
+# nix names failures only in prose: "build of" (remote) / "builder for" (local).
+_BUILD_FAILED = re.compile(r"(?:build of|builder for) '([^']+\.drv)'.*?failed")
+_PHASE_MARKER = re.compile(r"Running phase: ")
 _QUOTED_LINE = re.compile(r"[^\s>]*> +(.*\S)")
 _EXCERPT_NOISE = re.compile(
     r"Output paths:|/nix/store/\S+$|Last \d+ log lines:"
@@ -602,6 +605,11 @@ class StructuredCapture:
         self._emit(
             {"t": "line", "idx": 0, "from": self._bump(self.SETUP), "text": text}
         )
+        # --keep-going: mark every failed drv, not just the top-level one.
+        for m in _BUILD_FAILED.finditer(strip_ansi(text)):
+            drv = m.group(1)
+            if drv in self._idx:
+                self.set_status(drv, "failed")
 
     def set_status(self, drv_path: str, status: str) -> None:
         if drv_path not in self._idx:
@@ -615,6 +623,32 @@ class StructuredCapture:
         self._w.status(drv_path, status)
         self._running.discard(drv_path)
         self._emit({"t": "status", "idx": self._idx[drv_path], "status": status})
+
+    def failure_excerpt(self, max_lines: int = 8, max_drvs: int = 3) -> str:
+        """Each failed derivation's own tail under a name header, capped
+        to `max_drvs` with the rest counted."""
+        failing = self._w.failing()
+        if not failing:
+            return ""
+        blocks = []
+        for name, lines in failing[-max_drvs:]:
+            # Phase markers are stdenv chrome already shown in the phase
+            # bar; keep the excerpt to real output.
+            kept = [
+                line
+                for line in lines
+                if line.strip() and not _PHASE_MARKER.match(strip_ansi(line))
+            ]
+            tail = kept[-max_lines:]
+            if tail:
+                body = "\n".join(_limit_line(line) for line in tail)
+                blocks.append(f"{name}:\n{body}")
+        dropped = max(0, len(failing) - max_drvs)
+        if dropped:
+            blocks.append(
+                f"… and {dropped} more failed derivation{'s' * (dropped > 1)}"
+            )
+        return "\n\n".join(blocks)
 
     def finalize(self) -> bytes:
         return self._w.finalize()

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -28,9 +28,10 @@ import io
 import json
 import logging
 import re
+import time
 from collections import OrderedDict, deque
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import zstandard
@@ -38,10 +39,11 @@ import zstandard
 from .ansi import ANSI_TOKEN_RE, strip_ansi
 from .build_scheduler import BuildOutcome
 from .gcroots import safe_attr_filename
+from .logstore import LogContainerWriter
 from .proc import ProcessGroup
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Callable
     from pathlib import Path
 
     from .models import NixEvalJobSuccess
@@ -452,6 +454,7 @@ def failure_excerpt(tail: str, max_lines: int = 8) -> str:
 # nix activity/result types (nix/util/logging.hh).
 ACT_BUILD = 105
 RES_BUILD_LOG_LINE = 101
+RES_SET_PHASE = 104
 
 
 def _drv_display_name(drv_path: str) -> str:
@@ -460,19 +463,66 @@ def _drv_display_name(drv_path: str) -> str:
     return name or drv_path
 
 
-def render_log_event(line: bytes, activities: dict[int, str]) -> bytes | None:
-    """One line of `nix build --log-format internal-json` to log text.
+class StructuredCapture:
+    """Demux the internal-json stream into a per-derivation container.
 
-    Build-log lines get a `name> ` prefix from their build activity;
-    nix's own messages pass through with their ANSI colors. Returns
-    None for events with no log output (progress, stops, ...).
+    Activity ids map to full drv paths; log lines, phases and stop
+    timestamps attach to the owning derivation. Unattributed output (nix's
+    own messages) collects under a synthetic ``driver`` derivation.
     """
-    if not line.startswith(b"@nix "):
-        return line  # not an event: pass through (e.g. daemon chatter)
-    try:
-        event = json.loads(line[len(b"@nix ") :])
-    except ValueError:
-        return line
+
+    DRIVER = "<driver>"
+
+    def __init__(self, clock: Callable[[], float] = time.time) -> None:
+        self._w = LogContainerWriter()
+        self._clock = clock
+        self._act: dict[int, str] = {}
+        self._w.register(self.DRIVER, "driver")
+
+    def _ts(self) -> int:
+        return int(self._clock() * 1000)
+
+    def start_build(self, act_id: int, drv_path: str) -> None:
+        self._act[act_id] = drv_path
+        self._w.register(drv_path, _drv_display_name(drv_path))
+
+    def log_line(self, act_id: int, text: str) -> None:
+        self._w.line(self._act.get(act_id, self.DRIVER), text, ts=self._ts())
+
+    def phase(self, act_id: int, name: str) -> None:
+        self._w.phase(self._act.get(act_id, self.DRIVER), name, ts=self._ts())
+
+    def stop(self, act_id: int) -> None:
+        drv = self._act.get(act_id)
+        if drv is not None:
+            self._w.stop(drv, self._ts())
+
+    def driver_line(self, text: str) -> None:
+        self._w.line(self.DRIVER, text, ts=self._ts())
+
+    def set_status(self, drv_path: str, status: str) -> None:
+        self._w.status(drv_path, status)
+
+    def finalize(self) -> bytes:
+        return self._w.finalize()
+
+
+def _feed_capture(event: Any, capture: StructuredCapture) -> None:
+    action, etype = event.get("action"), event.get("type")
+    fields = event.get("fields") or []
+    if action == "start" and etype == ACT_BUILD and fields:
+        capture.start_build(event["id"], str(fields[0]))
+    elif action == "result" and etype == RES_BUILD_LOG_LINE:
+        capture.log_line(event.get("id"), (fields or [""])[0])
+    elif action == "result" and etype == RES_SET_PHASE and fields and fields[0]:
+        capture.phase(event.get("id"), str(fields[0]))
+    elif action == "stop":
+        capture.stop(event.get("id"))
+    elif action == "msg" and event.get("msg"):
+        capture.driver_line(event["msg"])
+
+
+def _render_event(event: Any, activities: dict[int, str]) -> bytes | None:
     action = event.get("action")
     if action == "start" and event.get("type") == ACT_BUILD:
         fields = event.get("fields") or []
@@ -491,16 +541,45 @@ def render_log_event(line: bytes, activities: dict[int, str]) -> bytes | None:
     return None
 
 
+def render_log_event(
+    line: bytes,
+    activities: dict[int, str],
+    capture: StructuredCapture | None = None,
+) -> bytes | None:
+    """One line of `nix build --log-format internal-json` to log text.
+
+    Build-log lines get a `name> ` prefix from their build activity;
+    nix's own messages pass through with their ANSI colors. Returns
+    None for events with no log output (progress, stops, ...). When
+    `capture` is given, the same parsed event also feeds the structured
+    per-derivation container (phases and stop timestamps included).
+    """
+    if not line.startswith(b"@nix "):
+        if capture is not None and line.strip():
+            capture.driver_line(line.decode(errors="replace").rstrip("\n"))
+        return line  # not an event: pass through (e.g. daemon chatter)
+    try:
+        event = json.loads(line[len(b"@nix ") :])
+    except ValueError:
+        return line
+    if capture is not None:
+        _feed_capture(event, capture)
+    return _render_event(event, activities)
+
+
 def is_transient_error(output_tail: str) -> bool:
     return any(marker in output_tail for marker in TRANSIENT_ERROR_MARKERS)
 
 
 async def _pump_output(
-    stream: asyncio.StreamReader, output_tail: deque[bytes], log_writer: LogWriter
+    stream: asyncio.StreamReader,
+    output_tail: deque[bytes],
+    log_writer: LogWriter,
+    capture: StructuredCapture | None = None,
 ) -> None:
     activities: dict[int, str] = {}
     async for raw in iter_lines(stream):
-        line = render_log_event(raw, activities)
+        line = render_log_event(raw, activities, capture)
         if line is None:
             continue
         output_tail.append(line)
@@ -594,8 +673,9 @@ class NixBuildExecutor:
         assert proc.stdout is not None  # noqa: S101
 
         output_tail: deque[bytes] = deque(maxlen=100)
+        capture = StructuredCapture()
         pump_task = asyncio.create_task(
-            _pump_output(proc.stdout, output_tail, log_writer)
+            _pump_output(proc.stdout, output_tail, log_writer, capture)
         )
         cancel_task = asyncio.create_task(cancel_event.wait())
         try:
@@ -614,14 +694,21 @@ class NixBuildExecutor:
                     f"\n\nnixbot: build timed out after "
                     f"{self.settings.timeout}s\n\n".encode()
                 )
+                await _finalize_container(
+                    capture, log_writer, job.drv_path, failed=True
+                )
                 # Timeouts are genuine failures (cached when enabled).
                 return BuildOutcome.failure, False
             if proc.returncode == 0:
                 # Even when the kill raced a clean exit: the build
                 # finished, the result is real.
+                await _finalize_container(
+                    capture, log_writer, job.drv_path, failed=False
+                )
                 return BuildOutcome.success, False
             if cancel_event.is_set():
                 return BuildOutcome.cancelled, False
+            await _finalize_container(capture, log_writer, job.drv_path, failed=True)
             tail_text = b"".join(output_tail).decode(errors="replace")
             return BuildOutcome.failure, is_transient_error(tail_text)
         finally:
@@ -636,6 +723,22 @@ class NixBuildExecutor:
                 with contextlib.suppress(asyncio.CancelledError):
                     await pump_task
                 await group.reap()
+
+
+def container_path(log_path: Path) -> Path:
+    return log_path.with_name(log_path.name + ".nbl1")
+
+
+async def _finalize_container(
+    capture: StructuredCapture,
+    log_writer: LogWriter,
+    drv_path: str,
+    *,
+    failed: bool,
+) -> None:
+    capture.set_status(drv_path, "failed" if failed else "built")
+    blob = capture.finalize()
+    await asyncio.to_thread(container_path(log_writer.path).write_bytes, blob)
 
 
 def read_log(path: Path) -> bytes:

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -57,6 +57,7 @@ STREAM_LIMIT = 16 * 1024 * 1024
 # Cap per-subscriber backlog so a stalled SSE client cannot buffer the
 # whole build output in memory; the oldest chunks are dropped.
 SUBSCRIBER_QUEUE_MAXSIZE = 256
+STRUCTURED_QUEUE_MAXSIZE = 4096  # per-line deltas, chattier than byte chunks
 RECENT_BUFFER_SIZE = 4096
 
 # Batch log output into zstd frames of at least this size; one frame
@@ -202,6 +203,8 @@ class LogWriter:
     bytes_seen: int = 0
     truncated: bool = False
     closed: bool = False
+    # Live capture, so the web layer can stream per-derivation deltas.
+    capture: StructuredCapture | None = None
     _head_budget: int = field(init=False)
     _tail: deque[bytes] = field(default_factory=deque)
     _tail_size: int = 0
@@ -473,35 +476,144 @@ class StructuredCapture:
 
     DRIVER = "<driver>"
 
-    def __init__(self, clock: Callable[[], float] = time.time) -> None:
-        self._w = LogContainerWriter()
+    def __init__(
+        self, clock: Callable[[], float] = time.time, max_lines: int | None = None
+    ) -> None:
+        self._w = (
+            LogContainerWriter(max_lines=max_lines)
+            if max_lines is not None
+            else LogContainerWriter()
+        )
         self._clock = clock
         self._act: dict[int, str] = {}
+        self._idx: dict[str, int] = {self.DRIVER: 0}
+        # Monotonic per-derivation line counter for live delta numbering:
+        # the container's line count stops growing once a drv hits its
+        # retention cap, which would repeat delta "from" and collide row
+        # ids. Live ids are ephemeral (the finish reload renumbers).
+        self._seen: dict[str, int] = {}
+        self._running: set[str] = set()
+        self._subs: list[asyncio.Queue[dict | None]] = []
+        self._closed = False
         self._w.register(self.DRIVER, "driver")
 
     def _ts(self) -> int:
         return int(self._clock() * 1000)
 
+    @staticmethod
+    def _put(q: asyncio.Queue[dict | None], item: dict | None) -> None:
+        # Drop the oldest delta for a stalled subscriber rather than grow
+        # unbounded; the missing line is a cosmetic gap the finish reload
+        # heals. Matches LogWriter's stalled-subscriber policy.
+        while True:
+            try:
+                q.put_nowait(item)
+            except asyncio.QueueFull:
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    q.get_nowait()
+            else:
+                return
+
+    def _emit(self, delta: dict) -> None:
+        for q in self._subs:
+            self._put(q, delta)
+
+    def subscribe(self) -> asyncio.Queue[dict | None]:
+        """Live deltas for a viewer; a full snapshot comes from state().
+        Subscribe then snapshot with no await between so no delta is lost
+        or duplicated (single event loop, atomic)."""
+        q: asyncio.Queue[dict | None] = asyncio.Queue(maxsize=STRUCTURED_QUEUE_MAXSIZE)
+        if self._closed:
+            q.put_nowait(None)
+        else:
+            self._subs.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue[dict | None]) -> None:
+        with contextlib.suppress(ValueError):
+            self._subs.remove(q)
+
+    def state(self) -> list[dict]:
+        st = self._w.state()
+        for e in st:
+            if e["idx"] in self._running_idx:
+                e["status"] = "running"
+        return st
+
+    @property
+    def _running_idx(self) -> set[int]:
+        return {self._idx[d] for d in self._running if d in self._idx}
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for q in self._subs:
+            self._put(q, None)
+        self._subs.clear()
+
     def start_build(self, act_id: int, drv_path: str) -> None:
         self._act[act_id] = drv_path
-        self._w.register(drv_path, _drv_display_name(drv_path))
+        name = _drv_display_name(drv_path)
+        self._w.register(drv_path, name)
+        if drv_path not in self._idx:
+            self._idx[drv_path] = len(self._idx)
+        self._running.add(drv_path)
+        self._emit({"t": "drv", "idx": self._idx[drv_path], "name": name})
+
+    def _bump(self, drv: str) -> int:
+        self._seen[drv] = self._seen.get(drv, 0) + 1
+        return self._seen[drv]
 
     def log_line(self, act_id: int, text: str) -> None:
-        self._w.line(self._act.get(act_id, self.DRIVER), text, ts=self._ts())
+        drv = self._act.get(act_id, self.DRIVER)
+        self._w.line(drv, text, ts=self._ts())
+        self._emit(
+            {
+                "t": "line",
+                "idx": self._idx.get(drv, 0),
+                "from": self._bump(drv),
+                "text": text,
+            }
+        )
 
     def phase(self, act_id: int, name: str) -> None:
-        self._w.phase(self._act.get(act_id, self.DRIVER), name, ts=self._ts())
+        drv = self._act.get(act_id, self.DRIVER)
+        self._w.phase(drv, name, ts=self._ts())
+        self._emit(
+            {
+                "t": "phase",
+                "idx": self._idx.get(drv, 0),
+                "phase": name,
+                "line": self._seen.get(drv, 0),
+            }
+        )
 
     def stop(self, act_id: int) -> None:
         drv = self._act.get(act_id)
         if drv is not None:
             self._w.stop(drv, self._ts())
+            self._running.discard(drv)
+            self._emit({"t": "status", "idx": self._idx.get(drv, 0), "status": "built"})
 
     def driver_line(self, text: str) -> None:
         self._w.line(self.DRIVER, text, ts=self._ts())
+        self._emit(
+            {"t": "line", "idx": 0, "from": self._bump(self.DRIVER), "text": text}
+        )
 
     def set_status(self, drv_path: str, status: str) -> None:
+        if drv_path not in self._idx:
+            # Finalized with no build activity (e.g. substituted): register
+            # now so the live delta lands on a card. Appended last, so its
+            # index equals its container position.
+            name = _drv_display_name(drv_path)
+            self._w.register(drv_path, name)
+            self._idx[drv_path] = len(self._idx)
+            self._emit({"t": "drv", "idx": self._idx[drv_path], "name": name})
         self._w.status(drv_path, status)
+        self._running.discard(drv_path)
+        self._emit({"t": "status", "idx": self._idx[drv_path], "status": status})
 
     def finalize(self) -> bytes:
         return self._w.finalize()
@@ -674,6 +786,7 @@ class NixBuildExecutor:
 
         output_tail: deque[bytes] = deque(maxlen=100)
         capture = StructuredCapture()
+        log_writer.capture = capture
         pump_task = asyncio.create_task(
             _pump_output(proc.stdout, output_tail, log_writer, capture)
         )
@@ -712,6 +825,9 @@ class NixBuildExecutor:
             tail_text = b"".join(output_tail).decode(errors="replace")
             return BuildOutcome.failure, is_transient_error(tail_text)
         finally:
+            # Terminate live viewers even on the cancel/timeout paths;
+            # idempotent with the close in _finalize_container.
+            capture.close()
             cancel_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await cancel_task
@@ -737,6 +853,7 @@ async def _finalize_container(
     failed: bool,
 ) -> None:
     capture.set_status(drv_path, "failed" if failed else "built")
+    capture.close()
     blob = capture.finalize()
     await asyncio.to_thread(container_path(log_writer.path).write_bytes, blob)
 

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -402,16 +402,11 @@ def build_nix_command(
 
 # nix names failures only in prose: "build of" (remote) / "builder for" (local).
 _BUILD_FAILED = re.compile(r"(?:build of|builder for) '([^']+\.drv)'.*?failed")
-_PHASE_MARKER = re.compile(r"Running phase: ")
+_PHASE_ECHO = "Running phase: "
 
 
 def _clean_tail(lines: list[str], max_lines: int) -> list[str]:
-    # Phase markers are stdenv chrome already shown in the phase bar.
-    kept = [
-        _limit_line(line)
-        for line in lines
-        if line.strip() and not _PHASE_MARKER.match(strip_ansi(line))
-    ]
+    kept = [_limit_line(line) for line in lines if line.strip()]
     return kept[-max_lines:]
 
 
@@ -583,6 +578,9 @@ class StructuredCapture:
 
     def log_line(self, act_id: int, text: str) -> None:
         drv = self._act.get(act_id, self.SETUP)
+        if strip_ansi(text).startswith(_PHASE_ECHO):
+            # RES_SET_PHASE already records this; drop stdenv's echo.
+            return
         self._w.line(drv, text, ts=self._ts())
         self._emit(
             {

--- a/nixbot/nixbot/logstore.py
+++ b/nixbot/nixbot/logstore.py
@@ -217,6 +217,22 @@ class LogContainerReader:
         raw = self._frame(e["off"], e["clen"])
         return raw[e["bs"] : e["bs"] + e["bn"]].decode().splitlines()
 
+    def lines_with_phases(self, i: int) -> list[str]:
+        """Lines with `ph` markers reinjected, for readers without a phase bar."""
+        lines = self.lines(i)
+        ph = self.toc[i].get("ph") or []
+        if not ph:
+            return lines
+        at: dict[int, list[str]] = {}
+        for name, line in ph:
+            at.setdefault(line, []).append(name)
+        out: list[str] = []
+        for n in range(len(lines) + 1):
+            out.extend(f"Running phase: {name}" for name in at.get(n, []))
+            if n < len(lines):
+                out.append(lines[n])
+        return out
+
     def search(self, query: str, per_drv_cap: int = 100) -> list[dict]:
         """Case-insensitive scan, grouped by drv. Fast-rejects frames
         lacking the term; attributes matches by byte bisect. No index."""

--- a/nixbot/nixbot/logstore.py
+++ b/nixbot/nixbot/logstore.py
@@ -1,0 +1,191 @@
+"""Per-derivation build-log container.
+
+Layout: ``<compressed frames> <toc json> <u32 toc_len> <NBL1>``. The reader
+tail-parses the TOC, so a derivation renders by decompressing only its
+group frame and slicing its byte range. Small derivations share a frame to
+keep zstd's ratio while staying addressable. Level 12, no trained dict:
+logs are small, so tune write CPU / read latency, not ratio.
+"""
+
+from __future__ import annotations
+
+import bisect
+import json
+import struct
+from dataclasses import dataclass, field
+
+import zstandard
+
+MAGIC = b"NBL1"
+_MAGIC_LEN = len(MAGIC)
+_LEVEL = 12
+_GROUP_BYTES = 64 * 1024
+
+
+@dataclass
+class _Drv:
+    name: str
+    status: str = "built"
+    lines: list[str] = field(default_factory=list)
+    phases: list[list] = field(default_factory=list)  # [name, first_line]
+    t0: int | None = None
+    t1: int | None = None
+
+
+class LogContainerWriter:
+    """Accumulate ``(drv, line, phase, ts)`` records, pack on ``finalize``.
+
+    Interleaved derivations are buffered contiguously, keyed by drv path,
+    and laid out in first-seen order. Holds the size-capped log in memory.
+    """
+
+    def __init__(self, level: int = _LEVEL, group_bytes: int = _GROUP_BYTES) -> None:
+        self._level = level
+        self._group_bytes = group_bytes
+        self._drvs: dict[str, _Drv] = {}
+
+    def _get(self, drv: str, name: str | None = None) -> _Drv:
+        d = self._drvs.get(drv)
+        if d is None:
+            d = self._drvs[drv] = _Drv(name=name or drv)
+        elif name is not None:
+            d.name = name
+        return d
+
+    def line(
+        self, drv: str, text: str, ts: int | None = None, name: str | None = None
+    ) -> None:
+        d = self._get(drv, name)
+        if ts is not None:
+            if d.t0 is None:
+                d.t0 = ts
+            d.t1 = ts
+        d.lines.append(text)
+
+    def phase(self, drv: str, phase: str, ts: int | None = None) -> None:
+        d = self._get(drv)
+        if not d.phases or d.phases[-1][0] != phase:
+            d.phases.append([phase, len(d.lines)])
+        if ts is not None:
+            d.t1 = ts
+
+    def status(self, drv: str, status: str) -> None:
+        self._get(drv).status = status
+
+    def stop(self, drv: str, ts: int) -> None:
+        self._get(drv).t1 = ts
+
+    def finalize(self) -> bytes:
+        c = zstandard.ZstdCompressor(level=self._level)
+        frames: list[bytes] = []
+        toc: list[dict] = []
+        off = 0
+        buf: list[bytes] = []
+        members: list[dict] = []
+        bufbytes = 0
+
+        def flush() -> None:
+            nonlocal off, buf, members, bufbytes
+            if not buf:
+                return
+            fr = c.compress(b"".join(buf))
+            for e in members:
+                e["off"], e["clen"] = off, len(fr)
+            frames.append(fr)
+            off += len(fr)
+            buf, members, bufbytes = [], [], 0
+
+        for d in self._drvs.values():
+            txt = "".join(t + "\n" for t in d.lines).encode()
+            e = {
+                "name": d.name,
+                "status": d.status,
+                "off": 0,
+                "clen": 0,
+                "bs": bufbytes,
+                "bn": len(txt),
+                "n": len(d.lines),
+                "ph": d.phases,
+                "t0": d.t0,
+                "t1": d.t1,
+            }
+            toc.append(e)
+            members.append(e)
+            buf.append(txt)
+            bufbytes += len(txt)
+            if bufbytes >= self._group_bytes:
+                flush()
+        flush()
+
+        payload = b"".join(frames)
+        tj = json.dumps(toc, separators=(",", ":")).encode()
+        return payload + tj + struct.pack("<I", len(tj)) + MAGIC
+
+
+def is_container(blob: bytes) -> bool:
+    return len(blob) >= _MAGIC_LEN and blob[-_MAGIC_LEN:] == MAGIC
+
+
+class LogContainerReader:
+    """Random-access reader; decompresses one group frame (cached) per drv."""
+
+    def __init__(self, blob: bytes) -> None:
+        (tlen,) = struct.unpack("<I", blob[-8:-4])
+        self.toc: list[dict] = json.loads(blob[-8 - tlen : -8])
+        self._blob = blob
+        self._d = zstandard.ZstdDecompressor()
+        self._cache_off = -1
+        self._cache_raw = b""
+
+    def __len__(self) -> int:
+        return len(self.toc)
+
+    def entry(self, i: int) -> dict:
+        return self.toc[i]
+
+    def _frame(self, off: int, clen: int) -> bytes:
+        if off != self._cache_off:
+            self._cache_raw = self._d.decompress(self._blob[off : off + clen])
+            self._cache_off = off
+        return self._cache_raw
+
+    def lines(self, i: int) -> list[str]:
+        e = self.toc[i]
+        raw = self._frame(e["off"], e["clen"])
+        return raw[e["bs"] : e["bs"] + e["bn"]].decode().splitlines()
+
+    def search(self, query: str, per_drv_cap: int = 100) -> list[dict]:
+        """Case-insensitive scan, grouped by drv. Fast-rejects frames
+        lacking the term; attributes matches by byte bisect. No index."""
+        qb = query.lower().encode()
+        toc = self.toc
+        groups: dict[int, list[tuple[int, int]]] = {}
+        for i, e in enumerate(toc):
+            groups.setdefault(e["off"], []).append((e["bs"], i))
+        hits: dict[int, dict] = {}
+        for off, mem in groups.items():
+            mem.sort()
+            starts = [bs for bs, _ in mem]
+            clen = toc[mem[0][1]]["clen"]
+            raw = self._d.decompress(self._blob[off : off + clen]).lower()
+            if qb not in raw:
+                continue
+            linebase, acc = [], 0
+            for _, ti in mem:
+                linebase.append(acc)
+                acc += toc[ti]["n"]
+            last_pos = last_line = 0
+            pos = raw.find(qb)
+            while pos != -1:
+                last_line += raw.count(b"\n", last_pos, pos)
+                last_pos = pos
+                mi = bisect.bisect_right(starts, pos) - 1
+                ti = mem[mi][1]
+                h = hits.setdefault(
+                    ti, {"idx": ti, "name": toc[ti]["name"], "lines": []}
+                )
+                if len(h["lines"]) < per_drv_cap:
+                    # 1-based, matching the rendered line numbers.
+                    h["lines"].append(last_line - linebase[mi] + 1)
+                pos = raw.find(qb, pos + 1)
+        return [hits[k] for k in sorted(hits)]

--- a/nixbot/nixbot/logstore.py
+++ b/nixbot/nixbot/logstore.py
@@ -52,6 +52,10 @@ class LogContainerWriter:
             d.name = name
         return d
 
+    def register(self, drv: str, name: str | None = None) -> None:
+        """Ensure a derivation exists (and set its name) before any line."""
+        self._get(drv, name)
+
     def line(
         self, drv: str, text: str, ts: int | None = None, name: str | None = None
     ) -> None:

--- a/nixbot/nixbot/logstore.py
+++ b/nixbot/nixbot/logstore.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import bisect
 import json
 import struct
+from collections import deque
 from dataclasses import dataclass, field
 
 import zstandard
@@ -20,16 +21,42 @@ MAGIC = b"NBL1"
 _MAGIC_LEN = len(MAGIC)
 _LEVEL = 12
 _GROUP_BYTES = 64 * 1024
+_MAX_LINES = 100_000  # per-derivation retention cap, keeps RAM bounded
 
 
 @dataclass
 class _Drv:
     name: str
     status: str = "built"
-    lines: list[str] = field(default_factory=list)
     phases: list[list] = field(default_factory=list)  # [name, first_line]
     t0: int | None = None
     t1: int | None = None
+    # Head + tail retention: a runaway log keeps its start and its end
+    # (where the failure is) and elides the middle, so RAM stays bounded
+    # without hiding the error.
+    head: list[str] = field(default_factory=list)
+    tail: deque[str] = field(default_factory=deque)
+    dropped: int = 0
+
+    def append(self, text: str, half: int) -> None:
+        if len(self.head) < half:
+            self.head.append(text)
+            return
+        self.tail.append(text)
+        if len(self.tail) > half:
+            self.tail.popleft()
+            self.dropped += 1
+
+    @property
+    def count(self) -> int:
+        return len(self.head) + (1 if self.dropped else 0) + len(self.tail)
+
+    @property
+    def lines(self) -> list[str]:
+        if not self.dropped:
+            return self.head + list(self.tail)
+        elided = f"… {self.dropped} lines elided (log too large) …"
+        return [*self.head, elided, *self.tail]
 
 
 class LogContainerWriter:
@@ -39,9 +66,15 @@ class LogContainerWriter:
     and laid out in first-seen order. Holds the size-capped log in memory.
     """
 
-    def __init__(self, level: int = _LEVEL, group_bytes: int = _GROUP_BYTES) -> None:
+    def __init__(
+        self,
+        level: int = _LEVEL,
+        group_bytes: int = _GROUP_BYTES,
+        max_lines: int = _MAX_LINES,
+    ) -> None:
         self._level = level
         self._group_bytes = group_bytes
+        self._half = max(1, max_lines // 2)
         self._drvs: dict[str, _Drv] = {}
 
     def _get(self, drv: str, name: str | None = None) -> _Drv:
@@ -64,12 +97,12 @@ class LogContainerWriter:
             if d.t0 is None:
                 d.t0 = ts
             d.t1 = ts
-        d.lines.append(text)
+        d.append(text, self._half)
 
     def phase(self, drv: str, phase: str, ts: int | None = None) -> None:
         d = self._get(drv)
         if not d.phases or d.phases[-1][0] != phase:
-            d.phases.append([phase, len(d.lines)])
+            d.phases.append([phase, d.count])
         if ts is not None:
             d.t1 = ts
 
@@ -78,6 +111,27 @@ class LogContainerWriter:
 
     def stop(self, drv: str, ts: int) -> None:
         self._get(drv).t1 = ts
+
+    def nlines(self, drv: str) -> int:
+        d = self._drvs.get(drv)
+        return d.count if d else 0
+
+    def state(self) -> list[dict]:
+        """Current per-derivation state for a live snapshot burst; mirrors
+        the finalized TOC plus the lines seen so far."""
+        return [
+            {
+                "idx": i,
+                "name": d.name,
+                "status": d.status,
+                "ph": d.phases,
+                "lines": d.lines,
+                "t0": d.t0,
+                "t1": d.t1,
+                "n": d.count,
+            }
+            for i, d in enumerate(self._drvs.values())
+        ]
 
     def finalize(self) -> bytes:
         c = zstandard.ZstdCompressor(level=self._level)
@@ -100,7 +154,8 @@ class LogContainerWriter:
             buf, members, bufbytes = [], [], 0
 
         for d in self._drvs.values():
-            txt = "".join(t + "\n" for t in d.lines).encode()
+            lines = d.lines
+            txt = "".join(t + "\n" for t in lines).encode()
             e = {
                 "name": d.name,
                 "status": d.status,
@@ -108,7 +163,7 @@ class LogContainerWriter:
                 "clen": 0,
                 "bs": bufbytes,
                 "bn": len(txt),
-                "n": len(d.lines),
+                "n": len(lines),
                 "ph": d.phases,
                 "t0": d.t0,
                 "t1": d.t1,

--- a/nixbot/nixbot/logstore.py
+++ b/nixbot/nixbot/logstore.py
@@ -116,6 +116,10 @@ class LogContainerWriter:
         d = self._drvs.get(drv)
         return d.count if d else 0
 
+    def failing(self) -> list[tuple[str, list[str]]]:
+        """(name, lines) for derivations left in a failed status."""
+        return [(d.name, d.lines) for d in self._drvs.values() if d.status == "failed"]
+
     def state(self) -> list[dict]:
         """Current per-derivation state for a live snapshot burst; mirrors
         the finalized TOC plus the lines seen so far."""

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -28,6 +28,7 @@ Target URLs point at the service's own URL scheme
 from __future__ import annotations
 
 import logging
+import re
 from collections import OrderedDict
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -682,7 +683,7 @@ class ForgeStatusReporter:
                         continue
                     reported += 1
                 await self.failed_statuses.mark_failed(revision, context)
-                description = result.error or result.status.value
+                description = _error_headline(result.error or "") or result.status.value
                 await self._post(
                     event,
                     build,
@@ -749,6 +750,21 @@ class ForgeStatusReporter:
 
 def _fence(text: str) -> str:
     return f"```\n{strip_ansi(text)}\n```"
+
+
+_DRV_PREFIX = re.compile(r"^[^\s>]+> +")
+# Mirrors executor.StructuredCapture.failure_excerpt's overflow line.
+_MORE_FAILURES = re.compile(r"^… and \d+ more failed derivation")
+
+
+def _error_headline(excerpt: str, limit: int = 200) -> str:
+    """The excerpt's last real error line, for a status blurb / check
+    summary; skips the multi-failure count."""
+    for raw in reversed(excerpt.splitlines()):
+        line = _DRV_PREFIX.sub("", strip_ansi(raw).strip())
+        if line and not _MORE_FAILURES.match(line):
+            return line[:limit]
+    return ""
 
 
 _STATUS_ICONS = {

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -683,7 +683,12 @@ class ForgeStatusReporter:
                         continue
                     reported += 1
                 await self.failed_statuses.mark_failed(revision, context)
-                description = _error_headline(result.error or "") or result.status.value
+                headline = (
+                    result.failure.headline()
+                    if result.failure
+                    else _error_headline(result.error or "")
+                )
+                description = headline or result.status.value
                 await self._post(
                     event,
                     build,
@@ -752,17 +757,17 @@ def _fence(text: str) -> str:
     return f"```\n{strip_ansi(text)}\n```"
 
 
+# Flat/effect excerpts prefix lines with "name> "; structured failures
+# skip this path entirely (they carry a BuildFailure).
 _DRV_PREFIX = re.compile(r"^[^\s>]+> +")
-# Mirrors executor.StructuredCapture.failure_excerpt's overflow line.
-_MORE_FAILURES = re.compile(r"^… and \d+ more failed derivation")
 
 
 def _error_headline(excerpt: str, limit: int = 200) -> str:
     """The excerpt's last real error line, for a status blurb / check
-    summary; skips the multi-failure count."""
+    summary."""
     for raw in reversed(excerpt.splitlines()):
         line = _DRV_PREFIX.sub("", strip_ansi(raw).strip())
-        if line and not _MORE_FAILURES.match(line):
+        if line:
             return line[:limit]
     return ""
 

--- a/nixbot/nixbot/tests/e2e/support.py
+++ b/nixbot/nixbot/tests/e2e/support.py
@@ -16,7 +16,8 @@ import asyncpg
 import uvicorn
 import zstandard
 
-from nixbot.executor import attribute_log_path
+from nixbot.executor import attribute_log_path, container_path
+from nixbot.logstore import LogContainerWriter
 from nixbot.tests.support import insert_build, insert_project
 from nixbot.web.app import create_app
 from nixbot.web.logs import LogRegistry
@@ -25,6 +26,27 @@ if TYPE_CHECKING:
     import concurrent.futures
     from collections.abc import Coroutine
     from pathlib import Path
+
+
+def _seed_container(*, failed: bool) -> bytes:
+    """A container with one primary derivation (phased, optionally
+    failed) plus a built dependency, for the structured log viewer."""
+    w = LogContainerWriter()
+    hello = "/nix/store/aaa-hello-2.12.drv"
+    w.register(hello, "hello-2.12")
+    w.phase(hello, "unpack")
+    w.line(hello, "unpacking sources")
+    w.phase(hello, "build")
+    for i in range(30):
+        w.line(hello, f"CC step {i}.o")
+    if failed:
+        w.line(hello, "error: build failed on the last step")
+    w.status(hello, "failed" if failed else "built")
+    dep = "/nix/store/bbb-zlib-1.3.drv"
+    w.register(dep, "zlib-1.3")
+    w.line(dep, "building zlib")
+    w.status(dep, "built")
+    return w.finalize()
 
 
 async def seed(dsn: str, state_dir: Path | None = None) -> None:
@@ -70,6 +92,11 @@ async def seed(dsn: str, state_dir: Path | None = None) -> None:
                 log_file.parent.mkdir(parents=True, exist_ok=True)
                 log_file.write_bytes(
                     zstandard.ZstdCompressor().compress(f"log #{number}\n".encode())
+                )
+                # Structured sidecar: the log page renders the
+                # per-derivation viewer when this exists.
+                container_path(log_file).write_bytes(
+                    _seed_container(failed=status == "failed")
                 )
                 await pool.execute(
                     "UPDATE build_attributes SET log_size = $3"

--- a/nixbot/nixbot/tests/e2e/support.py
+++ b/nixbot/nixbot/tests/e2e/support.py
@@ -40,7 +40,8 @@ def _seed_container(*, failed: bool) -> bytes:
     for i in range(30):
         w.line(hello, f"CC step {i}.o")
     if failed:
-        w.line(hello, "error: build failed on the last step")
+        # Colored so the viewer's ANSI->span rendering is exercised.
+        w.line(hello, "\x1b[31;1merror: build failed on the last step\x1b[0m")
     w.status(hello, "failed" if failed else "built")
     dep = "/nix/store/bbb-zlib-1.3.drv"
     w.register(dep, "zlib-1.3")

--- a/nixbot/nixbot/tests/e2e/test_browse.py
+++ b/nixbot/nixbot/tests/e2e/test_browse.py
@@ -43,15 +43,36 @@ def test_build_prev_next_navigation(page: Page) -> None:
 
 def test_structured_log_viewer(page: Page) -> None:
     page.goto("/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad")
-    # Failing derivation card is open with its phase bar; log rows load
-    # lazily from /drv/{idx}.
+    # Failing derivation card is open with inline phase dividers; log rows
+    # load lazily from /drv/{idx}.
     card = page.locator('.log-card[data-pos="0"]')
     card.get_by_text("hello-2.12").wait_for()
     assert card.get_attribute("open") is not None
-    card.locator(".phasebar").wait_for()
+    card.locator(".phase-sep").first.wait_for()
     card.locator("text=error: build failed on the last step").wait_for()
     # ANSI colors render as ansi-* spans, matching the flat log viewer.
     assert card.locator(".log-lines .logline .ansi-red").count() >= 1
+
+    # A failure opens at the bottom, where the error is.
+    lines = card.locator(".log-lines")
+    assert lines.evaluate("el => el.scrollTop") > 0
+
+    # Phase nav scrolls between the inline dividers, both ways.
+    lines.evaluate("el => el.scrollTop = 0")
+    seps = card.locator(".phase-sep")
+    seps.nth(0).locator(".phase-next").click()
+    down = lines.evaluate("el => el.scrollTop")
+    assert down > 0
+    seps.nth(1).locator(".phase-prev").click()
+    assert lines.evaluate("el => el.scrollTop") < down
+    # Past the last phase falls through to the bottom; before the first
+    # falls through to the top.
+    lines.evaluate("el => el.scrollTop = 0")
+    seps.nth(1).locator(".phase-next").click()
+    assert lines.evaluate("el => el.scrollTop") > down
+    lines.evaluate("el => el.scrollTop = 0")
+    seps.nth(0).locator(".phase-prev").click()
+    assert lines.evaluate("el => el.scrollTop") == 0
 
     # Successes hide behind a collapsed expand-to-browse panel.
     assert page.locator("#succeeded-panel").get_attribute("open") is None

--- a/nixbot/nixbot/tests/e2e/test_browse.py
+++ b/nixbot/nixbot/tests/e2e/test_browse.py
@@ -65,6 +65,14 @@ def test_structured_log_viewer(page: Page) -> None:
     hit.wait_for()
     assert hit.get_attribute("id") == "d0-L32"
 
+    # A #d{idx}-L{n} permalink expands the collapsed Succeeded panel, opens
+    # the toggle-loaded card, waits for its lazy rows, then highlights the
+    # line -- even though the row did not exist at page load.
+    page.goto("/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad#d1-L1")
+    linked = page.locator(".log-lines .logline.hit")
+    linked.wait_for()
+    assert linked.get_attribute("id") == "d1-L1"
+
 
 def test_project_filter_form(page: Page) -> None:
     page.goto("/repos/github/acme/widget")

--- a/nixbot/nixbot/tests/e2e/test_browse.py
+++ b/nixbot/nixbot/tests/e2e/test_browse.py
@@ -41,6 +41,29 @@ def test_build_prev_next_navigation(page: Page) -> None:
     page.wait_for_url("**/builds/2")
 
 
+def test_structured_log_viewer(page: Page) -> None:
+    page.goto("/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad")
+    # Failing derivation card is open with its phase bar; log rows load
+    # lazily from /drv/{idx}.
+    card = page.locator('.log-card[data-pos="0"]')
+    card.get_by_text("hello-2.12").wait_for()
+    assert card.get_attribute("open") is not None
+    card.locator(".phasebar").wait_for()
+    card.locator("text=error: build failed on the last step").wait_for()
+
+    # Successes hide behind an expand-to-browse panel until opened.
+    assert page.locator("#succeeded-list .log-card").count() == 0
+    page.locator("#succeeded-panel > summary").click()
+    page.locator("#succeeded-list").get_by_text("zlib-1.3").wait_for()
+
+    # Build-scoped search groups hits and jumps to the matching line.
+    page.fill("#search-input", "error")
+    page.locator("#search-results a[data-line]").first.click()
+    hit = page.locator(".log-lines .logline.hit")
+    hit.wait_for()
+    assert hit.get_attribute("id") == "d0-L32"
+
+
 def test_project_filter_form(page: Page) -> None:
     page.goto("/repos/github/acme/widget")
     # No filter button: the select applies itself, the ref input

--- a/nixbot/nixbot/tests/e2e/test_browse.py
+++ b/nixbot/nixbot/tests/e2e/test_browse.py
@@ -50,9 +50,11 @@ def test_structured_log_viewer(page: Page) -> None:
     assert card.get_attribute("open") is not None
     card.locator(".phasebar").wait_for()
     card.locator("text=error: build failed on the last step").wait_for()
+    # ANSI colors render as ansi-* spans, matching the flat log viewer.
+    assert card.locator(".log-lines .logline .ansi-red").count() >= 1
 
-    # Successes hide behind an expand-to-browse panel until opened.
-    assert page.locator("#succeeded-list .log-card").count() == 0
+    # Successes hide behind a collapsed expand-to-browse panel.
+    assert page.locator("#succeeded-panel").get_attribute("open") is None
     page.locator("#succeeded-panel > summary").click()
     page.locator("#succeeded-list").get_by_text("zlib-1.3").wait_for()
 

--- a/nixbot/nixbot/tests/e2e/test_live.py
+++ b/nixbot/nixbot/tests/e2e/test_live.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING
 
-from nixbot.executor import LogWriter
+from nixbot.executor import LogWriter, StructuredCapture
 
 if TYPE_CHECKING:
     from playwright.sync_api import Page
@@ -62,28 +62,45 @@ def test_attribute_table_refreshes_while_building(
 def test_log_page_streams_live_output(page: Page, server: TestServer) -> None:
     build_id = server.run(_build_id(server, 3))
     writer = LogWriter(path=server.state_dir / "live" / f"{ATTR}.zst")
+    cap = StructuredCapture()
+    writer.capture = cap
     server.registry.register(build_id, ATTR, writer)
+    drv = "/nix/store/aaa-hello-2.12.drv"
+
+    started = False
+
+    async def emit(text: str) -> None:
+        nonlocal started
+        if not started:
+            cap.start_build(1, drv)
+            started = True
+        cap.log_line(1, text)
+
+    async def finish() -> None:
+        cap.close()
+
     try:
         page.goto(f"/repos/github/acme/widget/builds/3/logs/{ATTR}")
-        log = page.locator("#log")
 
-        # Live-only logs have no history replay: lines sent before the
-        # EventSource subscribes would be lost, so wait for the stream.
+        # Structured live has no history replay: deltas sent before the
+        # EventSource subscribes are lost, so wait for the subscription.
         deadline = time.monotonic() + 15
-        while not writer._subscribers:  # noqa: SLF001
+        while not cap._subs:  # noqa: SLF001
             if time.monotonic() > deadline:
                 msg = "browser never connected to the SSE stream"
                 raise TimeoutError(msg)
             time.sleep(0.1)
 
-        server.run(writer.write(b"hello from the build\n"))
-        log.get_by_text("hello from the build").wait_for(timeout=15_000)
+        lines = page.locator(".log-card .log-lines .logline")
+        server.run(emit("hello from the build"))
+        lines.get_by_text("hello from the build").wait_for(timeout=15_000)
 
-        server.run(writer.write(b"second line arrives later\n"))
-        log.get_by_text("second line arrives later").wait_for(timeout=15_000)
+        server.run(emit("second line arrives later"))
+        lines.get_by_text("second line arrives later").wait_for(timeout=15_000)
 
         # close() ends the SSE stream; streamed content stays visible.
-        server.run(writer.close())
-        assert "hello from the build" in log.inner_text()
+        server.run(finish())
+        card = page.locator(".log-card", has_text="hello-2.12")
+        assert "hello from the build" in card.inner_text()
     finally:
         server.registry.unregister(build_id, ATTR)

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -589,8 +589,8 @@ def test_structured_capture_demux() -> None:
     assert r.entry(qt)["ph"] == [["unpack", 0], ["build", 1]]
     assert r.entry(qt)["status"] == "failed"
     assert r.lines(by_name["zlib-1.3"]) == ["building zlib"]
-    # nix's own message lands in the synthetic driver bucket.
-    assert r.lines(by_name["driver"]) == ["note: keeping going"]
+    # nix's own message lands in the synthetic setup bucket.
+    assert r.lines(by_name["setup"]) == ["note: keeping going"]
 
 
 async def test_structured_capture_live_stream() -> None:

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -25,6 +25,7 @@ from nixbot.executor import (
     FairScheduler,
     LogWriter,
     NixBuildExecutor,
+    StructuredCapture,
     build_nix_command,
     failure_excerpt,
     is_transient_error,
@@ -32,6 +33,7 @@ from nixbot.executor import (
     read_log,
     render_log_event,
 )
+from nixbot.logstore import LogContainerReader
 
 from .support import mk_job
 
@@ -552,6 +554,42 @@ def test_render_log_event_attributes_and_colors() -> None:
     assert render_log_event(b'@nix {"action":"stop","id":7}', activities) is None
     # Non-event output passes through.
     assert render_log_event(b"plain line\n", activities) == b"plain line\n"
+
+
+def test_structured_capture_demux() -> None:
+    clock = iter(range(1000, 2000))
+    cap = StructuredCapture(clock=lambda: next(clock))
+    activities: dict[int, str] = {}
+
+    def feed(line: bytes) -> None:
+        render_log_event(line, activities, cap)
+
+    feed(
+        b'@nix {"action":"start","id":1,"type":105,'
+        b'"fields":["/nix/store/aaa-qtbase-5.0.drv"]}'
+    )
+    feed(
+        b'@nix {"action":"start","id":2,"type":105,'
+        b'"fields":["/nix/store/bbb-zlib-1.3.drv"]}'
+    )
+    feed(b'@nix {"action":"result","id":1,"type":104,"fields":["unpack"]}')
+    feed(b'@nix {"action":"result","id":1,"type":101,"fields":["unpacking qt"]}')
+    feed(b'@nix {"action":"result","id":2,"type":101,"fields":["building zlib"]}')
+    feed(b'@nix {"action":"result","id":1,"type":104,"fields":["build"]}')
+    feed(b'@nix {"action":"result","id":1,"type":101,"fields":["CC main.o"]}')
+    feed(b'@nix {"action":"msg","level":0,"msg":"note: keeping going"}')
+    feed(b'@nix {"action":"stop","id":1}')
+    cap.set_status("/nix/store/aaa-qtbase-5.0.drv", "failed")
+
+    r = LogContainerReader(cap.finalize())
+    by_name = {r.entry(i)["name"]: i for i in range(len(r))}
+    qt = by_name["qtbase-5.0"]
+    assert r.lines(qt) == ["unpacking qt", "CC main.o"]
+    assert r.entry(qt)["ph"] == [["unpack", 0], ["build", 1]]
+    assert r.entry(qt)["status"] == "failed"
+    assert r.lines(by_name["zlib-1.3"]) == ["building zlib"]
+    # nix's own message lands in the synthetic driver bucket.
+    assert r.lines(by_name["driver"]) == ["note: keeping going"]
 
 
 # As written by render_log_event: the builder's own lines arrive as

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -703,6 +703,27 @@ def test_structured_failure_excerpt_skips_phase_markers() -> None:
     assert excerpt.splitlines()[-1] == "boom"
 
 
+def test_build_failure_returns_structured_drvs() -> None:
+    cap = StructuredCapture(clock=lambda: 1.0)
+    cap.start_build(1, "/nix/store/aaa-pkg.drv")
+    cap.log_line(1, "Running phase: buildPhase")
+    cap.log_line(1, "boom")
+    cap.set_status("/nix/store/aaa-pkg.drv", "failed")
+    failure = cap.build_failure()
+    assert failure is not None
+    assert failure.total == 1
+    assert failure.drvs[0].tail == ["boom"]
+    assert failure.headline() == "boom"
+
+
+def test_build_failure_none_when_all_built() -> None:
+    cap = StructuredCapture(clock=lambda: 1.0)
+    cap.start_build(1, "/nix/store/aaa-pkg.drv")
+    cap.log_line(1, "ok")
+    cap.set_status("/nix/store/aaa-pkg.drv", "built")
+    assert cap.build_failure() is None
+
+
 def test_structured_failure_excerpt_none_when_all_built() -> None:
     cap = StructuredCapture(clock=lambda: 1.0)
     cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -703,6 +703,30 @@ def test_structured_failure_excerpt_skips_phase_markers() -> None:
     assert excerpt.splitlines()[-1] == "boom"
 
 
+def test_phase_echo_suppressed_and_marker_is_zero_based() -> None:
+    cap = StructuredCapture(clock=lambda: 1.0)
+    q = cap.subscribe()
+    cap.start_build(1, "/nix/store/aaa-pkg.drv")
+    # stdenv order: echo line, then the structured phase event.
+    cap.log_line(1, "Running phase: buildPhase")
+    cap.phase(1, "buildPhase")
+    cap.log_line(1, "boom")
+    cap.close()
+
+    reader = LogContainerReader(cap.finalize())
+    # idx 0 is the setup bucket; the build is idx 1. The echo is not
+    # stored; the marker points at the first real line (0-based).
+    assert reader.lines(1) == ["boom"]
+    assert reader.entry(1)["ph"] == [["buildPhase", 0]]
+
+    deltas = []
+    while not q.empty():
+        deltas.append(q.get_nowait())
+    assert {"t": "phase", "idx": 1, "phase": "buildPhase", "line": 0} in deltas
+    # No line delta was emitted for the suppressed echo.
+    assert not any(d and d.get("text", "").startswith("Running phase") for d in deltas)
+
+
 def test_build_failure_returns_structured_drvs() -> None:
     cap = StructuredCapture(clock=lambda: 1.0)
     cap.start_build(1, "/nix/store/aaa-pkg.drv")

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -20,6 +20,7 @@ from nixbot.ansi import strip_ansi
 from nixbot.build_scheduler import BuildOutcome
 from nixbot.executor import (
     FRAME_FLUSH_THRESHOLD,
+    STRUCTURED_QUEUE_MAXSIZE,
     SUBSCRIBER_QUEUE_MAXSIZE,
     BuildSettings,
     FairScheduler,
@@ -590,6 +591,82 @@ def test_structured_capture_demux() -> None:
     assert r.lines(by_name["zlib-1.3"]) == ["building zlib"]
     # nix's own message lands in the synthetic driver bucket.
     assert r.lines(by_name["driver"]) == ["note: keeping going"]
+
+
+async def test_structured_capture_live_stream() -> None:
+    cap = StructuredCapture(clock=lambda: 1.0)
+    q = cap.subscribe()  # subscribe before mutating: no delta lost
+    cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")
+    cap.phase(1, "build")
+    cap.log_line(1, "CC main.o")
+    cap.stop(1)
+    cap.set_status("/nix/store/aaa-qtbase-5.0.drv", "failed")
+    cap.close()
+
+    deltas = []
+    while not q.empty():
+        deltas.append(q.get_nowait())
+
+    assert deltas[0] == {"t": "drv", "idx": 1, "name": "qtbase-5.0"}
+    assert {"t": "phase", "idx": 1, "phase": "build", "line": 0} in deltas
+    assert {"t": "line", "idx": 1, "from": 1, "text": "CC main.o"} in deltas
+    # stop marks built, finalize status overrides to failed; both stream.
+    assert {"t": "status", "idx": 1, "status": "built"} in deltas
+    assert {"t": "status", "idx": 1, "status": "failed"} in deltas
+    assert deltas[-1] is None  # close signals done
+
+
+async def test_structured_capture_stalled_subscriber_bounded() -> None:
+    cap = StructuredCapture(clock=lambda: 1.0)
+    q = cap.subscribe()  # never drained: a stalled client
+    cap.start_build(1, "/nix/store/aaa-x.drv")
+    for i in range(STRUCTURED_QUEUE_MAXSIZE + 50):
+        cap.log_line(1, f"line {i}")
+    assert q.qsize() <= STRUCTURED_QUEUE_MAXSIZE
+    cap.close()
+    items = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    assert items[-1] is None  # done sentinel delivered even to a full queue
+
+
+async def test_structured_capture_monotonic_line_from_past_cap() -> None:
+    # The container caps retained lines, so its line count plateaus; live
+    # delta "from" must stay monotonic anyway or row ids would collide.
+    cap = StructuredCapture(clock=lambda: 1.0, max_lines=4)
+    q = cap.subscribe()
+    cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")
+    for _ in range(8):
+        cap.log_line(1, "x")
+    deltas = [q.get_nowait() for _ in range(q.qsize())]
+    lines = [d["from"] for d in deltas if d and d["t"] == "line"]
+    assert lines == [1, 2, 3, 4, 5, 6, 7, 8]
+
+
+async def test_structured_capture_status_without_start_build() -> None:
+    # Finalized without build activity: still emits a card, keeps its name.
+    cap = StructuredCapture(clock=lambda: 1.0)
+    q = cap.subscribe()
+    cap.set_status("/nix/store/aaa-qtbase-5.0.drv", "built")
+    deltas = [q.get_nowait() for _ in range(q.qsize())]
+    assert deltas[0] == {"t": "drv", "idx": 1, "name": "qtbase-5.0"}
+    assert deltas[1] == {"t": "status", "idx": 1, "status": "built"}
+    entry = next(e for e in cap.state() if e["idx"] == 1)
+    assert entry["name"] == "qtbase-5.0"
+
+
+async def test_structured_capture_state_snapshot() -> None:
+    cap = StructuredCapture(clock=lambda: 1.0)
+    cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")
+    cap.log_line(1, "CC main.o")
+    state = cap.state()
+    qt = next(e for e in state if e["name"] == "qtbase-5.0")
+    assert qt["status"] == "running"  # in-flight, not yet stopped
+    assert qt["lines"] == ["CC main.o"]
+    assert qt["n"] == 1
+    # A subscriber after close gets an immediate done, not a hang.
+    cap.close()
+    assert cap.subscribe().get_nowait() is None
 
 
 # As written by render_log_event: the builder's own lines arrive as

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -655,6 +655,78 @@ async def test_structured_capture_status_without_start_build() -> None:
     assert entry["name"] == "qtbase-5.0"
 
 
+def test_structured_failure_excerpt_uses_failed_derivation() -> None:
+    cap = StructuredCapture(clock=lambda: 1.0)
+    cap.start_build(1, "/nix/store/aaa-ghidra-cli-test.drv")
+    for line in ("configuring", "Starting Ghidra bridge...", "Error: exit status 1"):
+        cap.log_line(1, line)
+    cap.set_status("/nix/store/aaa-ghidra-cli-test.drv", "failed")
+    excerpt = cap.failure_excerpt()
+    # The failing derivation's own tail under a single name header; no
+    # per-line prefix, no nix re-quote.
+    assert excerpt.splitlines()[0] == "ghidra-cli-test:"
+    assert excerpt.splitlines()[-1] == "Error: exit status 1"
+    assert "configuring" in excerpt
+
+
+def test_structured_capture_marks_failures_from_nix_prose() -> None:
+    # nix names each failing derivation only in prose (never as a
+    # per-activity status), so --keep-going failures are recovered by
+    # scraping those messages. Covers remote ("build of") and local
+    # ("builder for") wording, ANSI included.
+    cap = StructuredCapture(clock=lambda: 1.0)
+    cap.start_build(1, "/nix/store/aaa-alpha.drv")
+    cap.log_line(1, "boom alpha")
+    cap.start_build(2, "/nix/store/bbb-beta.drv")
+    cap.log_line(2, "boom beta")
+    cap.setup_line(
+        "\x1b[31;1merror:\x1b[0m build of '/nix/store/aaa-alpha.drv' "
+        "on 'ssh-ng://h' failed: builder failed with exit code 1"
+    )
+    cap.setup_line(
+        "error: builder for '/nix/store/bbb-beta.drv' failed with exit code 1"
+    )
+    excerpt = cap.failure_excerpt()
+    assert "alpha:\nboom alpha" in excerpt
+    assert "beta:\nboom beta" in excerpt
+
+
+def test_structured_failure_excerpt_skips_phase_markers() -> None:
+    cap = StructuredCapture(clock=lambda: 1.0)
+    cap.start_build(1, "/nix/store/aaa-pkg.drv")
+    for line in ("Running phase: configurePhase", "Running phase: buildPhase", "boom"):
+        cap.log_line(1, line)
+    cap.set_status("/nix/store/aaa-pkg.drv", "failed")
+    excerpt = cap.failure_excerpt()
+    # Phase markers are stdenv chrome (shown in the phase bar), not output.
+    assert "Running phase" not in excerpt
+    assert excerpt.splitlines()[-1] == "boom"
+
+
+def test_structured_failure_excerpt_none_when_all_built() -> None:
+    cap = StructuredCapture(clock=lambda: 1.0)
+    cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")
+    cap.log_line(1, "CC main.o")
+    cap.set_status("/nix/store/aaa-qtbase-5.0.drv", "built")
+    assert cap.failure_excerpt() == ""
+
+
+def test_structured_failure_excerpt_caps_many_failures() -> None:
+    cap = StructuredCapture(clock=lambda: 1.0)
+    for i in range(5):
+        drv = f"/nix/store/aaa-pkg-{i}.drv"
+        cap.start_build(i + 1, drv)
+        cap.log_line(i + 1, f"boom {i}")
+        cap.set_status(drv, "failed")
+    excerpt = cap.failure_excerpt(max_drvs=2)
+    # Only the last two failures are shown, each under its name; the
+    # rest are counted.
+    assert "pkg-4:\nboom 4" in excerpt
+    assert "pkg-3:\nboom 3" in excerpt
+    assert "pkg-0" not in excerpt
+    assert "3 more failed derivations" in excerpt
+
+
 async def test_structured_capture_state_snapshot() -> None:
     cap = StructuredCapture(clock=lambda: 1.0)
     cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")

--- a/nixbot/nixbot/tests/test_logstore.py
+++ b/nixbot/nixbot/tests/test_logstore.py
@@ -51,6 +51,20 @@ def test_toc_metadata() -> None:
     assert e["t1"] == 30
 
 
+def test_line_cap_keeps_head_and_tail() -> None:
+    w = LogContainerWriter(max_lines=4)  # half = 2
+    for i in range(10):
+        w.line("pkg", f"line {i}")
+    r = LogContainerReader(w.finalize())
+    lines = r.lines(0)
+    # First two, an elision marker, then the last two (the failure tail).
+    assert lines[0] == "line 0"
+    assert lines[1] == "line 1"
+    assert "6 lines elided" in lines[2]
+    assert lines[-2:] == ["line 8", "line 9"]
+    assert r.entry(0)["n"] == 5
+
+
 def test_phase_indices() -> None:
     w = LogContainerWriter()
     w.phase("pkg", "unpack")

--- a/nixbot/nixbot/tests/test_logstore.py
+++ b/nixbot/nixbot/tests/test_logstore.py
@@ -78,6 +78,23 @@ def test_phase_indices() -> None:
     assert r.entry(0)["ph"] == [["unpack", 0], ["build", 1], ["install", 3]]
 
 
+def test_lines_with_phases_reinjects_markers() -> None:
+    w = LogContainerWriter()
+    w.phase("pkg", "buildPhase")
+    w.line("pkg", "compiling")
+    w.phase("pkg", "installPhase")
+    w.line("pkg", "installing")
+    r = LogContainerReader(w.finalize())
+    # Markers reconstructed from `ph`; plain lines() stays unchanged.
+    assert r.lines(0) == ["compiling", "installing"]
+    assert r.lines_with_phases(0) == [
+        "Running phase: buildPhase",
+        "compiling",
+        "Running phase: installPhase",
+        "installing",
+    ]
+
+
 def test_phase_dedup() -> None:
     w = LogContainerWriter()
     w.phase("p", "build")

--- a/nixbot/nixbot/tests/test_logstore.py
+++ b/nixbot/nixbot/tests/test_logstore.py
@@ -1,0 +1,136 @@
+"""Tests for the per-derivation log container (round-trip, TOC, search)."""
+
+# ruff: noqa: PLR2004 (test literals)
+
+from __future__ import annotations
+
+from nixbot.logstore import (
+    LogContainerReader,
+    LogContainerWriter,
+    is_container,
+)
+
+
+def _write(drvs: list[tuple[str, list[str]]], **kw: int) -> bytes:
+    w = LogContainerWriter(**kw)
+    for name, lines in drvs:
+        for i, text in enumerate(lines):
+            w.line(name, text, ts=i)
+    return w.finalize()
+
+
+def test_roundtrip_identical() -> None:
+    drvs = [
+        ("qtbase", ["configure", "CC main.o", "error: boom"]),
+        ("zlib", ["unpacking", "installing"]),
+    ]
+    r = LogContainerReader(_write(drvs))
+    assert len(r) == 2
+    assert r.lines(0) == drvs[0][1]
+    assert r.lines(1) == drvs[1][1]
+
+
+def test_is_container() -> None:
+    blob = _write([("a", ["x"])])
+    assert is_container(blob)
+    assert not is_container(b"plain text log")
+    assert not is_container(b"")
+
+
+def test_toc_metadata() -> None:
+    w = LogContainerWriter()
+    for i, t in enumerate(["a", "b", "c", "d"]):
+        w.line("pkg", t, ts=i * 10)
+    w.status("pkg", "failed")
+    r = LogContainerReader(w.finalize())
+    e = r.entry(0)
+    assert e["name"] == "pkg"
+    assert e["status"] == "failed"
+    assert e["n"] == 4
+    assert e["t0"] == 0
+    assert e["t1"] == 30
+
+
+def test_phase_indices() -> None:
+    w = LogContainerWriter()
+    w.phase("pkg", "unpack")
+    w.line("pkg", "unpacking source")
+    w.phase("pkg", "build")
+    w.line("pkg", "CC a.o")
+    w.line("pkg", "CC b.o")
+    w.phase("pkg", "install")
+    w.line("pkg", "installing")
+    r = LogContainerReader(w.finalize())
+    assert r.entry(0)["ph"] == [["unpack", 0], ["build", 1], ["install", 3]]
+
+
+def test_phase_dedup() -> None:
+    w = LogContainerWriter()
+    w.phase("p", "build")
+    w.line("p", "x")
+    w.phase("p", "build")  # same phase repeated -> no new marker
+    w.line("p", "y")
+    r = LogContainerReader(w.finalize())
+    assert r.entry(0)["ph"] == [["build", 0]]
+
+
+def test_grouping_shares_frame() -> None:
+    # Small drvs group into one frame; a big one forces a new frame.
+    w = LogContainerWriter(group_bytes=64)
+    w.line("a", "x" * 10)
+    w.line("b", "y" * 10)
+    w.line("c", "z" * 100)  # pushes past 64 bytes -> flush
+    w.line("d", "w" * 5)
+    r = LogContainerReader(w.finalize())
+    offs = [r.entry(i)["off"] for i in range(4)]
+    assert offs[0] == offs[1]  # a, b share the first frame
+    assert offs[3] != offs[0]  # d lands in a later frame
+    assert r.lines(0) == ["x" * 10]
+    assert r.lines(2) == ["z" * 100]
+
+
+def test_search_rare_term() -> None:
+    drvs = [
+        ("qtbase", ["configure", "CC a.o", "error: qtbase_init undeclared"]),
+        ("zlib", ["configure", "CC z.o", "done"]),
+    ]
+    r = LogContainerReader(_write(drvs))
+    hits = r.search("undeclared")
+    assert len(hits) == 1
+    assert hits[0]["name"] == "qtbase"
+    assert hits[0]["lines"] == [3]
+
+
+def test_search_common_term_line_numbers() -> None:
+    drvs = [
+        ("a", ["CC 1", "ld", "CC 2"]),
+        ("b", ["CC 3", "done"]),
+    ]
+    r = LogContainerReader(_write(drvs))
+    hits = {h["name"]: h["lines"] for h in r.search("cc")}
+    assert hits == {"a": [1, 3], "b": [1]}
+
+
+def test_search_phrase() -> None:
+    r = LogContainerReader(_write([("a", ["exit code 1", "exit code 2"])]))
+    hits = r.search("exit code 1")
+    assert hits[0]["lines"] == [1]
+
+
+def test_search_per_drv_cap() -> None:
+    r = LogContainerReader(_write([("a", ["hit"] * 50)]))
+    hits = r.search("hit", per_drv_cap=10)
+    assert len(hits[0]["lines"]) == 10
+
+
+def test_search_across_grouped_frame() -> None:
+    # Two drvs in one frame; matches must attribute to the right drv/line.
+    w = LogContainerWriter(group_bytes=1 << 20)
+    w.line("a", "alpha")
+    w.line("a", "target here")
+    w.line("b", "beta")
+    w.line("b", "target too")
+    r = LogContainerReader(w.finalize())
+    assert r.entry(0)["off"] == r.entry(1)["off"]  # same frame
+    hits = {h["name"]: h["lines"] for h in r.search("target")}
+    assert hits == {"a": [2], "b": [2]}

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -16,7 +16,12 @@ if TYPE_CHECKING:
 import httpx
 import pytest
 
-from nixbot.build_scheduler import AttributeResult, AttributeStatus
+from nixbot.build_scheduler import (
+    AttributeResult,
+    AttributeStatus,
+    BuildFailure,
+    DrvFailure,
+)
 from nixbot.db_gen.models import Build as BuildRecord
 from nixbot.events import BuildResult, ChangeEvent, EvalReport, RepoInfo
 from nixbot.forge import GitlabClient
@@ -118,13 +123,17 @@ BUILD = BuildRecord(
 
 
 def attr_result(
-    attr: str, status: AttributeStatus, error: str | None = None
+    attr: str,
+    status: AttributeStatus,
+    error: str | None = None,
+    failure: BuildFailure | None = None,
 ) -> AttributeResult:
     return AttributeResult(
         attr=attr,
         status=status,
         job=NixEvalJobError(error=error or "", attr=attr, attr_path=[attr]),
         error=error,
+        failure=failure,
     )
 
 
@@ -415,6 +424,23 @@ async def test_failure_description_is_headline_not_full_excerpt() -> None:
     # The full excerpt still ships as fenced check-run text.
     idx = poster.posts.index(post)
     assert "pkg> configuring" in poster.extras[idx]["text"]
+
+
+async def test_failure_description_from_structured_failure() -> None:
+    reporter, poster, _ = make_reporter()
+    failure = BuildFailure(
+        drvs=[DrvFailure("pkg", ["configuring", "error: build failed: reason here"])],
+        total=1,
+    )
+    results = [
+        attr_result("pkg", AttributeStatus.failed, error="ignored", failure=failure)
+    ]
+
+    await reporter.build_finished(EVENT, BUILD, BuildResult("failed", 1, results))
+    post = next(p for p in poster.posts if p.context.startswith("nixbot/nix-build "))
+    # Headline comes from the last line of the last failed derivation,
+    # derived from structure, not re-parsed from the error string.
+    assert post.description == "error: build failed: reason here"
 
 
 async def test_success_flip_on_rebuild() -> None:

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -402,6 +402,21 @@ async def test_per_attribute_failure_statuses_capped() -> None:
     assert "4 of 4" in combined.description
 
 
+async def test_failure_description_is_headline_not_full_excerpt() -> None:
+    reporter, poster, _ = make_reporter()
+    excerpt = "pkg> configuring\npkg> Error: build failed: reason here"
+    results = [attr_result("pkg", AttributeStatus.failed, error=excerpt)]
+
+    await reporter.build_finished(EVENT, BUILD, BuildResult("failed", 1, results))
+    post = next(p for p in poster.posts if p.context.startswith("nixbot/nix-build "))
+    # The blurb is the salient last line only, drv prefix stripped, so a
+    # length-capped commit status shows the failure, not the leading noise.
+    assert post.description == "Error: build failed: reason here"
+    # The full excerpt still ships as fenced check-run text.
+    idx = poster.posts.index(post)
+    assert "pkg> configuring" in poster.extras[idx]["text"]
+
+
 async def test_success_flip_on_rebuild() -> None:
     reporter, poster, store = make_reporter()
     context = attr_status_context("github", "acme/widget", "flaky")

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -784,6 +784,47 @@ def test_structured_log_endpoints(client: WebHarness, tmp_path: Path) -> None:
     assert "no matches" in client.get(f"{base}/search").text  # empty query
 
 
+def test_structured_log_window_caps_huge_derivation(
+    client: WebHarness, tmp_path: Path
+) -> None:
+    """A derivation larger than the render cap serves a head+tail window
+    with a load-more marker; ?start&end pulls a bounded middle chunk."""
+    drv = "/nix/store/aaa-huge.drv"
+
+    async def run() -> None:
+        ctx = client.ctx
+        ctx.state_dir = tmp_path
+        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
+        log_file = attribute_log_path(tmp_path, build_id, "x86_64-linux.bad")
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        w = LogContainerWriter()
+        w.register(drv, "huge")
+        for i in range(12000):
+            w.line(drv, f"line{i:05d}")
+        w.status(drv, "built")
+        container_path(log_file).write_bytes(w.finalize())
+
+    client.loop.run_until_complete(run())
+    base = "/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad"
+
+    capped = client.get(f"{base}/drv/0").text
+    assert 'id="d0-L1"' in capped  # head
+    assert "line00000" in capped
+    assert 'id="d0-L12000"' in capped  # tail
+    assert "line11999" in capped
+    assert "line05000" not in capped  # elided middle
+    # The marker auto-loads the gap in bounded chunks.
+    assert 'hx-trigger="revealed"' in capped
+    assert "start=2000&end=4000" in capped
+
+    chunk = client.get(f"{base}/drv/0?start=2000&end=4000").text
+    assert 'id="d0-L2001"' in chunk
+    assert "line02000" in chunk
+    assert 'id="d0-L4000"' in chunk
+    assert "line03999" in chunk
+    assert "start=4000" in chunk  # next marker for the remaining gap
+
+
 def test_log_toc_legacy_without_container(client: WebHarness, tmp_path: Path) -> None:
     seed_log(client, tmp_path)
     toc = client.get(

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -767,7 +767,8 @@ def test_structured_log_endpoints(client: WebHarness, tmp_path: Path) -> None:
 
     # Per-derivation raw: plain text, ANSI stripped.
     raw = client.get(f"{base}/logs/{attr}/drv/0/raw").text
-    assert raw == "CC main.o\nerror: boom undeclared"
+    # Phase markers reconstructed from `ph` so raw readers keep context.
+    assert raw == "Running phase: build\nCC main.o\nerror: boom undeclared"
     assert "\x1b" not in raw
     # A zero-line derivation still has a valid (empty) raw endpoint.
     assert client.get(f"{base}/logs/{attr}/drv/1/raw").text == ""

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -743,9 +743,12 @@ def test_structured_log_endpoints(client: WebHarness, tmp_path: Path) -> None:
         w = LogContainerWriter()
         w.register("/nix/store/aaa-qtbase-5.0.drv", "qtbase-5.0")
         w.phase("/nix/store/aaa-qtbase-5.0.drv", "build")
-        w.line("/nix/store/aaa-qtbase-5.0.drv", "CC main.o")
+        w.line("/nix/store/aaa-qtbase-5.0.drv", "\x1b[31mCC main.o\x1b[0m")
         w.line("/nix/store/aaa-qtbase-5.0.drv", "error: boom undeclared")
         w.status("/nix/store/aaa-qtbase-5.0.drv", "failed")
+        # A substituted dep with no build output.
+        w.register("/nix/store/bbb-zlib-1.3.drv", "zlib-1.3")
+        w.status("/nix/store/bbb-zlib-1.3.drv", "built")
         container_path(log_file).write_bytes(w.finalize())
 
     client.loop.run_until_complete(run())
@@ -758,8 +761,17 @@ def test_structured_log_endpoints(client: WebHarness, tmp_path: Path) -> None:
     assert toc["derivations"][0]["ph"] == [["build", 0]]
 
     rows = client.get(f"{base}/logs/{attr}/drv/0").text
-    assert 'id="L1"' in rows
+    assert 'id="d0-L1"' in rows
     assert "CC main.o" in rows
+
+    # Per-derivation raw: plain text, ANSI stripped.
+    raw = client.get(f"{base}/logs/{attr}/drv/0/raw").text
+    assert raw == "CC main.o\nerror: boom undeclared"
+    assert "\x1b" not in raw
+    # A zero-line derivation still has a valid (empty) raw endpoint.
+    assert client.get(f"{base}/logs/{attr}/drv/1/raw").text == ""
+    assert toc["derivations"][1]["n"] == 0
+    assert client.get(f"{base}/logs/{attr}/drv/9/raw").status_code == 404
 
     hits = client.get(f"{base}/search?q=undeclared").json()
     assert hits["groups"]

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -22,8 +22,14 @@ from nixbot.auth import User
 from nixbot.build_scheduler import AttributeStatus
 from nixbot.db import BuildStatus
 from nixbot.effects_state import TaskTokens
-from nixbot.executor import LogWriter, attribute_log_path, effect_log_path
+from nixbot.executor import (
+    LogWriter,
+    attribute_log_path,
+    container_path,
+    effect_log_path,
+)
 from nixbot.forge_tokens import ForgeTokenStore
+from nixbot.logstore import LogContainerWriter
 from nixbot.web import events as events_module
 from nixbot.web.auth_routes import SESSION_COOKIE, create_auth_router
 from nixbot.web.events import EventBroker
@@ -724,6 +730,51 @@ def test_log_viewer_and_raw(client: WebHarness, tmp_path: Path) -> None:
 
     missing = client.get("/repos/github/acme/widget/builds/2/logs/nope")
     assert missing.status_code == 404
+
+
+def test_structured_log_endpoints(client: WebHarness, tmp_path: Path) -> None:
+    async def run() -> None:
+        ctx = client.ctx
+        ctx.state_dir = tmp_path
+        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
+        log_file = attribute_log_path(tmp_path, build_id, "x86_64-linux.bad")
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        log_file.write_bytes(zstandard.ZstdCompressor().compress(b"flat\n"))
+        w = LogContainerWriter()
+        w.register("/nix/store/aaa-qtbase-5.0.drv", "qtbase-5.0")
+        w.phase("/nix/store/aaa-qtbase-5.0.drv", "build")
+        w.line("/nix/store/aaa-qtbase-5.0.drv", "CC main.o")
+        w.line("/nix/store/aaa-qtbase-5.0.drv", "error: boom undeclared")
+        w.status("/nix/store/aaa-qtbase-5.0.drv", "failed")
+        container_path(log_file).write_bytes(w.finalize())
+
+    client.loop.run_until_complete(run())
+    base = "/repos/github/acme/widget/builds/2"
+    attr = "x86_64-linux.bad"
+
+    toc = client.get(f"{base}/logs/{attr}/toc").json()
+    assert toc["format"] == "nbl1"
+    assert toc["derivations"][0]["name"] == "qtbase-5.0"
+    assert toc["derivations"][0]["ph"] == [["build", 0]]
+
+    rows = client.get(f"{base}/logs/{attr}/drv/0").text
+    assert 'id="L1"' in rows
+    assert "CC main.o" in rows
+
+    hits = client.get(f"{base}/search?q=undeclared").json()
+    assert hits["groups"]
+    g = hits["groups"][0]
+    assert g["name"] == "qtbase-5.0"
+    assert g["attr"] == attr
+    assert g["lines"] == [2]
+
+
+def test_log_toc_legacy_without_container(client: WebHarness, tmp_path: Path) -> None:
+    seed_log(client, tmp_path)
+    toc = client.get(
+        "/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad/toc"
+    ).json()
+    assert toc["format"] == "legacy"
 
 
 def test_attr_named_dot_txt_not_shadowed_by_raw_route(

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -24,6 +24,7 @@ from nixbot.db import BuildStatus
 from nixbot.effects_state import TaskTokens
 from nixbot.executor import (
     LogWriter,
+    StructuredCapture,
     attribute_log_path,
     container_path,
     effect_log_path,
@@ -1141,6 +1142,45 @@ def test_live_log_history_before_completion(client: WebHarness, tmp_path: Path) 
     assert "const LIVE = true" in viewer
     assert "early output" in stream
     assert "late output" in stream
+    assert "event: done" in stream
+
+
+def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
+    """A running attribute with a capture streams per-derivation deltas;
+    the viewer wires the structured client to that stream."""
+    ctx = client.ctx
+    ctx.state_dir = tmp_path
+    registry = client.app.state.log_registry
+
+    async def run() -> tuple[str, str]:
+        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 3")
+        writer = LogWriter(path=tmp_path / "logs" / "live" / "x86_64-linux.ok.zst")
+        cap = StructuredCapture(clock=lambda: 1.0)
+        writer.capture = cap
+        cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")
+        cap.log_line(1, "CC main.o")
+        registry.register(build_id, "x86_64-linux.ok", writer)
+        try:
+            base = "/repos/github/acme/widget/builds/3/logs/x86_64-linux.ok"
+            viewer = (await client.http.get(base)).text
+            task = asyncio.ensure_future(
+                client.http.get(f"{base}/stream?format=structured")
+            )
+            await asyncio.sleep(0.1)
+            cap.phase(1, "build")
+            cap.close()
+            stream = (await task).text
+        finally:
+            registry.unregister(build_id, "x86_64-linux.ok")
+        return viewer, stream
+
+    viewer, stream = client.loop.run_until_complete(run())
+    assert "const LIVE_STRUCTURED = true" in viewer
+    assert "format=structured" in viewer  # data-stream on #drv-list
+    assert "event: state" in stream
+    assert '"name":"qtbase-5.0"' in stream  # snapshot burst
+    assert "event: delta" in stream
+    assert '"t":"phase"' in stream  # live delta after subscribe
     assert "event: done" in stream
 
 

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -774,12 +774,14 @@ def test_structured_log_endpoints(client: WebHarness, tmp_path: Path) -> None:
     assert toc["derivations"][1]["n"] == 0
     assert client.get(f"{base}/logs/{attr}/drv/9/raw").status_code == 404
 
-    hits = client.get(f"{base}/search?q=undeclared").json()
-    assert hits["groups"]
-    g = hits["groups"][0]
-    assert g["name"] == "qtbase-5.0"
-    assert g["attr"] == attr
-    assert g["lines"] == [2]
+    # Search now returns rendered HTML the client swaps in.
+    hits = client.get(f"{base}/search?q=undeclared").text
+    assert 'class="search-name">qtbase-5.0<' in hits
+    assert 'data-idx="0" data-line="2"' in hits
+    assert "1 derivation," in hits
+    assert "1 log match" in hits
+    assert "no matches" in client.get(f"{base}/search?q=zzznope").text
+    assert "no matches" in client.get(f"{base}/search").text  # empty query
 
 
 def test_log_toc_legacy_without_container(client: WebHarness, tmp_path: Path) -> None:
@@ -1168,6 +1170,7 @@ def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
             )
             await asyncio.sleep(0.1)
             cap.phase(1, "build")
+            cap.log_line(1, "\x1b[31mCC failed\x1b[0m")
             cap.close()
             stream = (await task).text
         finally:
@@ -1179,8 +1182,13 @@ def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
     assert "format=structured" in viewer  # data-stream on #drv-list
     assert "event: state" in stream
     assert '"name":"qtbase-5.0"' in stream  # snapshot burst
+    # Rows are rendered server-side (ANSI applied), not shipped as raw text.
+    assert "d1-L1" in stream
+    assert '"text"' not in stream
     assert "event: delta" in stream
     assert '"t":"phase"' in stream  # live delta after subscribe
+    assert '"t":"line"' in stream  # rendered delta
+    assert "ansi-red" in stream
     assert "event: done" in stream
 
 

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -948,16 +948,6 @@ def test_log_viewer_unavailable_for_logless_status(client: WebHarness) -> None:
         client.loop.run_until_complete(restore())
 
 
-def test_log_sse_stream_finished(client: WebHarness, tmp_path: Path) -> None:
-    seed_log(client, tmp_path)
-    response = client.get(
-        "/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad/stream"
-    )
-    assert response.status_code == 200
-    assert "build exploded" in response.text
-    assert "event: done" in response.text
-
-
 # --- JSON API ----------------------------------------------------------
 
 
@@ -1111,42 +1101,6 @@ def test_openapi_docs(client: WebHarness) -> None:
 # --- live logs ---------------------------------------------------------
 
 
-def test_live_log_history_before_completion(client: WebHarness, tmp_path: Path) -> None:
-    """Running attributes have no logs DB row yet: viewer/raw/stream
-    must fall back to the registered LogWriter's on-disk file."""
-    ctx = client.ctx
-    ctx.state_dir = tmp_path
-    registry = client.app.state.log_registry
-
-    async def run() -> tuple[str, str, str]:
-        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 3")
-        writer = LogWriter(path=tmp_path / "logs" / "live" / "x86_64-linux.ok.zst")
-        await writer.write(b"early output\n")
-        registry.register(build_id, "x86_64-linux.ok", writer)
-        try:
-            base = "/repos/github/acme/widget/builds/3/logs/x86_64-linux.ok"
-            raw = (await client.http.get(f"{base}.txt")).text
-            viewer = (await client.http.get(base)).text
-            # The stream must replay history; close the writer so the
-            # SSE generator terminates.
-            stream_task = asyncio.ensure_future(client.http.get(f"{base}/stream"))
-            await asyncio.sleep(0.1)
-            await writer.write(b"late output\n")
-            await writer.close()
-            stream = (await stream_task).text
-        finally:
-            registry.unregister(build_id, "x86_64-linux.ok")
-        return raw, viewer, stream
-
-    raw, viewer, stream = client.loop.run_until_complete(run())
-    assert "early output" in raw
-    # The live viewer renders no snapshot; the stream replays history.
-    assert "const LIVE = true" in viewer
-    assert "early output" in stream
-    assert "late output" in stream
-    assert "event: done" in stream
-
-
 def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
     """A running attribute with a capture streams per-derivation deltas;
     the viewer wires the structured client to that stream."""
@@ -1178,7 +1132,7 @@ def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
         return viewer, stream
 
     viewer, stream = client.loop.run_until_complete(run())
-    assert "const LIVE_STRUCTURED = true" in viewer
+    assert "const LIVE = true" in viewer
     assert "format=structured" in viewer  # data-stream on #drv-list
     assert "event: state" in stream
     assert '"name":"qtbase-5.0"' in stream  # snapshot burst
@@ -1202,21 +1156,23 @@ def test_log_sse_stream_caps_history_backlog(
     registry = client.app.state.log_registry
 
     async def run() -> str:
-        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 3")
-        writer = LogWriter(path=tmp_path / "logs" / "live" / "big.zst")
+        project_id = await ctx.pool.fetchval(
+            "SELECT id FROM projects WHERE forge_repo_id = 'web-1'"
+        )
+        run_id = await _insert_scheduled_run(
+            ctx.pool, project_id, effect="big", status="running"
+        )
+        writer = LogWriter(path=tmp_path / "logs" / "scheduled" / f"{run_id}.zst")
         await writer.write("".join(f"line{i:05d}\n" for i in range(3000)).encode())
-        registry.register(build_id, "x86_64-linux.ok", writer)
+        registry.register_scheduled(run_id, writer)
         try:
-            stream_task = asyncio.ensure_future(
-                client.http.get(
-                    "/repos/github/acme/widget/builds/3/logs/x86_64-linux.ok/stream"
-                )
-            )
+            url = f"/repos/github/acme/widget/schedules/runs/{run_id}/stream"
+            stream_task = asyncio.ensure_future(client.http.get(url))
             await asyncio.sleep(0.1)
             await writer.close()
             return (await stream_task).text
         finally:
-            registry.unregister(build_id, "x86_64-linux.ok")
+            registry.unregister_scheduled(run_id)
 
     stream = client.loop.run_until_complete(run())
     assert "line02999" in stream
@@ -1235,21 +1191,23 @@ def test_log_sse_stream_neutralizes_carriage_returns(
     registry = client.app.state.log_registry
 
     async def run() -> str:
-        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 3")
-        writer = LogWriter(path=tmp_path / "logs" / "live" / "cr.zst")
+        project_id = await ctx.pool.fetchval(
+            "SELECT id FROM projects WHERE forge_repo_id = 'web-1'"
+        )
+        run_id = await _insert_scheduled_run(
+            ctx.pool, project_id, effect="cr", status="running"
+        )
+        writer = LogWriter(path=tmp_path / "logs" / "scheduled" / f"{run_id}.zst")
         await writer.write(b"progress 1%\rprogress 2%\r\nevent: done\rtail\n")
-        registry.register(build_id, "x86_64-linux.ok", writer)
+        registry.register_scheduled(run_id, writer)
         try:
-            stream_task = asyncio.ensure_future(
-                client.http.get(
-                    "/repos/github/acme/widget/builds/3/logs/x86_64-linux.ok/stream"
-                )
-            )
+            url = f"/repos/github/acme/widget/schedules/runs/{run_id}/stream"
+            stream_task = asyncio.ensure_future(client.http.get(url))
             await asyncio.sleep(0.1)
             await writer.close()
             return (await stream_task).text
         finally:
-            registry.unregister(build_id, "x86_64-linux.ok")
+            registry.unregister_scheduled(run_id)
 
     stream = client.loop.run_until_complete(run())
     body_lines = stream.split("\n")

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -634,22 +634,16 @@ class _LogRoutes:
         number: int,
         attr: str,
     ) -> StreamingResponse:
-        """SSE: history from disk, then live chunks until completion.
-
-        With ?format=structured, stream per-derivation deltas from the
-        live capture instead of rendered lines."""
-        _, build, path = await self._resolve(request, forge, owner, name, number, attr)
+        """SSE: a per-derivation state burst then structured deltas from
+        the live capture until the build finishes."""
+        _, build, _ = await self._resolve(request, forge, owner, name, number, attr)
         writer = self.registry.get(build["id"], attr)
-        if request.query_params.get("format") == "structured":
-            capture = writer.capture if writer else None
-            base = request.url.path.removesuffix("/stream")
-            macros: Any = self.ctx.env.get_template("_macros.html").module
-            return StreamingResponse(
-                _structured_events(capture, macros.drv_card, base),
-                media_type="text/event-stream",
-            )
+        capture = writer.capture if writer else None
+        base = request.url.path.removesuffix("/stream")
+        macros: Any = self.ctx.env.get_template("_macros.html").module
         return StreamingResponse(
-            _stream_events(writer, path), media_type="text/event-stream"
+            _structured_events(capture, macros.drv_card, base),
+            media_type="text/event-stream",
         )
 
     async def log_viewer(  # noqa: PLR0913

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -211,18 +211,27 @@ def render_log_lines(text: str) -> str:
     return "".join(lines)
 
 
-def render_drv_lines(reader: LogContainerReader, i: int, base: int = 0) -> str:
-    """One derivation's log as anchored HTML rows; `base` offsets the
-    global line numbers so anchors stay unique across the whole log."""
+def render_drv_lines(reader: LogContainerReader, i: int) -> str:
+    """One derivation's log as anchored HTML rows. Ids are prefixed with
+    the derivation index (`d{i}-L{n}`) so anchors stay unique when many
+    derivations share the page."""
     lines = []
     style = _RESET
-    for n, line in enumerate(reader.lines(i), base + 1):
+    for n, line in enumerate(reader.lines(i), 1):
         rendered, style = _ansi_convert(line, style)
         lines.append(
-            f'<span class="logline" id="L{n}">'
-            f'<a class="lineno" href="#L{n}">{n}</a>{rendered}</span>'
+            f'<span class="logline" id="d{i}-L{n}">'
+            f'<a class="lineno" href="#d{i}-L{n}">{n}</a>{rendered}</span>'
         )
     return "".join(lines)
+
+
+def _toc_entries(reader: LogContainerReader) -> list[dict]:
+    fields = ("name", "status", "n", "ph", "t0", "t1")
+    return [
+        {"idx": i, **{k: reader.entry(i)[k] for k in fields}}
+        for i in range(len(reader))
+    ]
 
 
 async def _load_container(path: Path | None) -> LogContainerReader | None:
@@ -541,12 +550,7 @@ class _LogRoutes:
         reader = await _load_container(path)
         if reader is None:
             return {"format": "legacy"}
-        fields = ("name", "status", "n", "ph", "t0", "t1")
-        drvs = [
-            {"idx": i, **{k: reader.entry(i)[k] for k in fields}}
-            for i in range(len(reader))
-        ]
-        return {"format": "nbl1", "derivations": drvs}
+        return {"format": "nbl1", "derivations": _toc_entries(reader)}
 
     async def log_drv_lines(  # noqa: PLR0913
         self,
@@ -563,9 +567,26 @@ class _LogRoutes:
         reader = await _load_container(path)
         if reader is None or not (0 <= idx < len(reader)):
             raise HTTPException(status_code=404)
-        base = sum(reader.entry(i)["n"] for i in range(idx))
-        html = await asyncio.to_thread(render_drv_lines, reader, idx, base)
+        html = await asyncio.to_thread(render_drv_lines, reader, idx)
         return HTMLResponse(html)
+
+    async def log_drv_raw(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        attr: str,
+        idx: int,
+    ) -> PlainTextResponse:
+        """One derivation's log as plain text (ANSI stripped)."""
+        _, _, path = await self._resolve(request, forge, owner, name, number, attr)
+        reader = await _load_container(path)
+        if reader is None or not (0 <= idx < len(reader)):
+            raise HTTPException(status_code=404)
+        lines = await asyncio.to_thread(reader.lines, idx)
+        return PlainTextResponse(strip_ansi("\n".join(lines)))
 
     async def build_search(  # noqa: PLR0913
         self,
@@ -627,10 +648,16 @@ class _LogRoutes:
         # history on connect, the client would throw it away.
         live = self.registry.get(build["id"], attr) is not None
         content = ""
+        toc: list[dict] | None = None
         waiting = False
         unavailable = False
         if not live:
-            if path is not None and path.exists():
+            reader = await _load_container(path)
+            if reader is not None:
+                # Structured viewer: per-derivation cards render lazily
+                # from /toc + /drv/{idx}; no flat body needed.
+                toc = _toc_entries(reader)
+            elif path is not None and path.exists():
                 data = await asyncio.to_thread(read_log, path)
                 content = await asyncio.to_thread(
                     render_log_lines, data.decode(errors="replace")
@@ -654,6 +681,7 @@ class _LogRoutes:
             attr_status=attr_status,
             attr=attr,
             content=content,
+            toc=toc,
             live=live,
             waiting=waiting,
             unavailable=unavailable,
@@ -678,6 +706,7 @@ def create_log_router(ctx: WebContext, registry: LogRegistry) -> APIRouter:
     router.get(f"{_BASE}/logs/{{attr}}.txt")(routes.log_raw_text_legacy)
     router.get(f"{_BASE}/logs/{{attr:path}}/stream")(routes.log_stream)
     router.get(f"{_BASE}/logs/{{attr:path}}/toc")(routes.log_toc)
+    router.get(f"{_BASE}/logs/{{attr:path}}/drv/{{idx}}/raw")(routes.log_drv_raw)
     router.get(f"{_BASE}/logs/{{attr:path}}/drv/{{idx}}", response_class=HTMLResponse)(
         routes.log_drv_lines
     )

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -11,7 +11,7 @@ import asyncio
 import dataclasses
 import html
 import json
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import (
@@ -37,7 +37,7 @@ from ..status import NO_LOG_STATUSES  # noqa: TID252
 from .api_routes import FailureSummary, clean_row
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    from collections.abc import AsyncGenerator, Callable, Iterable
     from pathlib import Path
 
     from ..executor import LogWriter, StructuredCapture  # noqa: TID252
@@ -212,19 +212,28 @@ def render_log_lines(text: str) -> str:
     return "".join(lines)
 
 
-def render_drv_lines(reader: LogContainerReader, i: int) -> str:
-    """One derivation's log as anchored HTML rows. Ids are prefixed with
-    the derivation index (`d{i}-L{n}`) so anchors stay unique when many
-    derivations share the page."""
-    lines = []
-    style = _RESET
-    for n, line in enumerate(reader.lines(i), 1):
+def render_rows(
+    idx: int, start: int, lines: Iterable[str], style: _Style = _RESET
+) -> tuple[str, _Style]:
+    """Anchored `d{idx}-L{n}` rows for a derivation, numbered from
+    ``start``. Returns the trailing SGR style so a live stream can carry
+    it into the next batch. Ids are prefixed with the derivation index so
+    anchors stay unique when many derivations share the page."""
+    out = []
+    n = start
+    for line in lines:
         rendered, style = _ansi_convert(line, style)
-        lines.append(
-            f'<span class="logline" id="d{i}-L{n}">'
-            f'<a class="lineno" href="#d{i}-L{n}">{n}</a>{rendered}</span>'
+        out.append(
+            f'<span class="logline" id="d{idx}-L{n}">'
+            f'<a class="lineno" href="#d{idx}-L{n}">{n}</a>{rendered}</span>'
         )
-    return "".join(lines)
+        n += 1
+    return "".join(out), style
+
+
+def render_drv_lines(reader: LogContainerReader, i: int) -> str:
+    """One derivation's log as anchored HTML rows."""
+    return render_rows(i, 1, reader.lines(i))[0]
 
 
 def _toc_entries(reader: LogContainerReader) -> list[dict]:
@@ -596,23 +605,25 @@ class _LogRoutes:
         owner: str,
         name: str,
         number: int,
-        q: str = Query(..., min_length=2),
-    ) -> dict:
+        q: str = "",
+    ) -> HTMLResponse:
         """Search every attribute's container; per-derivation hit groups
-        (attr, name, line numbers), failures first. No container -> skipped."""
+        (attr, name, line numbers), failures first. No container -> skipped.
+        Returns rendered HTML the client swaps into #search-results."""
         _, build = await self._build_or_404(request, forge, owner, name, number)
-        groups = []
-        for a in await self.ctx.queries.attributes(build["id"]):
-            path = log_path_for_key(self.ctx.state_dir, build["id"], a["attr"])
-            reader = await _load_container(path)
-            if reader is None:
-                continue
-            for hit in await asyncio.to_thread(reader.search, q):
-                hit["attr"] = a["attr"]
-                hit["status"] = reader.entry(hit["idx"])["status"]
-                groups.append(hit)
-        groups.sort(key=lambda h: (h["status"] != "failed", -len(h["lines"])))
-        return {"query": q, "groups": groups}
+        groups: list[dict] = []
+        if len(q.strip()) >= 2:  # noqa: PLR2004
+            for a in await self.ctx.queries.attributes(build["id"]):
+                path = log_path_for_key(self.ctx.state_dir, build["id"], a["attr"])
+                reader = await _load_container(path)
+                if reader is None:
+                    continue
+                for hit in await asyncio.to_thread(reader.search, q):
+                    hit["attr"] = a["attr"]
+                    hit["status"] = reader.entry(hit["idx"])["status"]
+                    groups.append(hit)
+            groups.sort(key=lambda h: (h["status"] != "failed", -len(h["lines"])))
+        return await self.ctx.render("_search_results.html", groups=groups)
 
     async def log_stream(  # noqa: PLR0913
         self,
@@ -631,8 +642,11 @@ class _LogRoutes:
         writer = self.registry.get(build["id"], attr)
         if request.query_params.get("format") == "structured":
             capture = writer.capture if writer else None
+            base = request.url.path.removesuffix("/stream")
+            macros: Any = self.ctx.env.get_template("_macros.html").module
             return StreamingResponse(
-                _structured_events(capture), media_type="text/event-stream"
+                _structured_events(capture, macros.drv_card, base),
+                media_type="text/event-stream",
             )
         return StreamingResponse(
             _stream_events(writer, path), media_type="text/event-stream"
@@ -800,15 +814,30 @@ async def _stream_events(
 
 async def _structured_events(
     capture: StructuredCapture | None,
+    drv_card: Callable[..., str],
+    base: str,
 ) -> AsyncGenerator[str, None]:
     """Live per-derivation stream: a full-state burst on connect, then
     JSON deltas until the build finishes. A finished/absent capture just
-    signals done so the client reloads into the container page."""
+    signals done so the client reloads into the container page.
+
+    Card shells (via the drv_card macro) and log rows are rendered here;
+    the client only inserts HTML. Each drv carries its trailing SGR style
+    so a later line delta continues the same color."""
+
+    def card(d: dict) -> str:
+        return str(drv_card(d, base, open=d["status"] in ("running", "failed")))
+
     if capture is None:
         yield "event: done\ndata: \n\n"
         return
     queue = capture.subscribe()
     state = capture.state()  # atomic with subscribe: no await between
+    styles: dict[int, _Style] = {}
+    for e in state:
+        html_rows, styles[e["idx"]] = render_rows(e["idx"], 1, e.pop("lines"))
+        e["html"] = html_rows
+        e["card"] = card(e)
     yield f"event: state\ndata: {json.dumps(state, separators=(',', ':'))}\n\n"
     try:
         while True:
@@ -820,6 +849,15 @@ async def _structured_events(
             if delta is None:
                 yield "event: done\ndata: \n\n"
                 return
+            if delta["t"] == "drv":
+                delta["card"] = card(
+                    {**delta, "status": "running", "n": 0, "ph": [], "t0": None}
+                )
+            elif delta["t"] == "line":
+                idx = delta["idx"]
+                delta["html"], styles[idx] = render_rows(
+                    idx, delta["from"], [delta.pop("text")], styles.get(idx, _RESET)
+                )
             yield f"event: delta\ndata: {json.dumps(delta, separators=(',', ':'))}\n\n"
     finally:
         capture.unsubscribe(queue)

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import html
+import json
 from typing import TYPE_CHECKING, NamedTuple
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -39,7 +40,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
     from pathlib import Path
 
-    from ..executor import LogWriter  # noqa: TID252
+    from ..executor import LogWriter, StructuredCapture  # noqa: TID252
     from .app import WebContext
 
 
@@ -622,9 +623,17 @@ class _LogRoutes:
         number: int,
         attr: str,
     ) -> StreamingResponse:
-        """SSE: history from disk, then live chunks until completion."""
+        """SSE: history from disk, then live chunks until completion.
+
+        With ?format=structured, stream per-derivation deltas from the
+        live capture instead of rendered lines."""
         _, build, path = await self._resolve(request, forge, owner, name, number, attr)
         writer = self.registry.get(build["id"], attr)
+        if request.query_params.get("format") == "structured":
+            capture = writer.capture if writer else None
+            return StreamingResponse(
+                _structured_events(capture), media_type="text/event-stream"
+            )
         return StreamingResponse(
             _stream_events(writer, path), media_type="text/event-stream"
         )
@@ -646,7 +655,11 @@ class _LogRoutes:
         )
         # Live pages render no snapshot: the stream replays full
         # history on connect, the client would throw it away.
-        live = self.registry.get(build["id"], attr) is not None
+        writer = self.registry.get(build["id"], attr)
+        live = writer is not None
+        # A running attribute with a capture streams structured deltas;
+        # the client builds cards from the stream, so no server toc.
+        live_structured = writer is not None and writer.capture is not None
         content = ""
         toc: list[dict] | None = None
         waiting = False
@@ -683,6 +696,7 @@ class _LogRoutes:
             content=content,
             toc=toc,
             live=live,
+            live_structured=live_structured,
             waiting=waiting,
             unavailable=unavailable,
             prev_number=prev_number,
@@ -782,6 +796,33 @@ async def _stream_events(
     finally:
         if writer is not None:
             writer.unsubscribe(queue)
+
+
+async def _structured_events(
+    capture: StructuredCapture | None,
+) -> AsyncGenerator[str, None]:
+    """Live per-derivation stream: a full-state burst on connect, then
+    JSON deltas until the build finishes. A finished/absent capture just
+    signals done so the client reloads into the container page."""
+    if capture is None:
+        yield "event: done\ndata: \n\n"
+        return
+    queue = capture.subscribe()
+    state = capture.state()  # atomic with subscribe: no await between
+    yield f"event: state\ndata: {json.dumps(state, separators=(',', ':'))}\n\n"
+    try:
+        while True:
+            try:
+                delta = await asyncio.wait_for(queue.get(), timeout=30)
+            except TimeoutError:
+                yield ": keepalive\n\n"
+                continue
+            if delta is None:
+                yield "event: done\ndata: \n\n"
+                return
+            yield f"event: delta\ndata: {json.dumps(delta, separators=(',', ':'))}\n\n"
+    finally:
+        capture.unsubscribe(queue)
 
 
 def _sse(text: str) -> str:

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -30,7 +30,8 @@ from ..build_scheduler import TERMINAL_FAILURES  # noqa: TID252
 from ..db_gen import maintenance as maint_gen  # noqa: TID252
 from ..db_gen import scheduled as sched_gen  # noqa: TID252
 from ..db_gen import web as gen  # noqa: TID252
-from ..executor import log_path_for_key, read_log  # noqa: TID252
+from ..executor import container_path, log_path_for_key, read_log  # noqa: TID252
+from ..logstore import LogContainerReader, is_container  # noqa: TID252
 from ..status import NO_LOG_STATUSES  # noqa: TID252
 from .api_routes import FailureSummary, clean_row
 
@@ -208,6 +209,31 @@ def render_log_lines(text: str) -> str:
     # .logline is display:block; a joining "\n" inside <pre> would
     # render as an extra blank line.
     return "".join(lines)
+
+
+def render_drv_lines(reader: LogContainerReader, i: int, base: int = 0) -> str:
+    """One derivation's log as anchored HTML rows; `base` offsets the
+    global line numbers so anchors stay unique across the whole log."""
+    lines = []
+    style = _RESET
+    for n, line in enumerate(reader.lines(i), base + 1):
+        rendered, style = _ansi_convert(line, style)
+        lines.append(
+            f'<span class="logline" id="L{n}">'
+            f'<a class="lineno" href="#L{n}">{n}</a>{rendered}</span>'
+        )
+    return "".join(lines)
+
+
+async def _load_container(path: Path | None) -> LogContainerReader | None:
+    """The `.nbl1` sidecar if a finished build wrote one, else None."""
+    if path is None:
+        return None
+    cpath = container_path(path)
+    if not await asyncio.to_thread(cpath.exists):
+        return None
+    blob = await asyncio.to_thread(cpath.read_bytes)
+    return LogContainerReader(blob) if is_container(blob) else None
 
 
 async def _log_text(
@@ -500,6 +526,72 @@ class _LogRoutes:
         _, build = await self._build_or_404(request, forge, owner, name, number)
         return await _failure_summary(self.ctx, self.registry, build, tail)
 
+    async def log_toc(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        attr: str,
+    ) -> dict:
+        """Per-derivation table of contents; `{format: "legacy"}` when no
+        container exists (old or running builds) so the client falls back."""
+        _, _, path = await self._resolve(request, forge, owner, name, number, attr)
+        reader = await _load_container(path)
+        if reader is None:
+            return {"format": "legacy"}
+        fields = ("name", "status", "n", "ph", "t0", "t1")
+        drvs = [
+            {"idx": i, **{k: reader.entry(i)[k] for k in fields}}
+            for i in range(len(reader))
+        ]
+        return {"format": "nbl1", "derivations": drvs}
+
+    async def log_drv_lines(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        attr: str,
+        idx: int,
+    ) -> HTMLResponse:
+        """One derivation's log as anchored HTML rows."""
+        _, _, path = await self._resolve(request, forge, owner, name, number, attr)
+        reader = await _load_container(path)
+        if reader is None or not (0 <= idx < len(reader)):
+            raise HTTPException(status_code=404)
+        base = sum(reader.entry(i)["n"] for i in range(idx))
+        html = await asyncio.to_thread(render_drv_lines, reader, idx, base)
+        return HTMLResponse(html)
+
+    async def build_search(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        q: str = Query(..., min_length=2),
+    ) -> dict:
+        """Search every attribute's container; per-derivation hit groups
+        (attr, name, line numbers), failures first. No container -> skipped."""
+        _, build = await self._build_or_404(request, forge, owner, name, number)
+        groups = []
+        for a in await self.ctx.queries.attributes(build["id"]):
+            path = log_path_for_key(self.ctx.state_dir, build["id"], a["attr"])
+            reader = await _load_container(path)
+            if reader is None:
+                continue
+            for hit in await asyncio.to_thread(reader.search, q):
+                hit["attr"] = a["attr"]
+                hit["status"] = reader.entry(hit["idx"])["status"]
+                groups.append(hit)
+        groups.sort(key=lambda h: (h["status"] != "failed", -len(h["lines"])))
+        return {"query": q, "groups": groups}
+
     async def log_stream(  # noqa: PLR0913
         self,
         request: Request,
@@ -581,9 +673,14 @@ def create_log_router(ctx: WebContext, registry: LogRegistry) -> APIRouter:
     # order matters — raw/stream/.txt are matched before the greedy
     # viewer catch-all. /logs/raw/{attr} is the unambiguous raw route;
     # the .txt suffix stays as a fallback for existing consumers.
+    router.get(f"{_BASE}/search")(routes.build_search)
     router.get(f"{_BASE}/logs/raw/{{attr:path}}")(routes.log_raw_text)
     router.get(f"{_BASE}/logs/{{attr}}.txt")(routes.log_raw_text_legacy)
     router.get(f"{_BASE}/logs/{{attr:path}}/stream")(routes.log_stream)
+    router.get(f"{_BASE}/logs/{{attr:path}}/toc")(routes.log_toc)
+    router.get(f"{_BASE}/logs/{{attr:path}}/drv/{{idx}}", response_class=HTMLResponse)(
+        routes.log_drv_lines
+    )
     router.get(f"{_BASE}/logs/{{attr:path}}", response_class=HTMLResponse)(
         routes.log_viewer
     )

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -231,9 +231,54 @@ def render_rows(
     return "".join(out), style
 
 
-def render_drv_lines(reader: LogContainerReader, i: int) -> str:
-    """One derivation's log as anchored HTML rows."""
-    return render_rows(i, 1, reader.lines(i))[0]
+# A single huge derivation would insert tens of thousands of DOM nodes in
+# one swap and hang the tab. Render only a head+tail window; the elided
+# middle auto-loads as the reader scrolls, one bounded chunk at a time.
+_RENDER_HEAD = 2000
+_RENDER_TAIL = 3000
+_RENDER_CAP = _RENDER_HEAD + _RENDER_TAIL
+_RENDER_CHUNK = 2000
+
+
+def _chunk_marker(idx: int, base: str, start: int, end: int) -> str:
+    """A marker that auto-loads lines [start, end) (0-based) once scrolled
+    into view, one bounded chunk at a time; htmx swaps the fetched rows
+    (and the next marker, if any) over it."""
+    nxt = min(start + _RENDER_CHUNK, end)
+    return (
+        f'<div class="log-elided" role="separator"'
+        f' hx-get="{base}/drv/{idx}?start={start}&end={nxt}"'
+        f' hx-trigger="revealed" hx-target="this" hx-swap="outerHTML">'
+        f"loading {end - start:,} hidden lines…</div>"
+    )
+
+
+def render_drv_window(
+    reader: LogContainerReader,
+    idx: int,
+    base: str,
+    start: int | None = None,
+    end: int | None = None,
+) -> str:
+    """A derivation's log as anchored rows. The initial view (no range)
+    is capped to a head+tail window with a load-more marker spanning the
+    gap; a range request renders lines [start, end) plus another marker
+    if more of the gap remains before the tail."""
+    lines = reader.lines(idx)
+    n = len(lines)
+    gap_end = n - _RENDER_TAIL  # tail starts here; never render past it
+    if start is None:
+        if n <= _RENDER_CAP:
+            return render_rows(idx, 1, lines)[0]
+        head = render_rows(idx, 1, lines[:_RENDER_HEAD])[0]
+        tail = render_rows(idx, gap_end + 1, lines[gap_end:])[0]
+        return head + _chunk_marker(idx, base, _RENDER_HEAD, gap_end) + tail
+    start = max(0, start)
+    end = min(end if end is not None else start + _RENDER_CHUNK, gap_end)
+    rows = render_rows(idx, start + 1, lines[start:end])[0]
+    if end < gap_end:
+        rows += _chunk_marker(idx, base, end, gap_end)
+    return rows
 
 
 def _toc_entries(reader: LogContainerReader) -> list[dict]:
@@ -572,12 +617,17 @@ class _LogRoutes:
         attr: str,
         idx: int,
     ) -> HTMLResponse:
-        """One derivation's log as anchored HTML rows."""
+        """One derivation's log as anchored HTML rows. ?start&end pulls a
+        bounded slice of the elided middle for the load-more marker."""
         _, _, path = await self._resolve(request, forge, owner, name, number, attr)
         reader = await _load_container(path)
         if reader is None or not (0 <= idx < len(reader)):
             raise HTTPException(status_code=404)
-        html = await asyncio.to_thread(render_drv_lines, reader, idx)
+        base = request.url.path.rsplit("/drv/", 1)[0]
+        qp = request.query_params
+        start = int(qp["start"]) if "start" in qp else None
+        end = int(qp["end"]) if "end" in qp else None
+        html = await asyncio.to_thread(render_drv_window, reader, idx, base, start, end)
         return HTMLResponse(html)
 
     async def log_drv_raw(  # noqa: PLR0913

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -645,7 +645,7 @@ class _LogRoutes:
         reader = await _load_container(path)
         if reader is None or not (0 <= idx < len(reader)):
             raise HTTPException(status_code=404)
-        lines = await asyncio.to_thread(reader.lines, idx)
+        lines = await asyncio.to_thread(reader.lines_with_phases, idx)
         return PlainTextResponse(strip_ansi("\n".join(lines)))
 
     async def build_search(  # noqa: PLR0913

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -212,16 +212,39 @@ def render_log_lines(text: str) -> str:
     return "".join(lines)
 
 
+def phase_sep(name: str) -> str:
+    """Inline phase divider; CSS pins it as the current-phase header."""
+    safe = html.escape(name)
+    return (
+        f'<div class="phase-sep" data-phase="{safe}">'
+        f'<span class="phase-name">{safe}</span>'
+        '<span class="phase-nav">'
+        '<button type="button" class="phase-prev" aria-label="Previous phase">↑</button>'
+        '<button type="button" class="phase-next" aria-label="Next phase">↓</button>'
+        "</span></div>"
+    )
+
+
+def _phase_at(ph: list) -> dict[int, str]:
+    """0-based line -> phase name; empty phases collapse into the next."""
+    return {line: name for name, line in ph}
+
+
 def render_rows(
-    idx: int, start: int, lines: Iterable[str], style: _Style = _RESET
+    idx: int,
+    start: int,
+    lines: Iterable[str],
+    style: _Style = _RESET,
+    phases: dict[int, str] | None = None,
 ) -> tuple[str, _Style]:
-    """Anchored `d{idx}-L{n}` rows for a derivation, numbered from
-    ``start``. Returns the trailing SGR style so a live stream can carry
-    it into the next batch. Ids are prefixed with the derivation index so
-    anchors stay unique when many derivations share the page."""
+    """Anchored `d{idx}-L{n}` rows numbered from ``start``, with phase
+    dividers spliced in at their first line. Returns the trailing SGR
+    style so a live stream carries color into the next batch."""
     out = []
     n = start
     for line in lines:
+        if phases and (n - 1) in phases:
+            out.append(phase_sep(phases[n - 1]))
         rendered, style = _ansi_convert(line, style)
         out.append(
             f'<span class="logline" id="d{idx}-L{n}">'
@@ -265,17 +288,18 @@ def render_drv_window(
     gap; a range request renders lines [start, end) plus another marker
     if more of the gap remains before the tail."""
     lines = reader.lines(idx)
+    ph = _phase_at(reader.entry(idx)["ph"])
     n = len(lines)
     gap_end = n - _RENDER_TAIL  # tail starts here; never render past it
     if start is None:
         if n <= _RENDER_CAP:
-            return render_rows(idx, 1, lines)[0]
-        head = render_rows(idx, 1, lines[:_RENDER_HEAD])[0]
-        tail = render_rows(idx, gap_end + 1, lines[gap_end:])[0]
+            return render_rows(idx, 1, lines, phases=ph)[0]
+        head = render_rows(idx, 1, lines[:_RENDER_HEAD], phases=ph)[0]
+        tail = render_rows(idx, gap_end + 1, lines[gap_end:], phases=ph)[0]
         return head + _chunk_marker(idx, base, _RENDER_HEAD, gap_end) + tail
     start = max(0, start)
     end = min(end if end is not None else start + _RENDER_CHUNK, gap_end)
-    rows = render_rows(idx, start + 1, lines[start:end])[0]
+    rows = render_rows(idx, start + 1, lines[start:end], phases=ph)[0]
     if end < gap_end:
         rows += _chunk_marker(idx, base, end, gap_end)
     return rows
@@ -879,7 +903,9 @@ async def _structured_events(
     state = capture.state()  # atomic with subscribe: no await between
     styles: dict[int, _Style] = {}
     for e in state:
-        html_rows, styles[e["idx"]] = render_rows(e["idx"], 1, e.pop("lines"))
+        html_rows, styles[e["idx"]] = render_rows(
+            e["idx"], 1, e.pop("lines"), phases=_phase_at(e["ph"])
+        )
         e["html"] = html_rows
         e["card"] = card(e)
     yield f"event: state\ndata: {json.dumps(state, separators=(',', ':'))}\n\n"
@@ -902,6 +928,8 @@ async def _structured_events(
                 delta["html"], styles[idx] = render_rows(
                     idx, delta["from"], [delta.pop("text")], styles.get(idx, _RESET)
                 )
+            elif delta["t"] == "phase":
+                delta["html"] = phase_sep(delta["phase"])
             yield f"event: delta\ndata: {json.dumps(delta, separators=(',', ':'))}\n\n"
     finally:
         capture.unsubscribe(queue)

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Structured per-derivation log viewer. Cards render lazily from the
 // embedded TOC; each fetches its rows (/drv/{idx}) on first open. Rows are
 // fixed 20px + content-visibility, so the whole log stays in the DOM
@@ -5,17 +6,38 @@
 // the phase bar maps scrollTop -> line via ROW_H. Disclosure is native
 // <details>, like the attr-group / error / menu widgets elsewhere.
 "use strict";
+
+/**
+ * @typedef {{idx:number,name:string,status:string,ph:[string,number][],n:number,pos?:number,t0?:number|null,t1?:number|null,lines?:string[]}} Drv
+ * @typedef {{t:string,idx:number,name?:string,status?:string,phase?:string,line?:number,from?:number,text?:string}} Delta
+ * @typedef {{idx:number,name:string,status:string,lines:number[]}} Group
+ * @typedef {{scrollToLine:(n:number)=>void,refresh:()=>void}} LogHandle
+ */
+
 (() => {
+  /** @param {string} id @returns {HTMLElement|null} */
   const $ = (id) => document.getElementById(id);
-  const esc = (s) =>
-    s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+  /** @param {string} id @returns {HTMLElement} */
+  const must = (id) => {
+    const el = document.getElementById(id);
+    if (!el) throw new Error(`missing #${id}`);
+    return el;
+  };
+  const escMap = /** @type {Record<string,string>} */ (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;" }
+  );
+  /** @param {string} s @returns {string} */
+  const esc = (s) => s.replace(/[&<>]/g, (c) => escMap[c]);
+  /** @param {number} n @param {string} word @param {string} [suffix] */
   const pl = (n, word, suffix = "s") => word + (n === 1 ? "" : suffix);
 
-  const list = $("drv-list");
+  const list = must("drv-list");
   const BASE = list.dataset.base;
   const SEARCH = list.dataset.search;
   const STREAM = list.dataset.stream; // set only while the build runs
   const ROW_H = 20; // must match .log-lines .logline height in style.css
+  /** @param {string} s */
+  // deno-lint-ignore no-control-regex -- ESC is the ANSI sequence intro
   const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "");
 
   const phaseBarHTML = `<div class="phasebar" hidden>
@@ -24,9 +46,23 @@
     <button type="button" class="phase-next" aria-label="Next phase">↓ next</button>
   </div>`;
 
+  /** @param {ParentNode} el @param {string} sel @returns {HTMLElement} */
+  const pick = (el, sel) => {
+    const found = el.querySelector(sel);
+    if (!found) throw new Error(`missing ${sel}`);
+    return /** @type {HTMLElement} */ (found);
+  };
+
   // ph is [[name, first_line], ...]; wire the bar to the rendered rows
   // in vp. Returns a handle so search can scroll to a line.
+  /**
+   * @param {HTMLElement} vp
+   * @param {[string,number][]} phases
+   * @param {HTMLElement|null} bar
+   * @returns {LogHandle}
+   */
   function wireLog(vp, phases, bar) {
+    /** @param {number} n */
     const scrollToLine = (n) => {
       vp.scrollTop = Math.max(0, (n - 1) * ROW_H - vp.clientHeight / 2);
       update();
@@ -41,13 +77,15 @@
       }
       bar.hidden = cur < 0;
       if (cur < 0) return;
-      bar.querySelector(".phase-label").innerHTML =
-        `${esc(phases[cur][0])} phase ` +
+      pick(bar, ".phase-label").innerHTML = `${esc(phases[cur][0])} phase ` +
         `<span class="phase-pos">${cur + 1}/${phases.length}</span>`;
-      bar.querySelector(".phase-prev").disabled = cur <= 0;
-      bar.querySelector(".phase-next").disabled = cur >= phases.length - 1;
+      /** @type {HTMLButtonElement} */ (pick(bar, ".phase-prev")).disabled =
+        cur <= 0;
+      /** @type {HTMLButtonElement} */ (pick(bar, ".phase-next")).disabled =
+        cur >= phases.length - 1;
     }
     if (bar && phases.length) {
+      /** @param {number} dir */
       const jump = (dir) => {
         const top = Math.round(vp.scrollTop / ROW_H);
         const t = dir > 0
@@ -56,16 +94,14 @@
         if (t) scrollToLine(t[1] + 1);
       };
       vp.addEventListener("scroll", update);
-      bar.querySelector(".phase-prev").addEventListener(
-        "click",
-        () => jump(-1),
-      );
-      bar.querySelector(".phase-next").addEventListener("click", () => jump(1));
+      pick(bar, ".phase-prev").addEventListener("click", () => jump(-1));
+      pick(bar, ".phase-next").addEventListener("click", () => jump(1));
       update();
     }
     return { scrollToLine, refresh: update };
   }
 
+  /** @param {Drv} d */
   const bodyInnerHTML = (d) =>
     d.n === 0
       ? `<div class="excerpt"><span class="meta">no output</span></div>`
@@ -75,6 +111,7 @@
     ${phaseBarHTML}
     <div class="log-lines" aria-busy="true"></div>`;
 
+  /** @param {Drv} d @param {boolean} open */
   function cardHTML(d, open) {
     const failed = d.status === "failed";
     const dur = d.t0 != null && d.t1 != null
@@ -96,35 +133,46 @@
     </details>`;
   }
 
+  /** @type {WeakMap<HTMLElement, LogHandle>} */
   const drawn = new WeakMap();
+  /** @param {HTMLElement} card @returns {Promise<LogHandle|null>} */
   async function showCard(card) {
-    const d = TOC[+card.dataset.pos];
-    const body = card.querySelector(".log-card-body");
+    const d = TOC[Number(card.dataset.pos)];
+    const body = pick(card, ".log-card-body");
     if (!body.firstElementChild) body.innerHTML = bodyInnerHTML(d);
-    let handle = drawn.get(card);
-    if (handle) return handle;
-    const vp = body.querySelector(".log-lines");
+    const cached = drawn.get(card);
+    if (cached) return cached;
+    const vp =
+      /** @type {HTMLElement|null} */ (body.querySelector(".log-lines"));
     if (!vp) return null; // no output: nothing to fetch or wire
     const res = await fetch(`${BASE}/drv/${d.idx}`);
     vp.innerHTML = await res.text();
     vp.removeAttribute("aria-busy");
-    handle = wireLog(vp, d.ph, body.querySelector(".phasebar"));
+    const handle = wireLog(
+      vp,
+      d.ph,
+      /** @type {HTMLElement|null} */ (body.querySelector(".phasebar")),
+    );
     drawn.set(card, handle);
     return handle;
   }
 
   // toggle doesn't bubble, so bind per-card when a list is (re)drawn.
+  /** @param {ParentNode} container */
   function wireCards(container) {
     for (const c of container.querySelectorAll(".log-card")) {
-      c.addEventListener("toggle", () => {
-        if (c.open) showCard(c);
+      const card = /** @type {HTMLDetailsElement} */ (c);
+      card.addEventListener("toggle", () => {
+        if (card.open) showCard(card);
       });
     }
   }
 
   if (STREAM) return runLive();
 
-  const TOC = JSON.parse($("toc-data").textContent);
+  const TOC = /** @type {Drv[]} */ (
+    JSON.parse(must("toc-data").textContent ?? "[]")
+  );
   TOC.forEach((d, i) => (d.pos = i));
   const FAILED = TOC.filter((d) => d.status === "failed");
   const OK = TOC.filter((d) => d.status !== "failed");
@@ -148,39 +196,48 @@
     FAILED.map((d, i) => cardHTML(d, i === 0)).join("") +
     okBlock;
   wireCards(list);
-  const firstFail = list.querySelector(".log-card");
+  const firstFail = /** @type {HTMLElement|null} */ (
+    list.querySelector(".log-card")
+  );
   if (firstFail && FAILED.length) showCard(firstFail);
 
   const LIST_CAP = 100;
+  /** @param {string} q */
   function drawOk(q) {
     const hits = q ? OK.filter((d) => d.name.toLowerCase().includes(q)) : OK;
-    $("succeeded-list").innerHTML = hits
+    must("succeeded-list").innerHTML = hits
       .slice(0, LIST_CAP)
       .map((d) => cardHTML(d, false))
       .join("");
-    wireCards($("succeeded-list"));
+    wireCards(must("succeeded-list"));
   }
-  const succeeded = $("succeeded-panel");
+  const succeeded =
+    /** @type {HTMLDetailsElement|null} */ ($("succeeded-panel"));
   if (succeeded) {
     succeeded.addEventListener("toggle", () => {
-      if (succeeded.open && !$("succeeded-list").firstElementChild) drawOk("");
+      if (succeeded.open && !must("succeeded-list").firstElementChild) {
+        drawOk("");
+      }
     });
   }
 
   // Build-scoped search: one debounced request, results grouped by
   // derivation (failures first), each line jumps into the owning card.
-  const posByIdx = new Map(TOC.map((d) => [d.idx, d.pos]));
+  const posByIdx = new Map(
+    TOC.map((d) => [d.idx, /** @type {number} */ (d.pos)]),
+  );
+  /** @param {string} raw */
   async function search(raw) {
     const q = raw.trim();
-    const results = $("search-results");
-    const count = $("search-count");
+    const results = must("search-results");
+    const count = must("search-count");
     results.innerHTML = "";
     if (q.length < 2) {
       count.textContent = "";
       return;
     }
     const res = await fetch(`${SEARCH}?q=${encodeURIComponent(q)}`);
-    const groups = (await res.json()).groups;
+    const groups = /** @type {Group[]} */ ((await res.json()).groups);
     const total = groups.reduce((n, g) => n + g.lines.length, 0);
     count.textContent = groups.length
       ? `${groups.length} ${pl(groups.length, "derivation")}, ` +
@@ -211,26 +268,36 @@
       })
       .join("");
   }
-  let t;
-  $("search-input").addEventListener("input", (e) => {
+  let t = 0;
+  must("search-input").addEventListener("input", (e) => {
     clearTimeout(t);
-    const v = e.target.value;
+    const v = /** @type {HTMLInputElement} */ (e.target).value;
     t = setTimeout(() => search(v), 200);
   });
-  $("search-results").addEventListener("click", (e) => {
-    const a = e.target.closest("a[data-idx]");
+  must("search-results").addEventListener("click", (e) => {
+    const a = /** @type {HTMLElement} */ (e.target).closest("a[data-idx]");
     if (!a) return;
     e.preventDefault();
-    openAt(+a.dataset.idx, a.dataset.line ? +a.dataset.line : null);
+    const link = /** @type {HTMLElement} */ (a);
+    openAt(
+      Number(link.dataset.idx),
+      link.dataset.line ? Number(link.dataset.line) : null,
+    );
   });
 
+  /** @param {number} idx @param {number|null} line */
   async function openAt(idx, line) {
     const pos = posByIdx.get(idx);
-    let card = list.querySelector(`.log-card[data-pos="${pos}"]`);
+    if (pos == null) return;
+    let card = /** @type {HTMLDetailsElement|null} */ (
+      list.querySelector(`.log-card[data-pos="${pos}"]`)
+    );
     if (!card && succeeded) {
       succeeded.open = true;
       drawOk(TOC[pos].name.toLowerCase());
-      card = list.querySelector(`.log-card[data-pos="${pos}"]`);
+      card = /** @type {HTMLDetailsElement|null} */ (
+        list.querySelector(`.log-card[data-pos="${pos}"]`)
+      );
     }
     if (!card) return;
     card.open = true;
@@ -249,21 +316,27 @@
   // in arrival order, the running one following its tail. The
   // terminal-status reload swaps to the polished container page.
   function runLive() {
+    /** @type {Map<number, Drv>} */
     const byIdx = new Map();
+    /** @type {Map<number, HTMLDetailsElement>} */
     const cardOf = new Map();
+    /** @type {Map<number, LogHandle>} */
     const handleOf = new Map();
+    /** @param {string} s */
     const iconState = (s) =>
       s === "failed" ? "failed" : s === "running" ? "running" : "succeeded";
+    /** @param {number} idx @param {number} n @param {string} text */
     const rowHTML = (idx, n, text) =>
       `<span class="logline" id="d${idx}-L${n}">` +
       `<a class="lineno" href="#d${idx}-L${n}">${n}</a>${
         esc(stripAnsi(text))
       }</span>`;
 
+    /** @param {Drv} d @returns {HTMLDetailsElement} */
     function cardEl(d) {
       const el = document.createElement("details");
       el.className = "log-card" + (d.status === "failed" ? "" : " ok");
-      el.dataset.idx = d.idx;
+      el.dataset.idx = String(d.idx);
       if (d.status === "running" || d.status === "failed") el.open = true;
       el.innerHTML = `<summary>
           <span class="status-icon ${
@@ -277,33 +350,37 @@
       return el;
     }
 
+    /** @param {Drv} d @returns {HTMLDetailsElement} */
     function ensureCard(d) {
-      let el = cardOf.get(d.idx);
-      if (el) return el;
-      el = cardEl(d);
+      const existing = cardOf.get(d.idx);
+      if (existing) return existing;
+      const el = cardEl(d);
       list.appendChild(el);
       cardOf.set(d.idx, el);
-      const vp = el.querySelector(".log-lines");
-      handleOf.set(d.idx, wireLog(vp, d.ph, el.querySelector(".phasebar")));
+      handleOf.set(
+        d.idx,
+        wireLog(pick(el, ".log-lines"), d.ph, el.querySelector(".phasebar")),
+      );
       return el;
     }
 
+    /** @param {Drv} d @returns {HTMLDetailsElement} */
     function setMeta(d) {
       const el = ensureCard(d);
-      el.querySelector(".status-icon").className = "status-icon " +
-        iconState(d.status);
+      pick(el, ".status-icon").className = "status-icon " + iconState(d.status);
       el.classList.toggle("ok", d.status !== "failed");
-      el.querySelector(".meta").textContent = d.status === "running"
+      pick(el, ".meta").textContent = d.status === "running"
         ? "building…"
         : d.status;
       return el;
     }
 
+    /** @param {number} idx @param {number} from @param {string[]} texts */
     function addLines(idx, from, texts) {
       const d = byIdx.get(idx);
       if (!d || !texts.length) return;
       const el = ensureCard(d);
-      const vp = el.querySelector(".log-lines");
+      const vp = pick(el, ".log-lines");
       // Follow the tail only when already at the bottom, so scrolling up
       // to read pauses following and scrolling back resumes it.
       const atBottom = vp.scrollHeight - vp.scrollTop - vp.clientHeight < 40;
@@ -315,33 +392,35 @@
       if (el.open && atBottom) vp.scrollTop = vp.scrollHeight;
     }
 
+    /** @param {Delta} delta */
     function apply(delta) {
       const d = byIdx.get(delta.idx);
       if (delta.t === "drv") {
         const nd = {
           idx: delta.idx,
-          name: delta.name,
+          name: delta.name ?? "",
           status: "running",
-          ph: [],
+          /** @type {[string,number][]} */ ph: [],
           n: 0,
         };
         byIdx.set(nd.idx, nd);
         setMeta(nd);
       } else if (delta.t === "line") {
-        addLines(delta.idx, delta.from, [delta.text]);
+        addLines(delta.idx, delta.from ?? 1, [delta.text ?? ""]);
       } else if (delta.t === "phase" && d) {
         if (!d.ph.length || d.ph[d.ph.length - 1][0] !== delta.phase) {
-          d.ph.push([delta.phase, delta.line]);
+          d.ph.push([delta.phase ?? "", delta.line ?? 0]);
         }
         handleOf.get(d.idx)?.refresh();
       } else if (delta.t === "status" && d) {
-        d.status = delta.status;
+        d.status = delta.status ?? d.status;
         const el = setMeta(d);
         if (delta.status === "failed") el.open = true;
         else if (delta.status !== "running") el.open = false;
       }
     }
 
+    /** @param {Drv[]} state */
     function reset(state) {
       list.innerHTML = "";
       byIdx.clear();
@@ -362,7 +441,7 @@
     }
 
     let errors = 0;
-    const src = new EventSource(STREAM);
+    const src = new EventSource(/** @type {string} */ (STREAM));
     src.addEventListener("state", (ev) => {
       errors = 0;
       reset(JSON.parse(ev.data));

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -1,0 +1,242 @@
+// Structured per-derivation log viewer. Cards render lazily from the
+// embedded TOC; each fetches its rows (/drv/{idx}) on first open. Rows are
+// fixed 20px + content-visibility, so the whole log stays in the DOM
+// (native Ctrl-F, anchors, selection, a11y) with off-screen layout skipped;
+// the phase bar maps scrollTop -> line via ROW_H. Disclosure is native
+// <details>, like the attr-group / error / menu widgets elsewhere.
+"use strict";
+(() => {
+  const $ = (id) => document.getElementById(id);
+  const esc = (s) =>
+    s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+  const pl = (n, word, suffix = "s") => word + (n === 1 ? "" : suffix);
+
+  const TOC = JSON.parse($("toc-data").textContent);
+  const list = $("drv-list");
+  const BASE = list.dataset.base;
+  const SEARCH = list.dataset.search;
+  TOC.forEach((d, i) => (d.pos = i));
+  const FAILED = TOC.filter((d) => d.status === "failed");
+  const OK = TOC.filter((d) => d.status !== "failed");
+  const ROW_H = 20; // must match .log-lines .logline height in style.css
+
+  const phaseBarHTML = `<div class="phasebar" hidden>
+    <span class="phase-label"></span>
+    <button type="button" class="phase-prev" aria-label="Previous phase">↑ prev</button>
+    <button type="button" class="phase-next" aria-label="Next phase">↓ next</button>
+  </div>`;
+
+  // ph is [[name, first_line], ...]; wire the bar to the rendered rows
+  // in vp. Returns a handle so search can scroll to a line.
+  function wireLog(vp, phases, bar) {
+    const scrollToLine = (n) => {
+      vp.scrollTop = Math.max(0, (n - 1) * ROW_H - vp.clientHeight / 2);
+      update();
+    };
+    function update() {
+      if (!bar || !phases.length) return;
+      const top = Math.round(vp.scrollTop / ROW_H);
+      let cur = -1;
+      for (const [, start] of phases) {
+        if (start <= top) cur++;
+        else break;
+      }
+      bar.hidden = cur < 0;
+      if (cur < 0) return;
+      bar.querySelector(".phase-label").innerHTML =
+        `${esc(phases[cur][0])} phase ` +
+        `<span class="phase-pos">${cur + 1}/${phases.length}</span>`;
+      bar.querySelector(".phase-prev").disabled = cur <= 0;
+      bar.querySelector(".phase-next").disabled = cur >= phases.length - 1;
+    }
+    if (bar && phases.length) {
+      const jump = (dir) => {
+        const top = Math.round(vp.scrollTop / ROW_H);
+        const t = dir > 0
+          ? phases.find((p) => p[1] > top)
+          : phases.filter((p) => p[1] < top).pop();
+        if (t) scrollToLine(t[1] + 1);
+      };
+      vp.addEventListener("scroll", update);
+      bar.querySelector(".phase-prev").addEventListener(
+        "click",
+        () => jump(-1),
+      );
+      bar.querySelector(".phase-next").addEventListener("click", () => jump(1));
+      update();
+    }
+    return { scrollToLine };
+  }
+
+  const bodyInnerHTML = (d) =>
+    d.n === 0
+      ? `<div class="excerpt"><span class="meta">no output</span></div>`
+      : `<div class="excerpt">
+      <a href="${BASE}/drv/${d.idx}/raw" class="raw">raw&nbsp;↗</a>
+    </div>
+    ${phaseBarHTML}
+    <div class="log-lines" aria-busy="true"></div>`;
+
+  function cardHTML(d, open) {
+    const failed = d.status === "failed";
+    const dur = d.t0 != null && d.t1 != null
+      ? `${((d.t1 - d.t0) / 1000).toFixed(1)}s`
+      : "";
+    const meta = failed ? "failed" : ["built", dur].filter(Boolean).join(" · ");
+    const state = failed ? "failed" : "succeeded";
+    return `<details class="log-card${
+      failed ? "" : " ok"
+    }" data-pos="${d.pos}"${open ? " open" : ""}>
+      <summary>
+        <span class="status-icon ${state}" aria-hidden="true"></span>
+        <span class="card-text">
+          <span class="card-name">${esc(d.name)}</span>
+          <span class="meta">${meta}</span>
+        </span>
+      </summary>
+      <div class="log-card-body">${open ? bodyInnerHTML(d) : ""}</div>
+    </details>`;
+  }
+
+  const drawn = new WeakMap();
+  async function showCard(card) {
+    const d = TOC[+card.dataset.pos];
+    const body = card.querySelector(".log-card-body");
+    if (!body.firstElementChild) body.innerHTML = bodyInnerHTML(d);
+    let handle = drawn.get(card);
+    if (handle) return handle;
+    const vp = body.querySelector(".log-lines");
+    if (!vp) return null; // no output: nothing to fetch or wire
+    const res = await fetch(`${BASE}/drv/${d.idx}`);
+    vp.innerHTML = await res.text();
+    vp.removeAttribute("aria-busy");
+    handle = wireLog(vp, d.ph, body.querySelector(".phasebar"));
+    drawn.set(card, handle);
+    return handle;
+  }
+
+  // toggle doesn't bubble, so bind per-card when a list is (re)drawn.
+  function wireCards(container) {
+    for (const c of container.querySelectorAll(".log-card")) {
+      c.addEventListener("toggle", () => {
+        if (c.open) showCard(c);
+      });
+    }
+  }
+
+  // failures first (first one open); successes collapsed behind a card.
+  const okBlock = OK.length
+    ? `<h2 class="section">Succeeded (${OK.length})</h2>
+       <details class="succeeded-panel" id="succeeded-panel">
+         <summary>
+           <span class="status-icon succeeded" aria-hidden="true"></span>
+           <span class="card-text"><span class="card-name">${OK.length} built</span>
+             <span class="meta">expand to browse</span></span>
+         </summary>
+         <div id="succeeded-list"></div>
+       </details>`
+    : "";
+  list.innerHTML =
+    (FAILED.length
+      ? `<h2 class="section">Failures (${FAILED.length})</h2>`
+      : "") +
+    FAILED.map((d, i) => cardHTML(d, i === 0)).join("") +
+    okBlock;
+  wireCards(list);
+  const firstFail = list.querySelector(".log-card");
+  if (firstFail && FAILED.length) showCard(firstFail);
+
+  const LIST_CAP = 100;
+  function drawOk(q) {
+    const hits = q ? OK.filter((d) => d.name.toLowerCase().includes(q)) : OK;
+    $("succeeded-list").innerHTML = hits
+      .slice(0, LIST_CAP)
+      .map((d) => cardHTML(d, false))
+      .join("");
+    wireCards($("succeeded-list"));
+  }
+  const succeeded = $("succeeded-panel");
+  if (succeeded) {
+    succeeded.addEventListener("toggle", () => {
+      if (succeeded.open && !$("succeeded-list").firstElementChild) drawOk("");
+    });
+  }
+
+  // Build-scoped search: one debounced request, results grouped by
+  // derivation (failures first), each line jumps into the owning card.
+  const posByIdx = new Map(TOC.map((d) => [d.idx, d.pos]));
+  async function search(raw) {
+    const q = raw.trim();
+    const results = $("search-results");
+    const count = $("search-count");
+    results.innerHTML = "";
+    if (q.length < 2) {
+      count.textContent = "";
+      return;
+    }
+    const res = await fetch(`${SEARCH}?q=${encodeURIComponent(q)}`);
+    const groups = (await res.json()).groups;
+    const total = groups.reduce((n, g) => n + g.lines.length, 0);
+    count.textContent = groups.length
+      ? `${groups.length} ${pl(groups.length, "derivation")}, ` +
+        `${total} log ${pl(total, "match", "es")}`
+      : "no matches";
+    results.innerHTML = groups
+      .map((g) => {
+        const ok = g.status !== "failed";
+        const head =
+          `<a href="#" class="search-drv${
+            ok ? " ok" : ""
+          }" data-idx="${g.idx}">` +
+          `<span class="status-icon ${
+            ok ? "succeeded" : "failed"
+          }" aria-hidden="true"></span>` +
+          `<span class="search-name">${esc(g.name)}</span>` +
+          `<span class="search-badge">${g.lines.length} ${
+            pl(g.lines.length, "match", "es")
+          }</span></a>`;
+        const lines = g.lines
+          .map(
+            (ln) =>
+              `<li><a href="#" data-idx="${g.idx}" data-line="${ln}">` +
+              `<span class="search-line">${ln}</span></a></li>`,
+          )
+          .join("");
+        return `<li class="search-group">${head}<ul class="search-lines">${lines}</ul></li>`;
+      })
+      .join("");
+  }
+  let t;
+  $("search-input").addEventListener("input", (e) => {
+    clearTimeout(t);
+    const v = e.target.value;
+    t = setTimeout(() => search(v), 200);
+  });
+  $("search-results").addEventListener("click", (e) => {
+    const a = e.target.closest("a[data-idx]");
+    if (!a) return;
+    e.preventDefault();
+    openAt(+a.dataset.idx, a.dataset.line ? +a.dataset.line : null);
+  });
+
+  async function openAt(idx, line) {
+    const pos = posByIdx.get(idx);
+    let card = list.querySelector(`.log-card[data-pos="${pos}"]`);
+    if (!card && succeeded) {
+      succeeded.open = true;
+      drawOk(TOC[pos].name.toLowerCase());
+      card = list.querySelector(`.log-card[data-pos="${pos}"]`);
+    }
+    if (!card) return;
+    card.open = true;
+    const handle = await showCard(card);
+    card.scrollIntoView({ block: "nearest" });
+    document
+      .querySelectorAll(".log-lines .logline.hit")
+      .forEach((x) => x.classList.remove("hit"));
+    if (line == null || !handle) return;
+    const row = document.getElementById(`d${idx}-L${line}`);
+    if (row) row.classList.add("hit");
+    handle.scrollToLine(line);
+  }
+})();

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -58,9 +58,9 @@
       if (!bar || !phases.length) return;
       const top = Math.round(vp.scrollTop / ROW_H);
       let cur = -1;
-      // first_line is 1-based, top 0-based: first phase shows at top=0.
+      // first_line and top are 0-based: first phase shows at top=0.
       for (const [, start] of phases) {
-        if (start - 1 <= top) cur++;
+        if (start <= top) cur++;
         else break;
       }
       bar.hidden = cur < 0;

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -1,6 +1,6 @@
 // @ts-check
-// Structured per-derivation log viewer. Cards render lazily from the
-// embedded TOC; each fetches its rows (/drv/{idx}) on first open. Rows are
+// Structured per-derivation log viewer. Cards are server-rendered; htmx
+// fetches each card's rows (/drv/{idx}) lazily on first open. Rows are
 // fixed 20px + content-visibility, so the whole log stays in the DOM
 // (native Ctrl-F, anchors, selection, a11y) with off-screen layout skipped;
 // the phase bar maps scrollTop -> line via ROW_H. Disclosure is native
@@ -8,9 +8,8 @@
 "use strict";
 
 /**
- * @typedef {{idx:number,name:string,status:string,ph:[string,number][],n:number,pos?:number,t0?:number|null,t1?:number|null,lines?:string[]}} Drv
- * @typedef {{t:string,idx:number,name?:string,status?:string,phase?:string,line?:number,from?:number,text?:string}} Delta
- * @typedef {{idx:number,name:string,status:string,lines:number[]}} Group
+ * @typedef {{idx:number,name:string,status:string,ph:[string,number][],n:number,t0?:number|null,t1?:number|null,html?:string,card?:string}} Drv
+ * @typedef {{t:string,idx:number,name?:string,status?:string,phase?:string,line?:number,from?:number,html?:string,card?:string}} Delta
  * @typedef {{scrollToLine:(n:number)=>void,refresh:()=>void}} LogHandle
  */
 
@@ -23,28 +22,16 @@
     if (!el) throw new Error(`missing #${id}`);
     return el;
   };
-  const escMap = /** @type {Record<string,string>} */ (
-    { "&": "&amp;", "<": "&lt;", ">": "&gt;" }
-  );
   /** @param {string} s @returns {string} */
-  const esc = (s) => s.replace(/[&<>]/g, (c) => escMap[c]);
-  /** @param {number} n @param {string} word @param {string} [suffix] */
-  const pl = (n, word, suffix = "s") => word + (n === 1 ? "" : suffix);
+  const esc = (s) =>
+    s.replace(
+      /[&<>]/g,
+      (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c] ?? c),
+    );
 
   const list = must("drv-list");
-  const BASE = list.dataset.base;
-  const SEARCH = list.dataset.search;
   const STREAM = list.dataset.stream; // set only while the build runs
   const ROW_H = 20; // must match .log-lines .logline height in style.css
-  /** @param {string} s */
-  // deno-lint-ignore no-control-regex -- ESC is the ANSI sequence intro
-  const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "");
-
-  const phaseBarHTML = `<div class="phasebar" hidden>
-    <span class="phase-label"></span>
-    <button type="button" class="phase-prev" aria-label="Previous phase">↑ prev</button>
-    <button type="button" class="phase-next" aria-label="Next phase">↓ next</button>
-  </div>`;
 
   /** @param {ParentNode} el @param {string} sel @returns {HTMLElement} */
   const pick = (el, sel) => {
@@ -101,216 +88,65 @@
     return { scrollToLine, refresh: update };
   }
 
-  /** @param {Drv} d */
-  const bodyInnerHTML = (d) =>
-    d.n === 0
-      ? `<div class="excerpt"><span class="meta">no output</span></div>`
-      : `<div class="excerpt">
-      <a href="${BASE}/drv/${d.idx}/raw" class="raw">raw&nbsp;↗</a>
-    </div>
-    ${phaseBarHTML}
-    <div class="log-lines" aria-busy="true"></div>`;
-
-  /** @param {Drv} d @param {boolean} open */
-  function cardHTML(d, open) {
-    const failed = d.status === "failed";
-    const dur = d.t0 != null && d.t1 != null
-      ? `${((d.t1 - d.t0) / 1000).toFixed(1)}s`
-      : "";
-    const meta = failed ? "failed" : ["built", dur].filter(Boolean).join(" · ");
-    const state = failed ? "failed" : "succeeded";
-    return `<details class="log-card${
-      failed ? "" : " ok"
-    }" data-pos="${d.pos}"${open ? " open" : ""}>
-      <summary>
-        <span class="status-icon ${state}" aria-hidden="true"></span>
-        <span class="card-text">
-          <span class="card-name">${esc(d.name)}</span>
-          <span class="meta">${meta}</span>
-        </span>
-      </summary>
-      <div class="log-card-body">${open ? bodyInnerHTML(d) : ""}</div>
-    </details>`;
-  }
-
-  /** @type {WeakMap<HTMLElement, LogHandle>} */
-  const drawn = new WeakMap();
-  /** @param {HTMLElement} card @returns {Promise<LogHandle|null>} */
-  async function showCard(card) {
-    const d = TOC[Number(card.dataset.pos)];
-    const body = pick(card, ".log-card-body");
-    if (!body.firstElementChild) body.innerHTML = bodyInnerHTML(d);
-    const cached = drawn.get(card);
-    if (cached) return cached;
-    const vp =
-      /** @type {HTMLElement|null} */ (body.querySelector(".log-lines"));
-    if (!vp) return null; // no output: nothing to fetch or wire
-    const res = await fetch(`${BASE}/drv/${d.idx}`);
-    vp.innerHTML = await res.text();
-    vp.removeAttribute("aria-busy");
-    const handle = wireLog(
-      vp,
-      d.ph,
-      /** @type {HTMLElement|null} */ (body.querySelector(".phasebar")),
-    );
-    drawn.set(card, handle);
-    return handle;
-  }
-
-  // toggle doesn't bubble, so bind per-card when a list is (re)drawn.
-  /** @param {ParentNode} container */
-  function wireCards(container) {
-    for (const c of container.querySelectorAll(".log-card")) {
-      const card = /** @type {HTMLDetailsElement} */ (c);
-      card.addEventListener("toggle", () => {
-        if (card.open) showCard(card);
-      });
-    }
-  }
-
   if (STREAM) return runLive();
 
-  const TOC = /** @type {Drv[]} */ (
-    JSON.parse(must("toc-data").textContent ?? "[]")
-  );
-  TOC.forEach((d, i) => (d.pos = i));
-  const FAILED = TOC.filter((d) => d.status === "failed");
-  const OK = TOC.filter((d) => d.status !== "failed");
-
-  // failures first (first one open); successes collapsed behind a card.
-  const okBlock = OK.length
-    ? `<h2 class="section">Succeeded (${OK.length})</h2>
-       <details class="succeeded-panel" id="succeeded-panel">
-         <summary>
-           <span class="status-icon succeeded" aria-hidden="true"></span>
-           <span class="card-text"><span class="card-name">${OK.length} built</span>
-             <span class="meta">expand to browse</span></span>
-         </summary>
-         <div id="succeeded-list"></div>
-       </details>`
-    : "";
-  list.innerHTML =
-    (FAILED.length
-      ? `<h2 class="section">Failures (${FAILED.length})</h2>`
-      : "") +
-    FAILED.map((d, i) => cardHTML(d, i === 0)).join("") +
-    okBlock;
-  wireCards(list);
-  const firstFail = /** @type {HTMLElement|null} */ (
-    list.querySelector(".log-card")
-  );
-  if (firstFail && FAILED.length) showCard(firstFail);
-
-  const LIST_CAP = 100;
-  /** @param {string} q */
-  function drawOk(q) {
-    const hits = q ? OK.filter((d) => d.name.toLowerCase().includes(q)) : OK;
-    must("succeeded-list").innerHTML = hits
-      .slice(0, LIST_CAP)
-      .map((d) => cardHTML(d, false))
-      .join("");
-    wireCards(must("succeeded-list"));
-  }
+  // htmx fetches each card's rows into .log-lines (on open, or on load for
+  // the first failure); here we wire the phase bar to the swapped-in rows.
+  /** @type {WeakMap<HTMLElement, LogHandle>} */
+  const drawn = new WeakMap();
   const succeeded =
     /** @type {HTMLDetailsElement|null} */ ($("succeeded-panel"));
-  if (succeeded) {
-    succeeded.addEventListener("toggle", () => {
-      if (succeeded.open && !must("succeeded-list").firstElementChild) {
-        drawOk("");
-      }
-    });
+  /** @type {{card:HTMLElement, idx:number, line:number|null}|null} */
+  let pending = null;
+
+  /** @param {HTMLElement} card @param {LogHandle} handle
+   * @param {number} idx @param {number|null} line */
+  function jump(card, handle, idx, line) {
+    card.scrollIntoView({ block: "nearest" });
+    document
+      .querySelectorAll(".log-lines .logline.hit")
+      .forEach((x) => x.classList.remove("hit"));
+    if (line == null) return;
+    document.getElementById(`d${idx}-L${line}`)?.classList.add("hit");
+    handle.scrollToLine(line);
   }
 
-  // Build-scoped search: one debounced request, results grouped by
-  // derivation (failures first), each line jumps into the owning card.
-  const posByIdx = new Map(
-    TOC.map((d) => [d.idx, /** @type {number} */ (d.pos)]),
-  );
-  /** @param {string} raw */
-  async function search(raw) {
-    const q = raw.trim();
-    const results = must("search-results");
-    const count = must("search-count");
-    results.innerHTML = "";
-    if (q.length < 2) {
-      count.textContent = "";
-      return;
+  document.body.addEventListener("htmx:afterSwap", (e) => {
+    const vp = /** @type {HTMLElement} */ (e.target);
+    if (!vp.classList?.contains("log-lines")) return;
+    vp.removeAttribute("aria-busy");
+    const card = /** @type {HTMLElement|null} */ (vp.closest(".log-card"));
+    if (!card) return;
+    const ph = /** @type {[string,number][]} */ (
+      JSON.parse(card.dataset.ph || "[]")
+    );
+    const handle = wireLog(vp, ph, card.querySelector(".phasebar"));
+    drawn.set(card, handle);
+    if (pending && pending.card === card) {
+      jump(card, handle, pending.idx, pending.line);
+      pending = null;
     }
-    const res = await fetch(`${SEARCH}?q=${encodeURIComponent(q)}`);
-    const groups = /** @type {Group[]} */ ((await res.json()).groups);
-    const total = groups.reduce((n, g) => n + g.lines.length, 0);
-    count.textContent = groups.length
-      ? `${groups.length} ${pl(groups.length, "derivation")}, ` +
-        `${total} log ${pl(total, "match", "es")}`
-      : "no matches";
-    results.innerHTML = groups
-      .map((g) => {
-        const ok = g.status !== "failed";
-        const head =
-          `<a href="#" class="search-drv${
-            ok ? " ok" : ""
-          }" data-idx="${g.idx}">` +
-          `<span class="status-icon ${
-            ok ? "succeeded" : "failed"
-          }" aria-hidden="true"></span>` +
-          `<span class="search-name">${esc(g.name)}</span>` +
-          `<span class="search-badge">${g.lines.length} ${
-            pl(g.lines.length, "match", "es")
-          }</span></a>`;
-        const lines = g.lines
-          .map(
-            (ln) =>
-              `<li><a href="#" data-idx="${g.idx}" data-line="${ln}">` +
-              `<span class="search-line">${ln}</span></a></li>`,
-          )
-          .join("");
-        return `<li class="search-group">${head}<ul class="search-lines">${lines}</ul></li>`;
-      })
-      .join("");
-  }
-  let t = 0;
-  must("search-input").addEventListener("input", (e) => {
-    clearTimeout(t);
-    const v = /** @type {HTMLInputElement} */ (e.target).value;
-    t = setTimeout(() => search(v), 200);
   });
+
+  // Search results are server-rendered; the client only jumps into a
+  // card, waiting for htmx to load its rows when they aren't yet present.
   must("search-results").addEventListener("click", (e) => {
     const a = /** @type {HTMLElement} */ (e.target).closest("a[data-idx]");
     if (!a) return;
     e.preventDefault();
     const link = /** @type {HTMLElement} */ (a);
-    openAt(
-      Number(link.dataset.idx),
-      link.dataset.line ? Number(link.dataset.line) : null,
+    const idx = Number(link.dataset.idx);
+    const line = link.dataset.line ? Number(link.dataset.line) : null;
+    const card = /** @type {HTMLDetailsElement|null} */ (
+      list.querySelector(`.log-card[data-idx="${idx}"]`)
     );
-  });
-
-  /** @param {number} idx @param {number|null} line */
-  async function openAt(idx, line) {
-    const pos = posByIdx.get(idx);
-    if (pos == null) return;
-    let card = /** @type {HTMLDetailsElement|null} */ (
-      list.querySelector(`.log-card[data-pos="${pos}"]`)
-    );
-    if (!card && succeeded) {
-      succeeded.open = true;
-      drawOk(TOC[pos].name.toLowerCase());
-      card = /** @type {HTMLDetailsElement|null} */ (
-        list.querySelector(`.log-card[data-pos="${pos}"]`)
-      );
-    }
     if (!card) return;
-    card.open = true;
-    const handle = await showCard(card);
-    card.scrollIntoView({ block: "nearest" });
-    document
-      .querySelectorAll(".log-lines .logline.hit")
-      .forEach((x) => x.classList.remove("hit"));
-    if (line == null || !handle) return;
-    const row = document.getElementById(`d${idx}-L${line}`);
-    if (row) row.classList.add("hit");
-    handle.scrollToLine(line);
-  }
+    if (succeeded && succeeded.contains(card)) succeeded.open = true;
+    card.open = true; // triggers the htmx fetch if not yet loaded
+    const handle = drawn.get(card);
+    if (handle) jump(card, handle, idx, line);
+    else pending = { card, idx, line }; // afterSwap completes the jump
+  });
 
   // Live mode: build cards from the structured SSE (state burst + deltas),
   // in arrival order, the running one following its tail. The
@@ -325,37 +161,15 @@
     /** @param {string} s */
     const iconState = (s) =>
       s === "failed" ? "failed" : s === "running" ? "running" : "succeeded";
-    /** @param {number} idx @param {number} n @param {string} text */
-    const rowHTML = (idx, n, text) =>
-      `<span class="logline" id="d${idx}-L${n}">` +
-      `<a class="lineno" href="#d${idx}-L${n}">${n}</a>${
-        esc(stripAnsi(text))
-      }</span>`;
 
-    /** @param {Drv} d @returns {HTMLDetailsElement} */
-    function cardEl(d) {
-      const el = document.createElement("details");
-      el.className = "log-card" + (d.status === "failed" ? "" : " ok");
-      el.dataset.idx = String(d.idx);
-      if (d.status === "running" || d.status === "failed") el.open = true;
-      el.innerHTML = `<summary>
-          <span class="status-icon ${
-        iconState(d.status)
-      }" aria-hidden="true"></span>
-          <span class="card-text"><span class="card-name">${
-        esc(d.name)
-      }</span><span class="meta"></span></span>
-        </summary>
-        <div class="log-card-body"><div class="excerpt"></div>${phaseBarHTML}<div class="log-lines"></div></div>`;
-      return el;
-    }
-
-    /** @param {Drv} d @returns {HTMLDetailsElement} */
+    /** Insert the server-rendered card shell (same drv_card macro as the
+     * finished page) and wire its phase bar.
+     * @param {Drv} d @returns {HTMLDetailsElement} */
     function ensureCard(d) {
       const existing = cardOf.get(d.idx);
       if (existing) return existing;
-      const el = cardEl(d);
-      list.appendChild(el);
+      list.insertAdjacentHTML("beforeend", d.card ?? "");
+      const el = /** @type {HTMLDetailsElement} */ (list.lastElementChild);
       cardOf.set(d.idx, el);
       handleOf.set(
         d.idx,
@@ -375,20 +189,18 @@
       return el;
     }
 
-    /** @param {number} idx @param {number} from @param {string[]} texts */
-    function addLines(idx, from, texts) {
+    /** Append server-rendered rows (ANSI already applied).
+     * @param {number} idx @param {number} n @param {string} html */
+    function addLines(idx, n, html) {
       const d = byIdx.get(idx);
-      if (!d || !texts.length) return;
+      if (!d || !html) return;
       const el = ensureCard(d);
       const vp = pick(el, ".log-lines");
       // Follow the tail only when already at the bottom, so scrolling up
       // to read pauses following and scrolling back resumes it.
       const atBottom = vp.scrollHeight - vp.scrollTop - vp.clientHeight < 40;
-      vp.insertAdjacentHTML(
-        "beforeend",
-        texts.map((t, k) => rowHTML(idx, from + k, t)).join(""),
-      );
-      d.n = from + texts.length - 1;
+      vp.insertAdjacentHTML("beforeend", html);
+      d.n = n;
       if (el.open && atBottom) vp.scrollTop = vp.scrollHeight;
     }
 
@@ -402,11 +214,12 @@
           status: "running",
           /** @type {[string,number][]} */ ph: [],
           n: 0,
+          card: delta.card,
         };
         byIdx.set(nd.idx, nd);
         setMeta(nd);
       } else if (delta.t === "line") {
-        addLines(delta.idx, delta.from ?? 1, [delta.text ?? ""]);
+        addLines(delta.idx, delta.from ?? 1, delta.html ?? "");
       } else if (delta.t === "phase" && d) {
         if (!d.ph.length || d.ph[d.ph.length - 1][0] !== delta.phase) {
           d.ph.push([delta.phase ?? "", delta.line ?? 0]);
@@ -433,10 +246,11 @@
           status: e.status,
           ph: e.ph || [],
           n: e.n,
+          card: e.card,
         };
         byIdx.set(d.idx, d);
         setMeta(d);
-        addLines(d.idx, 1, e.lines || []);
+        addLines(d.idx, e.n, e.html || "");
       }
     }
 

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -11,14 +11,12 @@
     s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
   const pl = (n, word, suffix = "s") => word + (n === 1 ? "" : suffix);
 
-  const TOC = JSON.parse($("toc-data").textContent);
   const list = $("drv-list");
   const BASE = list.dataset.base;
   const SEARCH = list.dataset.search;
-  TOC.forEach((d, i) => (d.pos = i));
-  const FAILED = TOC.filter((d) => d.status === "failed");
-  const OK = TOC.filter((d) => d.status !== "failed");
+  const STREAM = list.dataset.stream; // set only while the build runs
   const ROW_H = 20; // must match .log-lines .logline height in style.css
+  const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "");
 
   const phaseBarHTML = `<div class="phasebar" hidden>
     <span class="phase-label"></span>
@@ -65,7 +63,7 @@
       bar.querySelector(".phase-next").addEventListener("click", () => jump(1));
       update();
     }
-    return { scrollToLine };
+    return { scrollToLine, refresh: update };
   }
 
   const bodyInnerHTML = (d) =>
@@ -123,6 +121,13 @@
       });
     }
   }
+
+  if (STREAM) return runLive();
+
+  const TOC = JSON.parse($("toc-data").textContent);
+  TOC.forEach((d, i) => (d.pos = i));
+  const FAILED = TOC.filter((d) => d.status === "failed");
+  const OK = TOC.filter((d) => d.status !== "failed");
 
   // failures first (first one open); successes collapsed behind a card.
   const okBlock = OK.length
@@ -238,5 +243,139 @@
     const row = document.getElementById(`d${idx}-L${line}`);
     if (row) row.classList.add("hit");
     handle.scrollToLine(line);
+  }
+
+  // Live mode: build cards from the structured SSE (state burst + deltas),
+  // in arrival order, the running one following its tail. The
+  // terminal-status reload swaps to the polished container page.
+  function runLive() {
+    const byIdx = new Map();
+    const cardOf = new Map();
+    const handleOf = new Map();
+    const iconState = (s) =>
+      s === "failed" ? "failed" : s === "running" ? "running" : "succeeded";
+    const rowHTML = (idx, n, text) =>
+      `<span class="logline" id="d${idx}-L${n}">` +
+      `<a class="lineno" href="#d${idx}-L${n}">${n}</a>${
+        esc(stripAnsi(text))
+      }</span>`;
+
+    function cardEl(d) {
+      const el = document.createElement("details");
+      el.className = "log-card" + (d.status === "failed" ? "" : " ok");
+      el.dataset.idx = d.idx;
+      if (d.status === "running" || d.status === "failed") el.open = true;
+      el.innerHTML = `<summary>
+          <span class="status-icon ${
+        iconState(d.status)
+      }" aria-hidden="true"></span>
+          <span class="card-text"><span class="card-name">${
+        esc(d.name)
+      }</span><span class="meta"></span></span>
+        </summary>
+        <div class="log-card-body"><div class="excerpt"></div>${phaseBarHTML}<div class="log-lines"></div></div>`;
+      return el;
+    }
+
+    function ensureCard(d) {
+      let el = cardOf.get(d.idx);
+      if (el) return el;
+      el = cardEl(d);
+      list.appendChild(el);
+      cardOf.set(d.idx, el);
+      const vp = el.querySelector(".log-lines");
+      handleOf.set(d.idx, wireLog(vp, d.ph, el.querySelector(".phasebar")));
+      return el;
+    }
+
+    function setMeta(d) {
+      const el = ensureCard(d);
+      el.querySelector(".status-icon").className = "status-icon " +
+        iconState(d.status);
+      el.classList.toggle("ok", d.status !== "failed");
+      el.querySelector(".meta").textContent = d.status === "running"
+        ? "building…"
+        : d.status;
+      return el;
+    }
+
+    function addLines(idx, from, texts) {
+      const d = byIdx.get(idx);
+      if (!d || !texts.length) return;
+      const el = ensureCard(d);
+      const vp = el.querySelector(".log-lines");
+      // Follow the tail only when already at the bottom, so scrolling up
+      // to read pauses following and scrolling back resumes it.
+      const atBottom = vp.scrollHeight - vp.scrollTop - vp.clientHeight < 40;
+      vp.insertAdjacentHTML(
+        "beforeend",
+        texts.map((t, k) => rowHTML(idx, from + k, t)).join(""),
+      );
+      d.n = from + texts.length - 1;
+      if (el.open && atBottom) vp.scrollTop = vp.scrollHeight;
+    }
+
+    function apply(delta) {
+      const d = byIdx.get(delta.idx);
+      if (delta.t === "drv") {
+        const nd = {
+          idx: delta.idx,
+          name: delta.name,
+          status: "running",
+          ph: [],
+          n: 0,
+        };
+        byIdx.set(nd.idx, nd);
+        setMeta(nd);
+      } else if (delta.t === "line") {
+        addLines(delta.idx, delta.from, [delta.text]);
+      } else if (delta.t === "phase" && d) {
+        if (!d.ph.length || d.ph[d.ph.length - 1][0] !== delta.phase) {
+          d.ph.push([delta.phase, delta.line]);
+        }
+        handleOf.get(d.idx)?.refresh();
+      } else if (delta.t === "status" && d) {
+        d.status = delta.status;
+        const el = setMeta(d);
+        if (delta.status === "failed") el.open = true;
+        else if (delta.status !== "running") el.open = false;
+      }
+    }
+
+    function reset(state) {
+      list.innerHTML = "";
+      byIdx.clear();
+      cardOf.clear();
+      handleOf.clear();
+      for (const e of state) {
+        const d = {
+          idx: e.idx,
+          name: e.name,
+          status: e.status,
+          ph: e.ph || [],
+          n: e.n,
+        };
+        byIdx.set(d.idx, d);
+        setMeta(d);
+        addLines(d.idx, 1, e.lines || []);
+      }
+    }
+
+    let errors = 0;
+    const src = new EventSource(STREAM);
+    src.addEventListener("state", (ev) => {
+      errors = 0;
+      reset(JSON.parse(ev.data));
+    });
+    src.addEventListener("delta", (ev) => apply(JSON.parse(ev.data)));
+    src.addEventListener("done", () => src.close());
+    // EventSource reconnects ~every 1s; if the server stays gone (engine
+    // restart) give up and reload so the finished log renders server-side.
+    src.onerror = () => {
+      if (++errors >= 5) {
+        src.close();
+        setTimeout(() => location.reload(), 3000);
+      }
+    };
   }
 })();

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -117,8 +117,10 @@
     vp.removeAttribute("aria-busy");
     const card = /** @type {HTMLElement|null} */ (vp.closest(".log-card"));
     if (!card) return;
+    // A capped (head+tail) log has a gap, so scrollTop->line math and its
+    // phase bar would be wrong; drop the phases for those.
     const ph = /** @type {[string,number][]} */ (
-      JSON.parse(card.dataset.ph || "[]")
+      vp.querySelector(".log-elided") ? [] : JSON.parse(card.dataset.ph || "[]")
     );
     const handle = wireLog(vp, ph, card.querySelector(".phasebar"));
     drawn.set(card, handle);

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -130,15 +130,9 @@
     }
   });
 
-  // Search results are server-rendered; the client only jumps into a
-  // card, waiting for htmx to load its rows when they aren't yet present.
-  must("search-results").addEventListener("click", (e) => {
-    const a = /** @type {HTMLElement} */ (e.target).closest("a[data-idx]");
-    if (!a) return;
-    e.preventDefault();
-    const link = /** @type {HTMLElement} */ (a);
-    const idx = Number(link.dataset.idx);
-    const line = link.dataset.line ? Number(link.dataset.line) : null;
+  // Open the owning card (loading its rows if needed) and jump to a line.
+  /** @param {number} idx @param {number|null} line */
+  function openAt(idx, line) {
     const card = /** @type {HTMLDetailsElement|null} */ (
       list.querySelector(`.log-card[data-idx="${idx}"]`)
     );
@@ -148,7 +142,34 @@
     const handle = drawn.get(card);
     if (handle) jump(card, handle, idx, line);
     else pending = { card, idx, line }; // afterSwap completes the jump
+  }
+
+  // Search results are server-rendered; the client only jumps into a
+  // card, waiting for htmx to load its rows when they aren't yet present.
+  must("search-results").addEventListener("click", (e) => {
+    const a = /** @type {HTMLElement} */ (e.target).closest("a[data-idx]");
+    if (!a) return;
+    e.preventDefault();
+    const link = /** @type {HTMLElement} */ (a);
+    openAt(
+      Number(link.dataset.idx),
+      link.dataset.line ? Number(link.dataset.line) : null,
+    );
   });
+
+  // A #d{idx}-L{n} permalink can't scroll on its own: the row is fetched
+  // lazily, so on load (and on hashchange) resolve it through openAt.
+  function jumpToHash() {
+    const m = /^#d(\d+)-L(\d+)$/.exec(location.hash);
+    if (m) openAt(Number(m[1]), Number(m[2]));
+  }
+  globalThis.addEventListener("hashchange", jumpToHash);
+  // Wait for htmx to wire its toggle triggers (on DOMContentLoaded);
+  // opening a card sooner fires toggle into the void and never fetches.
+  if (document.readyState === "complete") jumpToHash();
+  else {document.addEventListener("DOMContentLoaded", jumpToHash, {
+      once: true,
+    });}
 
   // Live mode: build cards from the structured SSE (state burst + deltas),
   // in arrival order, the running one following its tail. The

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -1,16 +1,14 @@
 // @ts-check
 // Structured per-derivation log viewer. Cards are server-rendered; htmx
-// fetches each card's rows (/drv/{idx}) lazily on first open. Rows are
-// fixed 20px + content-visibility, so the whole log stays in the DOM
-// (native Ctrl-F, anchors, selection, a11y) with off-screen layout skipped;
-// the phase bar maps scrollTop -> line via ROW_H. Disclosure is native
-// <details>, like the attr-group / error / menu widgets elsewhere.
+// fetches each card's rows (/drv/{idx}) lazily on first open. Phase
+// dividers are inline sticky elements the server splices in (see
+// phase_sep in logs.py); CSS pins them, so there is no scroll math here.
+// Disclosure is native <details>, like the attr-group / error widgets.
 "use strict";
 
 /**
- * @typedef {{idx:number,name:string,status:string,ph:[string,number][],n:number,t0?:number|null,t1?:number|null,html?:string,card?:string}} Drv
- * @typedef {{t:string,idx:number,name?:string,status?:string,phase?:string,line?:number,from?:number,html?:string,card?:string}} Delta
- * @typedef {{scrollToLine:(n:number)=>void,refresh:()=>void}} LogHandle
+ * @typedef {{idx:number,name:string,status:string,n:number,t0?:number|null,t1?:number|null,html?:string,card?:string}} Drv
+ * @typedef {{t:string,idx:number,name?:string,status?:string,from?:number,html?:string,card?:string}} Delta
  */
 
 (() => {
@@ -22,16 +20,8 @@
     if (!el) throw new Error(`missing #${id}`);
     return el;
   };
-  /** @param {string} s @returns {string} */
-  const esc = (s) =>
-    s.replace(
-      /[&<>]/g,
-      (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c] ?? c),
-    );
-
   const list = must("drv-list");
   const STREAM = list.dataset.stream; // set only while the build runs
-  const ROW_H = 20; // must match .log-lines .logline height in style.css
 
   /** @param {ParentNode} el @param {string} sel @returns {HTMLElement} */
   const pick = (el, sel) => {
@@ -40,76 +30,51 @@
     return /** @type {HTMLElement} */ (found);
   };
 
-  // ph is [[name, first_line], ...]; wire the bar to the rendered rows
-  // in vp. Returns a handle so search can scroll to a line.
-  /**
-   * @param {HTMLElement} vp
-   * @param {[string,number][]} phases
-   * @param {HTMLElement|null} bar
-   * @returns {LogHandle}
-   */
-  function wireLog(vp, phases, bar) {
-    /** @param {number} n */
-    const scrollToLine = (n) => {
-      vp.scrollTop = Math.max(0, (n - 1) * ROW_H - vp.clientHeight / 2);
-      update();
-    };
-    function update() {
-      if (!bar || !phases.length) return;
-      const top = Math.round(vp.scrollTop / ROW_H);
-      let cur = -1;
-      // first_line and top are 0-based: first phase shows at top=0.
-      for (const [, start] of phases) {
-        if (start <= top) cur++;
-        else break;
-      }
-      bar.hidden = cur < 0;
-      if (cur < 0) return;
-      pick(bar, ".phase-label").innerHTML = `${esc(phases[cur][0])} ` +
-        `<span class="phase-pos">(${cur + 1}/${phases.length})</span>`;
-      /** @type {HTMLButtonElement} */ (pick(bar, ".phase-prev")).disabled =
-        cur <= 0;
-      /** @type {HTMLButtonElement} */ (pick(bar, ".phase-next")).disabled =
-        cur >= phases.length - 1;
+  // Phase nav: prev/next scroll to the sibling divider. The clicked
+  // button lives in the sticky (current) divider, so no state to track.
+  list.addEventListener("click", (e) => {
+    const btn = /** @type {HTMLElement} */ (e.target).closest(
+      ".phase-prev, .phase-next",
+    );
+    if (!btn) return;
+    const sep = btn.closest(".phase-sep");
+    const vp = /** @type {HTMLElement|null} */ (btn.closest(".log-lines"));
+    if (!sep || !vp) return;
+    const seps = [...vp.querySelectorAll(".phase-sep")];
+    const next = btn.matches(".phase-next");
+    const to = seps[seps.indexOf(sep) + (next ? 1 : -1)];
+    // Target the phase's first line, not the divider: dividers are sticky
+    // (always pinned at top), so nothing scrolls to them. Past the last /
+    // before the first phase, fall through to the log's bottom / top.
+    const row = to?.nextElementSibling;
+    if (row) {
+      vp.scrollTop += row.getBoundingClientRect().top -
+        vp.getBoundingClientRect().top;
+    } else {
+      vp.scrollTop = next ? vp.scrollHeight : 0;
     }
-    if (bar && phases.length) {
-      /** @param {number} dir */
-      const jump = (dir) => {
-        const top = Math.round(vp.scrollTop / ROW_H);
-        const t = dir > 0
-          ? phases.find((p) => p[1] > top)
-          : phases.filter((p) => p[1] < top).pop();
-        if (t) scrollToLine(t[1] + 1);
-      };
-      vp.addEventListener("scroll", update);
-      pick(bar, ".phase-prev").addEventListener("click", () => jump(-1));
-      pick(bar, ".phase-next").addEventListener("click", () => jump(1));
-      update();
-    }
-    return { scrollToLine, refresh: update };
-  }
+  });
 
   if (STREAM) return runLive();
 
-  // htmx fetches each card's rows into .log-lines (on open, or on load for
-  // the first failure); here we wire the phase bar to the swapped-in rows.
-  /** @type {WeakMap<HTMLElement, LogHandle>} */
-  const drawn = new WeakMap();
+  // Track cards whose rows are loaded so a jump fires now or waits.
+  /** @type {WeakSet<HTMLElement>} */
+  const loaded = new WeakSet();
   const succeeded =
     /** @type {HTMLDetailsElement|null} */ ($("succeeded-panel"));
   /** @type {{card:HTMLElement, idx:number, line:number|null}|null} */
   let pending = null;
 
-  /** @param {HTMLElement} card @param {LogHandle} handle
-   * @param {number} idx @param {number|null} line */
-  function jump(card, handle, idx, line) {
+  /** @param {HTMLElement} card @param {number} idx @param {number|null} line */
+  function jump(card, idx, line) {
     card.scrollIntoView({ block: "nearest" });
     document
       .querySelectorAll(".log-lines .logline.hit")
       .forEach((x) => x.classList.remove("hit"));
     if (line == null) return;
-    document.getElementById(`d${idx}-L${line}`)?.classList.add("hit");
-    handle.scrollToLine(line);
+    const el = document.getElementById(`d${idx}-L${line}`);
+    el?.classList.add("hit");
+    el?.scrollIntoView({ block: "center" });
   }
 
   document.body.addEventListener("htmx:afterSwap", (e) => {
@@ -118,16 +83,12 @@
     vp.removeAttribute("aria-busy");
     const card = /** @type {HTMLElement|null} */ (vp.closest(".log-card"));
     if (!card) return;
-    // A capped (head+tail) log has a gap, so scrollTop->line math and its
-    // phase bar would be wrong; drop the phases for those.
-    const ph = /** @type {[string,number][]} */ (
-      vp.querySelector(".log-elided") ? [] : JSON.parse(card.dataset.ph || "[]")
-    );
-    const handle = wireLog(vp, ph, card.querySelector(".phasebar"));
-    drawn.set(card, handle);
+    loaded.add(card);
     if (pending && pending.card === card) {
-      jump(card, handle, pending.idx, pending.line);
+      jump(card, pending.idx, pending.line);
       pending = null;
+    } else if (!card.classList.contains("ok")) {
+      vp.scrollTop = vp.scrollHeight; // a failure's error is at the end
     }
   });
 
@@ -140,8 +101,7 @@
     if (!card) return;
     if (succeeded && succeeded.contains(card)) succeeded.open = true;
     card.open = true; // triggers the htmx fetch if not yet loaded
-    const handle = drawn.get(card);
-    if (handle) jump(card, handle, idx, line);
+    if (loaded.has(card)) jump(card, idx, line);
     else pending = { card, idx, line }; // afterSwap completes the jump
   }
 
@@ -180,14 +140,12 @@
     const byIdx = new Map();
     /** @type {Map<number, HTMLDetailsElement>} */
     const cardOf = new Map();
-    /** @type {Map<number, LogHandle>} */
-    const handleOf = new Map();
     /** @param {string} s */
     const iconState = (s) =>
       s === "failed" ? "failed" : s === "running" ? "running" : "succeeded";
 
     /** Insert the server-rendered card shell (same drv_card macro as the
-     * finished page) and wire its phase bar.
+     * finished page).
      * @param {Drv} d @returns {HTMLDetailsElement} */
     function ensureCard(d) {
       const existing = cardOf.get(d.idx);
@@ -195,10 +153,6 @@
       list.insertAdjacentHTML("beforeend", d.card ?? "");
       const el = /** @type {HTMLDetailsElement} */ (list.lastElementChild);
       cardOf.set(d.idx, el);
-      handleOf.set(
-        d.idx,
-        wireLog(pick(el, ".log-lines"), d.ph, el.querySelector(".phasebar")),
-      );
       return el;
     }
 
@@ -236,7 +190,6 @@
           idx: delta.idx,
           name: delta.name ?? "",
           status: "running",
-          /** @type {[string,number][]} */ ph: [],
           n: 0,
           card: delta.card,
         };
@@ -245,10 +198,11 @@
       } else if (delta.t === "line") {
         addLines(delta.idx, delta.from ?? 1, delta.html ?? "");
       } else if (delta.t === "phase" && d) {
-        if (!d.ph.length || d.ph[d.ph.length - 1][0] !== delta.phase) {
-          d.ph.push([delta.phase ?? "", delta.line ?? 0]);
-        }
-        handleOf.get(d.idx)?.refresh();
+        // The divider is a normal row appended before the phase's output.
+        pick(ensureCard(d), ".log-lines").insertAdjacentHTML(
+          "beforeend",
+          delta.html ?? "",
+        );
       } else if (delta.t === "status" && d) {
         d.status = delta.status ?? d.status;
         const el = setMeta(d);
@@ -262,13 +216,11 @@
       list.innerHTML = "";
       byIdx.clear();
       cardOf.clear();
-      handleOf.clear();
       for (const e of state) {
         const d = {
           idx: e.idx,
           name: e.name,
           status: e.status,
-          ph: e.ph || [],
           n: e.n,
           card: e.card,
         };

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -58,14 +58,15 @@
       if (!bar || !phases.length) return;
       const top = Math.round(vp.scrollTop / ROW_H);
       let cur = -1;
+      // first_line is 1-based, top 0-based: first phase shows at top=0.
       for (const [, start] of phases) {
-        if (start <= top) cur++;
+        if (start - 1 <= top) cur++;
         else break;
       }
       bar.hidden = cur < 0;
       if (cur < 0) return;
-      pick(bar, ".phase-label").innerHTML = `${esc(phases[cur][0])} phase ` +
-        `<span class="phase-pos">${cur + 1}/${phases.length}</span>`;
+      pick(bar, ".phase-label").innerHTML = `${esc(phases[cur][0])} ` +
+        `<span class="phase-pos">(${cur + 1}/${phases.length})</span>`;
       /** @type {HTMLButtonElement} */ (pick(bar, ".phase-prev")).disabled =
         cur <= 0;
       /** @type {HTMLButtonElement} */ (pick(bar, ".phase-next")).disabled =

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -900,18 +900,23 @@ details.webhook-setup summary {
 
 /* Structured log viewer: per-derivation cards, phase bar, lazy log.
    Disclosure is native <details>; only the summary chrome is styled. */
-.log-card {
+.log-card,
+.succeeded-panel {
 	background: var(--card);
 	border: 1px solid var(--border);
-	border-left: 3px solid var(--bad);
 	border-radius: 8px;
+}
+.log-card {
+	border-left: 3px solid var(--bad);
 	margin: 0.5rem 0;
 	overflow: hidden;
 }
-.log-card.ok {
+.log-card.ok,
+.search-drv.ok {
 	border-left-color: var(--ok);
 }
-.log-card > summary {
+.log-card > summary,
+.succeeded-panel > summary {
 	display: flex;
 	align-items: center;
 	gap: 0.6rem;
@@ -919,10 +924,12 @@ details.webhook-setup summary {
 	cursor: pointer;
 	list-style: none;
 }
-.log-card > summary::-webkit-details-marker {
+.log-card > summary::-webkit-details-marker,
+.succeeded-panel > summary::-webkit-details-marker {
 	display: none;
 }
-.log-card > summary:hover {
+.log-card > summary:hover,
+.succeeded-panel > summary:hover {
 	background: var(--hover);
 }
 .card-text {
@@ -930,7 +937,8 @@ details.webhook-setup summary {
 	flex-direction: column;
 	min-width: 0;
 }
-.card-name {
+.card-name,
+.search-name {
 	font-weight: 600;
 	overflow-wrap: anywhere;
 }
@@ -1108,12 +1116,6 @@ details.webhook-setup summary {
 .search-drv {
 	border-left: 3px solid var(--bad);
 }
-.search-drv.ok {
-	border-left-color: var(--ok);
-}
-.search-name {
-	font-weight: 600;
-}
 .search-badge {
 	color: var(--muted);
 	font-size: 0.75rem;
@@ -1130,25 +1132,6 @@ details.webhook-setup summary {
 	font-variant-numeric: tabular-nums;
 	width: 5ch;
 	text-align: right;
-}
-.succeeded-panel {
-	background: var(--card);
-	border: 1px solid var(--border);
-	border-radius: 8px;
-}
-.succeeded-panel > summary {
-	display: flex;
-	align-items: center;
-	gap: 0.6rem;
-	padding: 0.55rem 0.8rem;
-	cursor: pointer;
-	list-style: none;
-}
-.succeeded-panel > summary::-webkit-details-marker {
-	display: none;
-}
-.succeeded-panel > summary:hover {
-	background: var(--hover);
 }
 #succeeded-list {
 	border-top: 1px solid var(--border);

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -741,6 +741,7 @@ pre.log {
 .pipeline:hover {
 	border-color: var(--accent);
 	border-left-color: var(--status-color, var(--accent));
+	text-decoration: none;
 }
 .pipeline-info {
 	display: flex;

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -897,3 +897,255 @@ details.webhook-setup summary {
 	font-size: 0.75rem;
 	padding: 0.15rem 0.5rem;
 }
+
+/* Structured log viewer: per-derivation cards, phase bar, lazy log.
+   Disclosure is native <details>; only the summary chrome is styled. */
+.log-card {
+	background: var(--card);
+	border: 1px solid var(--border);
+	border-left: 3px solid var(--bad);
+	border-radius: 8px;
+	margin: 0.5rem 0;
+	overflow: hidden;
+}
+.log-card.ok {
+	border-left-color: var(--ok);
+}
+.log-card > summary {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+	padding: 0.55rem 0.8rem;
+	cursor: pointer;
+	list-style: none;
+}
+.log-card > summary::-webkit-details-marker {
+	display: none;
+}
+.log-card > summary:hover {
+	background: var(--hover);
+}
+.card-text {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+.card-name {
+	font-weight: 600;
+	overflow-wrap: anywhere;
+}
+.card-text .meta {
+	color: var(--muted);
+	font-size: 0.8rem;
+}
+.browse-hint::after {
+	content: "expand to browse";
+}
+.succeeded-panel[open] > summary .browse-hint::after {
+	content: "collapse";
+}
+.log-card-body {
+	border-top: 1px solid var(--border);
+}
+.excerpt {
+	padding: 0.6rem 0.8rem;
+}
+.raw {
+	color: var(--accent);
+	text-decoration: none;
+	white-space: nowrap;
+}
+.raw:hover {
+	text-decoration: underline;
+}
+/* Grow to fit, cap then scroll; smaller cap on phones. */
+.log-lines {
+	max-height: 21rem;
+	overflow: auto;
+	overscroll-behavior: contain;
+	border-top: 1px solid var(--border);
+	background: var(--card);
+	font-family: var(--mono);
+	font-size: 0.8125rem;
+}
+@media (max-width: 40rem) {
+	.log-lines {
+		max-height: 14rem;
+	}
+}
+/* Whole log stays in the DOM (Ctrl-F, anchors, selection, a11y);
+   content-visibility skips off-screen layout/paint. Fixed 20px row +
+   matching contain-intrinsic-size keeps the scrollbar honest and lets
+   the phase bar map scrollTop -> line by ROW_H (see structured-logs.js). */
+.log-lines .logline {
+	display: flex;
+	height: 20px;
+	line-height: 20px;
+	white-space: pre;
+	content-visibility: auto;
+	contain-intrinsic-size: auto 20px;
+	scroll-margin-top: 2rem;
+}
+/* Space the gutter with margin, not flex gap: ANSI colors split a line
+   into several span children and gap would space them apart mid-line. */
+.log-lines .lineno {
+	width: 5ch;
+	margin: 0 1ch 0 0;
+	padding: 0;
+	color: var(--muted);
+	text-decoration: none;
+	text-align: right;
+	flex: none;
+}
+.log-lines .logline:target,
+.log-lines .logline.hit {
+	background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+.phasebar {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.2rem 0.5rem 0.2rem 0.8rem;
+	background: var(--card);
+	border-top: 1px solid var(--border);
+	border-bottom: 1px solid var(--border);
+	font-size: 0.7rem;
+	text-transform: uppercase;
+	letter-spacing: 0.07em;
+	color: var(--muted);
+}
+.phasebar[hidden] {
+	display: none;
+}
+.phase-label {
+	font-weight: 600;
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.phase-pos {
+	font-weight: 400;
+	opacity: 0.7;
+}
+.phasebar button {
+	all: unset;
+	cursor: pointer;
+	padding: 0.1rem 0.4rem;
+	border-radius: 4px;
+	color: var(--muted);
+}
+.phasebar button:hover:not(:disabled) {
+	background: var(--hover);
+	color: var(--fg);
+}
+.phasebar button:disabled {
+	opacity: 0.35;
+	cursor: default;
+}
+/* Touch: 44px tap targets (WCAG 2.5.5) without bloating desktop. */
+@media (pointer: coarse) {
+	.phasebar {
+		padding-block: 0;
+	}
+	.phasebar button {
+		padding: 0 0.7rem;
+		min-height: 44px;
+		display: inline-flex;
+		align-items: center;
+	}
+}
+.log-search {
+	margin: 0 0 1rem;
+}
+.log-search input {
+	width: 100%;
+	box-sizing: border-box;
+	border-radius: 8px;
+	padding: 0.55rem 0.8rem;
+	font: inherit;
+}
+.search-count {
+	margin: 0.4rem 0 0;
+	font-size: 0.8rem;
+	color: var(--muted);
+}
+.search-results {
+	list-style: none;
+	margin: 0.3rem 0 0;
+	padding: 0;
+}
+.search-group {
+	margin: 0.15rem 0;
+}
+.search-results a {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.35rem 0.5rem;
+	border-radius: 6px;
+	text-decoration: none;
+	color: inherit;
+	font-size: 0.8125rem;
+}
+.search-results a:hover,
+.search-results a:focus-visible {
+	background: var(--hover);
+	outline: none;
+}
+.search-results a:focus-visible {
+	box-shadow: inset 0 0 0 2px var(--accent);
+}
+.search-drv {
+	border-left: 3px solid var(--bad);
+}
+.search-drv.ok {
+	border-left-color: var(--ok);
+}
+.search-name {
+	font-weight: 600;
+}
+.search-badge {
+	color: var(--muted);
+	font-size: 0.75rem;
+	margin-left: auto;
+}
+.search-lines {
+	list-style: none;
+	margin: 0;
+	padding: 0 0 0 1.6rem;
+}
+.search-line {
+	color: var(--muted);
+	flex: none;
+	font-variant-numeric: tabular-nums;
+	width: 5ch;
+	text-align: right;
+}
+.succeeded-panel {
+	background: var(--card);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+}
+.succeeded-panel > summary {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+	padding: 0.55rem 0.8rem;
+	cursor: pointer;
+	list-style: none;
+}
+.succeeded-panel > summary::-webkit-details-marker {
+	display: none;
+}
+.succeeded-panel > summary:hover {
+	background: var(--hover);
+}
+#succeeded-list {
+	border-top: 1px solid var(--border);
+	padding: 0.4rem 0.6rem;
+}
+#succeeded-list .log-card {
+	margin: 0.35rem 0;
+}

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -898,8 +898,13 @@ details.webhook-setup summary {
 	padding: 0.15rem 0.5rem;
 }
 
-/* Structured log viewer: per-derivation cards, phase bar, lazy log.
-   Disclosure is native <details>; only the summary chrome is styled. */
+/* ======================================================================
+   Structured log viewer (log.html + _macros.html drv_card).
+   Native <details> disclosure; only the summary chrome is styled.
+   Sections below: Cards, Log body, Phase bar, Search, Succeeded panel.
+   ====================================================================== */
+
+/* Cards: the per-derivation card and the Succeeded panel share chrome. */
 .log-card,
 .succeeded-panel {
 	background: var(--card);
@@ -969,7 +974,8 @@ details.webhook-setup summary {
 .raw:hover {
 	text-decoration: underline;
 }
-/* Grow to fit, cap then scroll; smaller cap on phones. */
+/* Log body: the scrolling line list htmx fetches into .log-lines.
+   Grow to fit, cap then scroll; smaller cap on phones. */
 .log-lines {
 	max-height: 21rem;
 	overflow: auto;
@@ -1020,6 +1026,7 @@ details.webhook-setup summary {
 	border-block: 1px dashed var(--border);
 	text-align: center;
 }
+/* Phase bar: current-phase label + prev/next jump (structured-logs.js). */
 .phasebar {
 	display: flex;
 	align-items: center;
@@ -1075,6 +1082,7 @@ details.webhook-setup summary {
 		align-items: center;
 	}
 }
+/* Search: the query box and its server-rendered results (_search_results.html). */
 .log-search {
 	margin: 0 0 1rem;
 }
@@ -1136,6 +1144,7 @@ details.webhook-setup summary {
 	width: 5ch;
 	text-align: right;
 }
+/* Succeeded panel: collapsed list of built derivations (log.html). */
 #succeeded-list {
 	border-top: 1px solid var(--border);
 	padding: 0.4rem 0.6rem;

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -1040,54 +1040,48 @@ details.webhook-setup summary {
 	border-block: 1px dashed var(--border);
 	text-align: center;
 }
-/* Phase bar: current-phase label + prev/next jump (structured-logs.js). */
-.phasebar {
+/* Phase divider: inline separator the server splices in; sticky pins it
+   as the current-phase header. prev/next scroll siblings (see the JS). */
+.phase-sep {
+	position: sticky;
+	top: 0;
+	z-index: 1;
 	display: flex;
 	align-items: center;
-	gap: 0.4rem;
-	padding: 0.2rem 0.5rem 0.2rem 0.8rem;
+	gap: 0.5rem;
+	padding: 0.3rem 0.8rem;
 	background: var(--card);
 	border-top: 1px solid var(--border);
 	border-bottom: 1px solid var(--border);
-	font-size: 0.7rem;
-	color: var(--muted);
-}
-.phasebar[hidden] {
-	display: none;
-}
-.phase-label {
+	color: var(--accent);
+	font-size: 0.72rem;
 	font-weight: 600;
-	flex: 1;
+}
+.phase-name {
 	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
-.phase-pos {
-	font-weight: 400;
-	opacity: 0.7;
+.phase-nav {
+	margin-left: auto;
+	display: flex;
+	gap: 0.2rem;
 }
-.phasebar button {
+.phase-sep button {
 	all: unset;
 	cursor: pointer;
-	padding: 0.1rem 0.4rem;
+	padding: 0.1rem 0.5rem;
 	border-radius: 4px;
 	color: var(--muted);
 }
-.phasebar button:hover:not(:disabled) {
+.phase-sep button:hover {
 	background: var(--hover);
 	color: var(--fg);
 }
-.phasebar button:disabled {
-	opacity: 0.35;
-	cursor: default;
-}
 /* Touch: 44px tap targets (WCAG 2.5.5) without bloating desktop. */
 @media (pointer: coarse) {
-	.phasebar {
-		padding-block: 0;
-	}
-	.phasebar button {
+	.phase-sep button {
 		padding: 0 0.7rem;
 		min-height: 44px;
 		display: inline-flex;

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -1071,7 +1071,7 @@ details.webhook-setup summary {
 	font-size: 0.8rem;
 	color: var(--muted);
 }
-.search-results {
+.search-results-list {
 	list-style: none;
 	margin: 0.3rem 0 0;
 	padding: 0;

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -1050,8 +1050,6 @@ details.webhook-setup summary {
 	border-top: 1px solid var(--border);
 	border-bottom: 1px solid var(--border);
 	font-size: 0.7rem;
-	text-transform: uppercase;
-	letter-spacing: 0.07em;
 	color: var(--muted);
 }
 .phasebar[hidden] {

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -399,9 +399,10 @@ details summary {
 details.attr-group {
 	margin: 0.75rem 0;
 }
-details.attr-group summary {
-	color: var(--muted);
+/* Chrome shared with the log viewer's summary selectors above. */
+.attr-group > summary {
 	font-size: 0.85rem;
+	color: var(--muted);
 }
 details.error summary {
 	color: var(--bad);
@@ -907,7 +908,8 @@ details.webhook-setup summary {
    Sections below: Cards, Log body, Phase bar, Search, Succeeded panel.
    ====================================================================== */
 
-/* Cards: the per-derivation card and the Succeeded panel share chrome. */
+/* Cards: the per-derivation card and the Succeeded panel share chrome;
+   the summary chrome below is reused by the build-page attribute groups. */
 .log-card,
 .succeeded-panel {
 	background: var(--card);
@@ -924,7 +926,8 @@ details.webhook-setup summary {
 	border-left-color: var(--ok);
 }
 .log-card > summary,
-.succeeded-panel > summary {
+.succeeded-panel > summary,
+.attr-group > summary {
 	display: flex;
 	align-items: center;
 	gap: 0.6rem;
@@ -933,11 +936,13 @@ details.webhook-setup summary {
 	list-style: none;
 }
 .log-card > summary::-webkit-details-marker,
-.succeeded-panel > summary::-webkit-details-marker {
+.succeeded-panel > summary::-webkit-details-marker,
+.attr-group > summary::-webkit-details-marker {
 	display: none;
 }
 .log-card > summary:hover,
-.succeeded-panel > summary:hover {
+.succeeded-panel > summary:hover,
+.attr-group > summary:hover {
 	background: var(--hover);
 }
 .card-text {

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -199,6 +199,7 @@ td.attr-duration {
 	border-radius: 50%;
 	margin-right: 0.5rem;
 	background: var(--status-color, var(--muted));
+	user-select: none;
 }
 /* Radar ping: an expanding ring fades out while the icon stays solid. */
 @keyframes ping {
@@ -257,6 +258,7 @@ td.attr-duration {
 	font-size: 0.7rem;
 	line-height: 1;
 	vertical-align: text-bottom;
+	user-select: none; /* selection must not box the round icon */
 }
 td.attr-status .status-icon {
 	margin-right: 0;
@@ -520,6 +522,7 @@ details.menu .menu-label {
 	border-top-color: var(--run);
 	border-radius: 50%;
 	animation: spin 0.9s linear infinite;
+	user-select: none;
 }
 @keyframes spin {
 	to {
@@ -541,6 +544,7 @@ details.menu .menu-label {
 	overflow: hidden;
 	border-radius: 0.3rem;
 	background: var(--border);
+	user-select: none;
 }
 .progress-track .seg {
 	transition: width 0.6s ease;
@@ -761,6 +765,7 @@ pre.log {
 	gap: 3px;
 	height: 2.2rem;
 	width: 12rem;
+	user-select: none; /* selection skips the decorative bars and gaps */
 }
 .spark-bar {
 	flex: 1;

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -952,11 +952,14 @@ details.webhook-setup summary {
 .succeeded-panel[open] > summary .browse-hint::after {
 	content: "collapse";
 }
-.log-card-body {
+.card-body {
 	border-top: 1px solid var(--border);
 }
-.excerpt {
+.log-empty {
+	margin: 0;
 	padding: 0.6rem 0.8rem;
+	color: var(--muted);
+	font-size: 0.8rem;
 }
 .raw {
 	color: var(--accent);

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -167,12 +167,15 @@ table.attrs tr:hover td,
 table.builds tr:hover td {
 	background: var(--hover);
 }
+table.attrs th,
 table.builds th {
 	padding: 0.5rem 0.75rem;
 	border-bottom: 1px solid var(--border);
 	font-size: 0.75rem;
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
+	text-align: left;
+	color: var(--muted);
 }
 td.attr-name {
 	width: 100%;

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -1001,6 +1001,14 @@ details.webhook-setup summary {
 .log-lines .logline.hit {
 	background: color-mix(in srgb, var(--accent) 22%, transparent);
 }
+.log-lines .log-elided {
+	padding: 0.4rem 1ch;
+	color: var(--muted);
+	font-style: italic;
+	background: color-mix(in srgb, var(--muted) 12%, transparent);
+	border-block: 1px dashed var(--border);
+	text-align: center;
+}
 .phasebar {
 	display: flex;
 	align-items: center;

--- a/nixbot/nixbot/web/templates/_attributes.html
+++ b/nixbot/nixbot/web/templates/_attributes.html
@@ -1,3 +1,4 @@
+{% from "_macros.html" import status_icon %}
 {% if group_counts.values() | sum == 0 %}
   <p class="muted">{{ "no matches" if q else "no attributes (yet)" }}</p>
 {% endif %}
@@ -12,7 +13,9 @@
              id="attrs-{{ group }}"
              data-group="{{ group }}"
              {% if eager %}open{% endif %}>
-      <summary>{{ count }} {{ "already built" if group == "skipped" else group }}</summary>
+      <summary>
+        {{ status_icon("skipped_local" if group == "skipped" else group, labelled=false) }}<span>{{ count }} {{ "already built" if group == "skipped" else group }}</span>
+      </summary>
       <div class="attr-scroll">
         <table class="attrs">
           <caption class="visually-hidden">{{ group }} attributes</caption>

--- a/nixbot/nixbot/web/templates/_macros.html
+++ b/nixbot/nixbot/web/templates/_macros.html
@@ -60,13 +60,6 @@
               aria-label="copy {{ label }}">copy</button>
     {%- endmacro %}
     {# Phase-bar widget; scroll position drives it client-side. #}
-    {% macro phasebar() -%}
-      <div class="phasebar" hidden>
-        <span class="phase-label"></span>
-        <button type="button" class="phase-prev" aria-label="Previous phase">↑ prev</button>
-        <button type="button" class="phase-next" aria-label="Next phase">↓ next</button>
-      </div>
-    {%- endmacro %}
     {# Structured log card, shared by the finished page and the live SSE.
        On the finished page htmx fetches the rows into .log-lines on first
        open (or immediately for the open card); live cards omit htmx and
@@ -81,7 +74,6 @@
                data-pos="{{ d.idx }}"
                data-idx="{{ d.idx }}"
                data-n="{{ d.n }}"
-               data-ph='{{ d.ph | tojson }}'
                {% if open %}open{% endif %}
                {% if fetch %} hx-get="{{ base }}/drv/{{ d.idx }}" hx-trigger="{{ 'load' if open else 'toggle once' }}" hx-target="find .log-lines" hx-swap="innerHTML" {% endif %}>
         <summary>
@@ -101,7 +93,6 @@
           {% if d.n == 0 and d.status != "running" %}
             <p class="log-empty">no output</p>
           {% else %}
-            {{ phasebar() }}
             <div class="log-lines" aria-busy="true"></div>
           {% endif %}
         </div>

--- a/nixbot/nixbot/web/templates/_macros.html
+++ b/nixbot/nixbot/web/templates/_macros.html
@@ -97,11 +97,9 @@
             </span>
           </span>
         </summary>
-        <div class="log-card-body">
+        <div class="card-body">
           {% if d.n == 0 and d.status != "running" %}
-            <div class="excerpt">
-              <span class="meta">no output</span>
-            </div>
+            <p class="log-empty">no output</p>
           {% else %}
             {{ phasebar() }}
             <div class="log-lines" aria-busy="true"></div>

--- a/nixbot/nixbot/web/templates/_macros.html
+++ b/nixbot/nixbot/web/templates/_macros.html
@@ -59,6 +59,56 @@
               data-copy="{{ value }}"
               aria-label="copy {{ label }}">copy</button>
     {%- endmacro %}
+    {# Phase-bar widget; scroll position drives it client-side. #}
+    {% macro phasebar() -%}
+      <div class="phasebar" hidden>
+        <span class="phase-label"></span>
+        <button type="button" class="phase-prev" aria-label="Previous phase">↑ prev</button>
+        <button type="button" class="phase-next" aria-label="Next phase">↓ next</button>
+      </div>
+    {%- endmacro %}
+    {# Structured log card, shared by the finished page and the live SSE.
+       On the finished page htmx fetches the rows into .log-lines on first
+       open (or immediately for the open card); live cards omit htmx and
+       stream rows in over the SSE. Metadata rides on data-*. #}
+    {% macro drv_card(d, base, open=false, live=false) -%}
+      {%- set failed = d.status == "failed" -%}
+      {%- set state = "failed" if failed else "succeeded" -%}
+      {%- set dur = ("%.1fs" | format((d.t1 - d.t0) / 1000)) if (d.t0 is not none and d.t1 is not none) else "" -%}
+      {%- set meta = "failed" if failed else (["built", dur] | select | join(" · ")) -%}
+      {%- set fetch = (not live) and d.n > 0 -%}
+      <details class="log-card{{ '' if failed else ' ok' }}"
+               data-pos="{{ d.idx }}"
+               data-idx="{{ d.idx }}"
+               data-n="{{ d.n }}"
+               data-ph='{{ d.ph | tojson }}'
+               {% if open %}open{% endif %}
+               {% if fetch %} hx-get="{{ base }}/drv/{{ d.idx }}" hx-trigger="{{ 'load' if open else 'toggle once' }}" hx-target="find .log-lines" hx-swap="innerHTML" {% endif %}>
+        <summary>
+          <span class="status-icon {{ state }}" aria-hidden="true"></span>
+          <span class="card-text">
+            <span class="card-name">{{ d.name }}</span>
+            <span class="meta">{{ meta }}
+              {% if d.n > 0 %}
+                · <a href="{{ base }}/drv/{{ d.idx }}/raw"
+    class="raw"
+    onclick="event.stopPropagation()">raw&nbsp;↗</a>
+              {% endif %}
+            </span>
+          </span>
+        </summary>
+        <div class="log-card-body">
+          {% if d.n == 0 and d.status != "running" %}
+            <div class="excerpt">
+              <span class="meta">no output</span>
+            </div>
+          {% else %}
+            {{ phasebar() }}
+            <div class="log-lines" aria-busy="true"></div>
+          {% endif %}
+        </div>
+      </details>
+    {%- endmacro %}
     {% macro error_row(error, colspan=3) -%}
       <tr>
         <td colspan="{{ colspan }}">

--- a/nixbot/nixbot/web/templates/_search_results.html
+++ b/nixbot/nixbot/web/templates/_search_results.html
@@ -1,0 +1,31 @@
+{# Grouped log-search hits (failures first); each line jumps into the
+   owning card. Rendered server-side and swapped into #search-results. #}
+{% if not groups %}
+  <p class="search-count">no matches</p>
+{% else %}
+  {% set total = groups | map(attribute="lines") | map("length") | sum %}
+  <p class="search-count">
+    {{ groups | length }} derivation{{ "" if groups | length == 1 else "s" }},
+    {{ total }} log match{{ "" if total == 1 else "es" }}
+  </p>
+  <ol class="search-results-list">
+    {% for g in groups %}
+      {% set ok = g.status != "failed" %}
+      <li class="search-group">
+        <a href="#" class="search-drv{{ ' ok' if ok }}" data-idx="{{ g.idx }}">
+          <span class="status-icon {{ 'succeeded' if ok else 'failed' }}"
+                aria-hidden="true"></span>
+          <span class="search-name">{{ g.name }}</span>
+          <span class="search-badge">{{ g.lines | length }} match{{ "" if g.lines | length == 1 else "es" }}</span>
+        </a>
+        <ul class="search-lines">
+          {% for ln in g.lines %}
+            <li>
+              <a href="#" data-idx="{{ g.idx }}" data-line="{{ ln }}"><span class="search-line">{{ ln }}</span></a>
+            </li>
+          {% endfor %}
+        </ul>
+      </li>
+    {% endfor %}
+  </ol>
+{% endif %}

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -37,7 +37,7 @@
           {% endif %}
         </div>
       </div>
-      {% if live %}
+      {% if live and not live_structured %}
         <label>
           <input type="checkbox" id="follow" checked>
           follow tail
@@ -47,20 +47,24 @@
         <p class="muted">waiting for the build to start…</p>
       {% elif unavailable %}
         <p class="muted">no log available for this attribute ({{ attr_status }})</p>
-      {% elif toc %}
-        <section class="log-search">
-          <input id="search-input"
-                 type="search"
-                 placeholder="Search this build's logs…"
-                 aria-label="Search logs"
-                 autocomplete="off">
-          <p class="search-count" id="search-count" aria-live="polite"></p>
-          <ol class="search-results" id="search-results">
-          </ol>
-        </section>
+      {% elif toc or live_structured %}
+        {% if not live_structured %}
+          <section class="log-search">
+            <input id="search-input"
+                   type="search"
+                   placeholder="Search this build's logs…"
+                   aria-label="Search logs"
+                   autocomplete="off">
+            <p class="search-count" id="search-count" aria-live="polite"></p>
+            <ol class="search-results" id="search-results">
+            </ol>
+          </section>
+        {% endif %}
         <div id="drv-list"
              data-base="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}"
-             data-search="{{ build_path(project, build.number) }}/search"></div>
+             data-search="{{ build_path(project, build.number) }}/search"
+             {% if live_structured %}data-stream="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}/stream?format=structured"{% endif %}>
+        </div>
       {% elif not content and not live %}
         <p class="muted">no output — everything was already built</p>
       {% else %}
@@ -68,12 +72,13 @@
       {% endif %}
     </section>
   </main>
-  {% if toc %}
-    <script id="toc-data" type="application/json">{{ toc | tojson }}</script>
+  {% if toc or live_structured %}
+    {% if toc %}<script id="toc-data" type="application/json">{{ toc | tojson }}</script>{% endif %}
     <script src="/static/structured-logs.js?v={{ static_v }}" defer></script>
   {% endif %}
   <script>
     const LIVE = {{ live | tojson }};
+    const LIVE_STRUCTURED = {{ live_structured | tojson }};
     const RUNNING = {{ (attr_status in ("pending", "building")) | tojson }};
     const log = document.getElementById("log");
     /* Failures sit at the end; start there unless a line is linked. */
@@ -91,7 +96,7 @@
       if (e.attr !== {{ attr | tojson }}) return;
       if (!LIVE || !["pending", "building"].includes(e.status)) location.reload();
     };
-    if (LIVE) {
+    if (LIVE && !LIVE_STRUCTURED && log) {
       const follow = document.getElementById("follow");
       /* Scroll only the log pane so the header stays usable; scrolling
          up pauses following, scrolling back to the bottom resumes it. */

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "_macros.html" import status_icon %}
+{% from "_macros.html" import status_icon, drv_card %}
 {% block title %}
   {{ attr }} log
 {% endblock title %}
@@ -52,18 +52,41 @@
           <section class="log-search">
             <input id="search-input"
                    type="search"
+                   name="q"
                    placeholder="Search this build's logs…"
                    aria-label="Search logs"
-                   autocomplete="off">
-            <p class="search-count" id="search-count" aria-live="polite"></p>
-            <ol class="search-results" id="search-results">
-            </ol>
+                   autocomplete="off"
+                   hx-get="{{ build_path(project, build.number) }}/search"
+                   hx-trigger="input changed delay:200ms"
+                   hx-target="#search-results"
+                   hx-swap="innerHTML">
+            <div class="search-results" id="search-results" aria-live="polite"></div>
           </section>
         {% endif %}
         <div id="drv-list"
-             data-base="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}"
-             data-search="{{ build_path(project, build.number) }}/search"
              {% if live_structured %}data-stream="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}/stream?format=structured"{% endif %}>
+          {% if toc %}
+            {% set base = build_path(project, build.number) ~ "/logs/" ~ (attr | urlencode) %}
+            {% set failed = toc | selectattr("status", "equalto", "failed") | list %}
+            {% set ok = toc | rejectattr("status", "equalto", "failed") | list %}
+            {% if failed %}<h2 class="section">Failures ({{ failed | length }})</h2>{% endif %}
+            {% for d in failed %}{{ drv_card(d, base, open=loop.first) }}{% endfor %}
+            {% if ok %}
+              <h2 class="section">Succeeded ({{ ok | length }})</h2>
+              <details class="succeeded-panel" id="succeeded-panel">
+                <summary>
+                  <span class="status-icon succeeded" aria-hidden="true"></span>
+                  <span class="card-text">
+                    <span class="card-name">{{ ok | length }} built</span>
+                    <span class="meta browse-hint"></span>
+                  </span>
+                </summary>
+                <div id="succeeded-list">
+                  {% for d in ok %}{{ drv_card(d, base) }}{% endfor %}
+                </div>
+              </details>
+            {% endif %}
+          {% endif %}
         </div>
       {% elif not content and not live %}
         <p class="muted">no output — everything was already built</p>
@@ -73,7 +96,6 @@
     </section>
   </main>
   {% if toc or live_structured %}
-    {% if toc %}<script id="toc-data" type="application/json">{{ toc | tojson }}</script>{% endif %}
     <script src="/static/structured-logs.js?v={{ static_v }}" defer></script>
   {% endif %}
   <script>

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -47,6 +47,20 @@
         <p class="muted">waiting for the build to start…</p>
       {% elif unavailable %}
         <p class="muted">no log available for this attribute ({{ attr_status }})</p>
+      {% elif toc %}
+        <section class="log-search">
+          <input id="search-input"
+                 type="search"
+                 placeholder="Search this build's logs…"
+                 aria-label="Search logs"
+                 autocomplete="off">
+          <p class="search-count" id="search-count" aria-live="polite"></p>
+          <ol class="search-results" id="search-results">
+          </ol>
+        </section>
+        <div id="drv-list"
+             data-base="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}"
+             data-search="{{ build_path(project, build.number) }}/search"></div>
       {% elif not content and not live %}
         <p class="muted">no output — everything was already built</p>
       {% else %}
@@ -54,6 +68,10 @@
       {% endif %}
     </section>
   </main>
+  {% if toc %}
+    <script id="toc-data" type="application/json">{{ toc | tojson }}</script>
+    <script src="/static/structured-logs.js?v={{ static_v }}" defer></script>
+  {% endif %}
   <script>
     const LIVE = {{ live | tojson }};
     const RUNNING = {{ (attr_status in ("pending", "building")) | tojson }};

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -37,12 +37,6 @@
           {% endif %}
         </div>
       </div>
-      {% if live and not live_structured %}
-        <label>
-          <input type="checkbox" id="follow" checked>
-          follow tail
-        </label>
-      {% endif %}
       {% if waiting %}
         <p class="muted">waiting for the build to start…</p>
       {% elif unavailable %}
@@ -100,7 +94,6 @@
   {% endif %}
   <script>
     const LIVE = {{ live | tojson }};
-    const LIVE_STRUCTURED = {{ live_structured | tojson }};
     const RUNNING = {{ (attr_status in ("pending", "building")) | tojson }};
     const log = document.getElementById("log");
     /* Failures sit at the end; start there unless a line is linked. */
@@ -118,38 +111,5 @@
       if (e.attr !== {{ attr | tojson }}) return;
       if (!LIVE || !["pending", "building"].includes(e.status)) location.reload();
     };
-    if (LIVE && !LIVE_STRUCTURED && log) {
-      const follow = document.getElementById("follow");
-      /* Scroll only the log pane so the header stays usable; scrolling
-         up pauses following, scrolling back to the bottom resumes it. */
-      const atBottom = () =>
-        log.scrollHeight - log.scrollTop - log.clientHeight < 4;
-      log.addEventListener("scroll", () => { follow.checked = atBottom(); });
-      const source = new EventSource(
-        "{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}/stream");
-      /* The stream replays full history on every (re)connect. */
-      let errors = 0;
-      source.onopen = () => {
-        errors = 0;
-        log.textContent = "";
-      };
-      /* EventSource reconnects every ~1s forever; if the server stays
-         gone (engine restart), give up and let a reload render the
-         finished log server-side. */
-      source.onerror = () => {
-        if (++errors >= 5) {
-          source.close();
-          setTimeout(() => location.reload(), 3000);
-        }
-      };
-      source.onmessage = (event) => {
-        // server-rendered HTML chunks, newlines included
-        log.insertAdjacentHTML("beforeend", event.data);
-        if (follow.checked) log.scrollTop = log.scrollHeight;
-      };
-      /* The terminal status event reloads the page; just stop the
-         dead stream from reconnecting. */
-      source.addEventListener("done", () => source.close());
-    }
   </script>
 {% endblock body %}

--- a/nixbot/nixbot/web/templates/repo.html
+++ b/nixbot/nixbot/web/templates/repo.html
@@ -87,14 +87,18 @@
         <h2 class="section">Schedules</h2>
         <table class="attrs">
           <caption class="visually-hidden">scheduled effects</caption>
-          <thead class="visually-hidden">
+          <thead>
             <tr>
-              <th scope="col">status</th>
+              <th scope="col">
+                <span class="visually-hidden">status</span>
+              </th>
               <th scope="col">schedule</th>
               <th scope="col">when</th>
               <th scope="col">next run</th>
               <th scope="col">last run</th>
-              <th scope="col">actions</th>
+              <th scope="col">
+                <span class="visually-hidden">actions</span>
+              </th>
             </tr>
           </thead>
           {% for s in schedules %}


### PR DESCRIPTION
Logs are now structured to allow rendering seperate derivations with seperate phases in the frontend along with build timings. This allows to better filter down what the error is.
This will only apply to new builds. We change the log format but still accept old logs on disk.