### PR TITLE
gitrepo: fix blobless partial clones in private repos

### DIFF
--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -54,7 +54,10 @@ async def maybe_run_effects(
     config_text = None
     for filename in CONFIG_FILENAMES:
         config_text = await o.repos.show_file(
-            repo.key, f"refs/heads/{repo.default_branch}", filename
+            repo.key,
+            f"refs/heads/{repo.default_branch}",
+            filename,
+            credentials=credentials,
         )
         if config_text is not None:
             break

--- a/nixbot/nixbot/gitrepo.py
+++ b/nixbot/nixbot/gitrepo.py
@@ -193,7 +193,9 @@ class Worktree:
     async def commit_message(self, rev: str = "HEAD") -> str:
         return await run_git(["log", "-1", "--format=%B", rev], cwd=self.path)
 
-    async def merge(self, head_sha: str) -> None:
+    async def merge(
+        self, head_sha: str, credentials: FetchCredentials | None = None
+    ) -> None:
         """Merge `head_sha` into the currently checked-out base branch.
 
         Raises MergeConflictError on conflict; the caller fails the
@@ -213,6 +215,7 @@ class Worktree:
                     head_sha,
                 ],
                 cwd=self.path,
+                credentials=credentials,
             )
         except GitError as e:
             # Only a genuine content conflict (unmerged index entries)
@@ -316,18 +319,30 @@ class RepoManager:
             credentials=credentials,
         )
 
-    async def show_file(self, project_key: str, ref: str, file_path: str) -> str | None:
+    async def show_file(
+        self,
+        project_key: str,
+        ref: str,
+        file_path: str,
+        credentials: FetchCredentials | None = None,
+    ) -> str | None:
         """Read one file from a ref of the bare clone (no worktree).
         Returns None when the ref or file does not exist."""
         try:
             return await run_git(
-                ["show", f"{ref}:{file_path}"], cwd=self.clone_path(project_key)
+                ["show", f"{ref}:{file_path}"],
+                cwd=self.clone_path(project_key),
+                credentials=credentials,
             )
         except GitError:
             return None
 
     async def create_worktree(
-        self, project_key: str, worktree_id: str, commit: str
+        self,
+        project_key: str,
+        worktree_id: str,
+        commit: str,
+        credentials: FetchCredentials | None = None,
     ) -> Worktree:
         """Create a detached worktree for one build at `commit`."""
         clone = self.clone_path(project_key)
@@ -335,7 +350,11 @@ class RepoManager:
         if path.exists():
             await self.remove_worktree(Worktree(path=path, clone_path=clone))
         path.parent.mkdir(parents=True, exist_ok=True)
-        await run_git(["worktree", "add", "--detach", str(path), commit], cwd=clone)
+        await run_git(
+            ["worktree", "add", "--detach", str(path), commit],
+            cwd=clone,
+            credentials=credentials,
+        )
         self._active_worktrees.add(path.resolve())
         return Worktree(path=path, clone_path=clone)
 
@@ -415,13 +434,14 @@ class RepoManager:
             with contextlib.suppress(GitError):
                 await run_git(["gc", "--auto"], cwd=clone)
 
-    async def checkout_for_build(
+    async def checkout_for_build(  # noqa: PLR0913
         self,
         project_key: str,
         worktree_id: str,
         *,
         base_commit: str,
         head_commit: str | None = None,
+        credentials: FetchCredentials | None = None,
         submodule_credentials: FetchCredentials | None = None,
     ) -> Worktree:
         """Create the build worktree: base commit, optionally merging a
@@ -429,10 +449,12 @@ class RepoManager:
         bare clone does not carry submodule objects) WITHOUT the fetch
         credentials unless explicitly opted in. Returns the worktree;
         identity is its tree hash."""
-        worktree = await self.create_worktree(project_key, worktree_id, base_commit)
+        worktree = await self.create_worktree(
+            project_key, worktree_id, base_commit, credentials
+        )
         try:
             if head_commit is not None and head_commit != base_commit:
-                await worktree.merge(head_commit)
+                await worktree.merge(head_commit, credentials)
             if (worktree.path / ".gitmodules").exists():
                 # .gitmodules is PR-controlled: with the primary repo's
                 # credentials a malicious PR could exfiltrate any other

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -190,6 +190,7 @@ class Orchestrator:
                 f"{repo.id}-{event.commit_sha[:12]}-{uuid.uuid4().hex[:8]}",
                 base_commit=event.base_sha or event.commit_sha,
                 head_commit=event.commit_sha if event.base_sha else None,
+                credentials=credentials,
             )
         except MergeConflictError as e:
             # Merge conflict: failed build, status on the head SHA.

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -50,6 +50,7 @@ async def rerun_worktree(
         info.key,
         f"{prefix}-{build.id}",
         base_commit=build.commit_sha,
+        credentials=credentials,
     )
     try:
         yield event, worktree.path

--- a/nixbot/nixbot/schedule_runner.py
+++ b/nixbot/nixbot/schedule_runner.py
@@ -83,6 +83,7 @@ async def refresh_schedules(s: CIService, project_id: int, rev: str) -> None:
         info.key,
         f"schedules-{project_id}",
         base_commit=rev,
+        credentials=credentials,
     )
     try:
         ctx = EffectsContext(
@@ -134,6 +135,7 @@ async def _run_scheduled_inner(
         info.key,
         scheduled_worktree_id(due, run_id),
         base_commit=info.default_branch,
+        credentials=credentials,
     )
     task_token = s.orchestrator.task_tokens.issue(due.project_id)
     log_dir = s.config.state_dir / "logs" / "scheduled"

--- a/nixbot/nixbot/tests/test_gitrepo.py
+++ b/nixbot/nixbot/tests/test_gitrepo.py
@@ -340,17 +340,80 @@ async def test_submodules_fetched_without_credentials(
     monkeypatch.setattr(gitrepo, "run_git", spy_run_git)
 
     # Default: no credentials reach the submodule checkout.
-    wt = await manager.checkout_for_build(KEY, "sub-creds", base_commit=sha)
+    wt = await manager.checkout_for_build(
+        KEY, "sub-creds", base_commit=sha, credentials=creds
+    )
     await manager.remove_worktree(wt)
     # Explicit opt-in forwards them.
     wt = await manager.checkout_for_build(
-        KEY, "sub-creds-2", base_commit=sha, submodule_credentials=creds
+        KEY,
+        "sub-creds-2",
+        base_commit=sha,
+        credentials=creds,
+        submodule_credentials=creds,
     )
     await manager.remove_worktree(wt)
     submodule_calls = [c for c in calls if c[0][0] == "submodule"]
     assert len(submodule_calls) == 2  # noqa: PLR2004 — one call per checkout
     assert submodule_calls[0][1] is None
     assert submodule_calls[1][1] is creds
+
+
+async def test_checkout_lazy_fetch_needs_credentials(
+    manager: RepoManager,
+    upstream: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blob-less clone lazy-fetches missing objects from origin during
+    worktree checkout and merge. When origin needs authentication, those
+    fetches only succeed if the primary repo's credentials are
+    forwarded, reproducing the private-repo build failure.
+
+    A fake `ssh` gates on the `-i <key>` flag that
+    FetchCredentials.git_ssh_command emits: no credentials means no key
+    means the promisor fetch fails just like the real bug."""
+    git(upstream, "config", "uploadpack.allowFilter", "true")
+    base = git(upstream, "rev-parse", "HEAD")
+    git(upstream, "checkout", "-b", "pr")
+    (upstream / "feature.txt").write_text("feature\n")
+    git(upstream, "add", ".")
+    git(upstream, "commit", "-m", "feature")
+    head = git(upstream, "rev-parse", "HEAD")
+    git(upstream, "checkout", "main")
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    fake_ssh = bindir / "ssh"
+    fake_ssh.write_text(
+        "#!/bin/sh\n"
+        'case " $* " in *" -i "*) ;; *) echo "no key" >&2; exit 255;; esac\n'
+        'for a in "$@"; do last=$a; done\n'
+        'exec sh -c "$last"\n'
+    )
+    fake_ssh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+
+    key = tmp_path / "id"
+    key.write_text("dummy\n")
+    creds = FetchCredentials(ssh_private_key_file=key)
+    # ssh://fake<abs-path> routes through the fake ssh, which runs
+    # git-upload-pack against the local upstream repo.
+    url = f"ssh://fake{upstream}"
+    await manager.fetch(KEY, url, ["+refs/heads/*:refs/heads/*"], credentials=creds)
+
+    with pytest.raises(GitError, match="promisor remote"):
+        await manager.checkout_for_build(
+            KEY, "no-creds", base_commit=base, head_commit=head
+        )
+
+    wt = await manager.checkout_for_build(
+        KEY, "with-creds", base_commit=base, head_commit=head, credentials=creds
+    )
+    try:
+        assert (wt.path / "feature.txt").read_text() == "feature\n"
+    finally:
+        await manager.remove_worktree(wt)
 
 
 async def test_static_credentials_provider(tmp_path: Path) -> None:


### PR DESCRIPTION
Blobless clones (`--filter=blob:none`) can trigger remote fetches in more situations (e.g., worktree checkout, PR merges, git show); in private repos, these fetches also require credentials. This diff wires through credentials to all the git ops that may need them.

Here's the error log I started seeing after upgrading to https://github.com/Mic92/nixbot/commit/909f18127b583702aabaeb74d29891096f971f49, which contains this commit https://github.com/Mic92/nixbot/commit/00c01caee1c23c4fe9db5a283c6cfce4453a7526. `nixbot` is unable to `git worktree add`:

```
Traceback (most recent call last):
  File "/nix/store/zrk6ak7b437yj0bgi28fljpd496g9yi8-python3.13-nixbot/lib/python3.13/site-packages/nixbot/service.py", line 424, in _execute_work
    await self._dispatch_work(item)
  File "/nix/store/zrk6ak7b437yj0bgi28fljpd496g9yi8-python3.13-nixbot/lib/python3.13/site-packages/nixbot/service.py", line 437, in _dispatch_work
    await self._process_change(ChangeRequest(**payload))
  File "/nix/store/zrk6ak7b437yj0bgi28fljpd496g9yi8-python3.13-nixbot/lib/python3.13/site-packages/nixbot/service.py", line 319, in _process_change
    await self.orchestrator.handle_change_event(event, credentials)
  File "/nix/store/zrk6ak7b437yj0bgi28fljpd496g9yi8-python3.13-nixbot/lib/python3.13/site-packages/nixbot/orchestrator.py", line 188, in handle_change_event
    worktree = await self.repos.checkout_for_build(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
    )
    ^
  File "/nix/store/zrk6ak7b437yj0bgi28fljpd496g9yi8-python3.13-nixbot/lib/python3.13/site-packages/nixbot/gitrepo.py", line 432, in checkout_for_build
    worktree = await self.create_worktree(project_key, worktree_id, base_commit)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/zrk6ak7b437yj0bgi28fljpd496g9yi8-python3.13-nixbot/lib/python3.13/site-packages/nixbot/gitrepo.py", line 338, in create_worktree
    await run_git(["worktree", "add", "--detach", str(path), commit], cwd=clone)
  File "/nix/store/zrk6ak7b437yj0bgi28fljpd496g9yi8-python3.13-nixbot/lib/python3.13/site-packages/nixbot/gitrepo.py", line 162, in run_git
    raise GitError(args, proc.returncode or -1, stderr.decode(errors="replace"))
nixbot.gitrepo.GitError: git worktree add --detach /var/lib/nixbot/worktrees/9-94859e059c27-c60e2119 94859e059c27cf981df333ee02158127e9dae3c8 failed (128): Preparing worktree (detached HEAD 94859e0)
fatal: could not read Username for 'https://github.com': terminal prompts disabled
fatal: could not fetch 7c91c958af7c194c90da7b6dc6ee183734bc4037 from promisor remote

```