### PR TITLE
scheduler: wake on a completion queue, not a wait over all running tasks

### DIFF
--- a/nixbot/nixbot/build_scheduler.py
+++ b/nixbot/nixbot/build_scheduler.py
@@ -27,7 +27,7 @@ import graphlib
 import logging
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -285,6 +285,13 @@ class _State:
     result: ScheduleResult
     pending: list[NixEvalJobSuccess]
     job_closures: dict[str, set[str]]
+    # In-flight build tasks and the queue their done-callbacks feed.
+    running: dict[asyncio.Task[BuildOutcome], NixEvalJobSuccess] = field(
+        default_factory=dict
+    )
+    done_q: asyncio.Queue[asyncio.Task[BuildOutcome]] = field(
+        default_factory=asyncio.Queue
+    )
     # Static reverse edges from the initial closures: which jobs'
     # closures contain a given drv. Lets prune touch only actual
     # dependents instead of every closure (O(deps) vs O(jobs)).
@@ -365,11 +372,7 @@ class JobScheduler:
             # build nor block aggregation.
         return successful_jobs
 
-    async def _dispatch_ready(
-        self,
-        state: _State,
-        running: dict[asyncio.Task[BuildOutcome], NixEvalJobSuccess],
-    ) -> bool:
+    async def _dispatch_ready(self, state: _State) -> bool:
         """Start or skip all dependency-free jobs. Returns whether any
         job was ready. Loops until a fixpoint: skipping a job prunes it
         from the closures, which can free its dependents immediately."""
@@ -386,7 +389,8 @@ class JobScheduler:
                 action = await self._classify(job, state.result)
                 if action == "run":
                     task = asyncio.create_task(self.executor.build(job))
-                    running[task] = job
+                    state.running[task] = job
+                    task.add_done_callback(state.done_q.put_nowait)
                 else:
                     if action == "skip-failed":
                         # Cached failure counts as a failure: propagate to
@@ -427,7 +431,6 @@ class JobScheduler:
     async def _wait_for_progress(
         self,
         state: _State,
-        running: dict[asyncio.Task[BuildOutcome], NixEvalJobSuccess],
         queue: asyncio.Queue[list[NixEvalJob] | None],
         get_task: asyncio.Task[list[NixEvalJob] | None] | None,
         flush: Callable[[], Awaitable[None]],
@@ -436,24 +439,34 @@ class JobScheduler:
         finishes, then fold the outcome into the state. Returns the
         (possibly replaced) queue reader task; None after the
         end-of-input sentinel."""
-        waits: set[asyncio.Task[object]] = set(running)
+        waits: set[asyncio.Task[object]] = set()
         if get_task is not None:
             waits.add(get_task)
+        # One dequeue instead of a wait over every running task: O(1) per
+        # finished build, not O(N) re-armed after each completion.
+        done_get = asyncio.create_task(state.done_q.get()) if state.running else None
+        if done_get is not None:
+            waits.add(done_get)
+        if not waits:
+            return get_task
         done_tasks, _ = await asyncio.wait(waits, return_when=asyncio.FIRST_COMPLETED)
         if get_task is not None and get_task in done_tasks:
-            done_tasks.discard(get_task)
-            get_task = self._on_queue_item(state, running, queue, get_task.result())
-        for done in done_tasks:
-            # Only build tasks remain after the queue reader was discarded.
-            task = cast("asyncio.Task[BuildOutcome]", done)
-            await self._finish_job(state, running.pop(task), task.result())
-            await flush()
+            get_task = self._on_queue_item(state, queue, get_task.result())
+        if done_get is not None and done_get in done_tasks:
+            # Drain every build that finished, not just the first.
+            finished = [done_get.result()]
+            while not state.done_q.empty():
+                finished.append(state.done_q.get_nowait())
+            for task in finished:
+                await self._finish_job(state, state.running.pop(task), task.result())
+                await flush()
+        elif done_get is not None:
+            done_get.cancel()  # a batch arrived first; no build consumed
         return get_task
 
     def _on_queue_item(
         self,
         state: _State,
-        running: dict[asyncio.Task[BuildOutcome], NixEvalJobSuccess],
         queue: asyncio.Queue[list[NixEvalJob] | None],
         batch: list[NixEvalJob] | None,
     ) -> asyncio.Task[list[NixEvalJob] | None] | None:
@@ -461,13 +474,12 @@ class JobScheduler:
         on the end-of-input sentinel."""
         if batch is None:
             return None
-        self._ingest(state, running, batch)
+        self._ingest(state, batch)
         return asyncio.create_task(queue.get())
 
     def _ingest(
         self,
         state: _State,
-        running: dict[asyncio.Task[BuildOutcome], NixEvalJobSuccess],
         batch: list[NixEvalJob],
     ) -> None:
         """Merge a batch of eval results into the live scheduling state.
@@ -505,7 +517,7 @@ class JobScheduler:
                     remaining.append(job)
             candidates = remaining
         state.pending = candidates
-        unfinished = state.pending + list(running.values())
+        unfinished = state.pending + list(state.running.values())
         state.job_closures = compute_job_closures(unfinished)
         state.reverse_deps = compute_reverse_deps(state.job_closures)
         state.pending = sort_jobs_by_closures(state.pending, state.job_closures)
@@ -524,34 +536,31 @@ class JobScheduler:
         sentinel marks the end of input."""
         result = ScheduleResult()
         state = _State(result=result, pending=[], job_closures={})
-        running: dict[asyncio.Task[BuildOutcome], NixEvalJobSuccess] = {}
         flush = _ResultEmitter(result, self.on_result).flush
         # get_task is None once the end-of-input sentinel arrived.
         get_task: asyncio.Task[list[NixEvalJob] | None] | None = asyncio.create_task(
             queue.get()
         )
         try:
-            while get_task is not None or state.pending or running:
-                any_ready = await self._dispatch_ready(state, running)
+            while get_task is not None or state.pending or state.running:
+                any_ready = await self._dispatch_ready(state)
                 await flush()
 
-                if not running and get_task is None:
+                if not state.running and get_task is None:
                     if state.pending and not any_ready:
                         _fail_unresolvable(state)
                     continue
 
-                get_task = await self._wait_for_progress(
-                    state, running, queue, get_task, flush
-                )
+                get_task = await self._wait_for_progress(state, queue, get_task, flush)
         finally:
             # On cancellation (eval failure, superseded build) stop the
             # in-flight executor tasks instead of orphaning them.
             if get_task is not None:
                 get_task.cancel()
-            for task in running:
+            for task in state.running:
                 task.cancel()
-            if running:
-                await asyncio.gather(*running, return_exceptions=True)
+            if state.running:
+                await asyncio.gather(*state.running, return_exceptions=True)
 
         await flush()
         return result

--- a/nixbot/nixbot/build_scheduler.py
+++ b/nixbot/nixbot/build_scheduler.py
@@ -216,8 +216,12 @@ def get_failed_dependents(
 
 def compute_job_closures(
     jobs: list[NixEvalJobSuccess],
+    extra_drvs: frozenset[str] = frozenset(),
 ) -> dict[str, set[str]]:
-    job_set = {job.drv_path for job in jobs}
+    """Each job's in-flight dependencies, keyed by `jobs`. `extra_drvs`
+    (e.g. running builds) count as in-flight so a pending edge to one
+    survives, but get no entry of their own."""
+    job_set = {job.drv_path for job in jobs} | extra_drvs
     return {
         job.drv_path: (job_set & {*job.needed_builds, *job.needed_substitutes})
         - {job.drv_path}
@@ -517,8 +521,11 @@ class JobScheduler:
                     remaining.append(job)
             candidates = remaining
         state.pending = candidates
-        unfinished = state.pending + list(state.running.values())
-        state.job_closures = compute_job_closures(unfinished)
+        # Only pending jobs get closures; running builds (which can be in
+        # the thousands) merely stay in the intersection set. Keeps each
+        # batch O(pending), not O(pending + running).
+        running_drvs = frozenset(j.drv_path for j in state.running.values())
+        state.job_closures = compute_job_closures(state.pending, running_drvs)
         state.reverse_deps = compute_reverse_deps(state.job_closures)
         state.pending = sort_jobs_by_closures(state.pending, state.job_closures)
 

--- a/nixbot/nixbot/tests/test_build_scheduler.py
+++ b/nixbot/nixbot/tests/test_build_scheduler.py
@@ -59,6 +59,10 @@ async def test_topological_order() -> None:
     order = sort_jobs_by_closures([c, a, b], closures)
     assert [j.attr for j in order] == ["a", "b", "c"]
 
+    # A running build (b) is not keyed but keeps c's edge to it alive.
+    running = compute_job_closures([c], frozenset({b.drv_path}))
+    assert running == {c.drv_path: {b.drv_path}}
+
     executor = FakeExecutor()
     result = await run_scheduler(JobScheduler(executor, [SYSTEM]), [c, a, b])
     assert executor.built.index("a") < executor.built.index("b")

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -1359,6 +1359,32 @@ def test_event_broker_pushes_status_changes(
     assert build_event["status"] == "failed"
 
 
+def test_events_stream_coalesces_burst(client: WebHarness) -> None:
+    """A burst of status changes collapses to one SSE refetch signal."""
+    ctx = client.ctx
+    broker = client.app.state.event_broker
+    request = Request({"type": "http", "headers": [], "query_string": b""})
+
+    async def run() -> None:
+        sub = broker.subscribe(build_id=7, visible=None)
+        gen = events_module.event_stream(ctx, request, broker, sub)
+        assert (await anext(gen)).startswith("retry:")
+        for _ in range(5):
+            broker._on_notify(  # noqa: SLF001
+                None,
+                None,
+                None,
+                json.dumps({"build_id": 7, "project_id": 1, "status": "building"}),
+            )
+        async with asyncio.timeout(5):
+            line = await anext(gen)
+        assert line.startswith("data:")
+        assert sub.queue.empty()  # the rest of the burst was dropped
+        await gen.aclose()
+
+    client.loop.run_until_complete(run())
+
+
 def test_events_stream_refreshes_visibility(
     client: WebHarness, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/nixbot/nixbot/web/events.py
+++ b/nixbot/nixbot/web/events.py
@@ -31,6 +31,9 @@ logger = logging.getLogger(__name__)
 CHANNEL = "build_events"
 KEEPALIVE_SECONDS = 30.0
 RECONNECT_SECONDS = 5.0
+# A burst of status changes is one "refetch" cue to a subscriber; emit
+# at most one SSE write per this interval.
+COALESCE_SECONDS = 0.25
 # Long-lived streams must not keep a revoked viewer's visibility
 # snapshot forever; re-resolve it periodically.
 VISIBILITY_REFRESH_SECONDS = 300.0
@@ -161,7 +164,11 @@ async def event_stream(
             if payload is None:
                 yield ": keepalive\n\n"
                 continue
+            # Drop the rest of the burst; one refetch covers them all.
+            while not sub.queue.empty():
+                sub.queue.get_nowait()
             yield f"data: {payload}\n\n"
+            await asyncio.sleep(COALESCE_SECONDS)
     finally:
         broker.unsubscribe(sub)
 

--- a/nixbot/nixbot/web/templates/activity.html
+++ b/nixbot/nixbot/web/templates/activity.html
@@ -9,7 +9,7 @@
   <main id="main">
     <section class="content">
       <div hx-get="/builds/queue"
-           hx-trigger="sse:message delay:300ms"
+           hx-trigger="sse:message throttle:1s"
            hx-swap="morph:innerHTML">{% include "_queue.html" %}</div>
       <h2 class="section">Recent activity</h2>
       <div class="table-scroll">
@@ -26,7 +26,7 @@
           </thead>
           <tbody id="feed"
                  hx-get="/builds/rows"
-                 hx-trigger="sse:message delay:300ms"
+                 hx-trigger="sse:message throttle:1s"
                  hx-swap="morph:innerHTML"
                  hx-vals='js:{limit: document.querySelectorAll("#feed tr[data-id]").length}'>
             {% include "_build_rows.html" %}

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -11,7 +11,9 @@
   {# sseOpen re-checks state rendered before the stream connected; a
      status change in that gap (eval start, attr restart) would
      otherwise be lost. #}
-  {% set trigger = "sse:message delay:300ms, htmx:sseOpen from:body" %}
+  {# throttle, not delay: delay debounces, so a busy build's event
+     stream keeps resetting it and the refetch never fires. #}
+  {% set trigger = "sse:message throttle:1s, htmx:sseOpen from:body" %}
   {# hx-disinherit: the lazy attribute-row fetches inside would
      otherwise inherit hx-select="#main" and swap in nothing. #}
   <main id="main"

--- a/nixbot/nixbot/web/templates/index.html
+++ b/nixbot/nixbot/web/templates/index.html
@@ -10,7 +10,7 @@
         hx-select="#main"
         hx-target="this"
         hx-swap="morph:outerHTML"
-        hx-trigger="sse:message delay:300ms">
+        hx-trigger="sse:message throttle:1s">
     <section class="content dashboard">
       <h2 class="section">Repositories</h2>
       <p class="filters">

--- a/nixbot/nixbot/web/templates/repo.html
+++ b/nixbot/nixbot/web/templates/repo.html
@@ -155,7 +155,7 @@
           </thead>
           <tbody id="feed"
                  hx-get="{{ rows_url }}"
-                 hx-trigger="sse:message delay:300ms"
+                 hx-trigger="sse:message throttle:1s"
                  hx-swap="morph:innerHTML"
                  hx-vals='js:{limit: document.querySelectorAll("#feed tr[data-id]").length}'>
             {% with builds = builds["items"], has_more = builds.has_next, more_url = rows_url %}


### PR DESCRIPTION
_dispatch_ready starts a task per dependency-free job, so a wide jobset (the torture flake has ~25k independent attrs) leaves tens of thousands of tasks in `running`. _wait_for_progress rebuilt asyncio.wait(running, FIRST_COMPLETED) after each single completion, arming and disarming a done-callback on every task per build: O(N) per completion, O(N^2) over the run. Once all Linux builds funneled through tribuchet the completion rate rose enough to peg the event loop.

Feed a queue from each task's done-callback and wake on one dequeue. Progress is O(1) per finished build. `running` and the queue live in _State so the helpers share them without extra arguments.