### PR TITLE
executor: attribute build failures to the right card

### DIFF
--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -400,8 +400,11 @@ def build_nix_command(
     ]
 
 
-# nix names failures only in prose: "build of" (remote) / "builder for" (local).
+# nix names failures only in prose: "build of" (remote) / "builder for"
+# (local). Newer nix also uses a two-line "Cannot build '<drv>'." /
+# "Reason:" form (see setup_line).
 _BUILD_FAILED = re.compile(r"(?:build of|builder for) '([^']+\.drv)'.*?failed")
+_CANNOT_BUILD = re.compile(r"Cannot build '([^']+\.drv)'")
 _PHASE_ECHO = "Running phase: "
 
 
@@ -504,6 +507,7 @@ class StructuredCapture:
         # ids. Live ids are ephemeral (the finish reload renumbers).
         self._seen: dict[str, int] = {}
         self._running: set[str] = set()
+        self._pending_cannot: str | None = None
         self._subs: list[asyncio.Queue[dict | None]] = []
         self._closed = False
         self._w.register(self.SETUP, "setup")
@@ -615,10 +619,19 @@ class StructuredCapture:
         self._emit(
             {"t": "line", "idx": 0, "from": self._bump(self.SETUP), "text": text}
         )
+        stripped = strip_ansi(text)
         # --keep-going: mark every failed drv, not just the top-level one.
-        for m in _BUILD_FAILED.finditer(strip_ansi(text)):
+        for m in _BUILD_FAILED.finditer(stripped):
             drv = m.group(1)
             if drv in self._idx:
+                self.set_status(drv, "failed")
+        # Two-line form: flag the drv only once its "Reason:" says the
+        # builder failed, not a dependency (a cascade parent).
+        if m := _CANNOT_BUILD.search(stripped):
+            self._pending_cannot = m.group(1)
+        elif self._pending_cannot and "Reason:" in stripped:
+            drv, self._pending_cannot = self._pending_cannot, None
+            if "builder failed" in stripped and drv in self._idx:
                 self.set_status(drv, "failed")
 
     def set_status(self, drv_path: str, status: str) -> None:
@@ -633,6 +646,18 @@ class StructuredCapture:
         self._w.status(drv_path, status)
         self._running.discard(drv_path)
         self._emit({"t": "status", "idx": self._idx[drv_path], "status": status})
+
+    def mark_failed(self, drv_path: str) -> None:
+        if drv_path in self._idx:
+            self.set_status(drv_path, "failed")
+        elif not self._w.failing():
+            # Top-level never ran and no leaf failed: the failure was in
+            # setup (eval, scheduling, remote-builder). Attribute it there,
+            # else the setup bucket keeps its default "built" (succeeded).
+            self._w.status(self.SETUP, "failed")
+            self._emit({"t": "status", "idx": 0, "status": "failed"})
+        # else: a leaf drv already carries the failure; adding the
+        # top-level as a phantom "no output" card only duplicates it.
 
     def build_failure(
         self, max_lines: int = 8, max_drvs: int = 3
@@ -888,7 +913,10 @@ async def _finalize_container(
     *,
     failed: bool,
 ) -> None:
-    capture.set_status(drv_path, "failed" if failed else "built")
+    if failed:
+        capture.mark_failed(drv_path)
+    else:
+        capture.set_status(drv_path, "built")
     capture.close()
     blob = capture.finalize()
     await asyncio.to_thread(container_path(log_writer.path).write_bytes, blob)

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -627,8 +627,8 @@ class StructuredCapture:
                 self.set_status(drv, "failed")
         # Two-line form: flag the drv only once its "Reason:" says the
         # builder failed, not a dependency (a cascade parent).
-        if m := _CANNOT_BUILD.search(stripped):
-            self._pending_cannot = m.group(1)
+        if cannot := _CANNOT_BUILD.search(stripped):
+            self._pending_cannot = cannot.group(1)
         elif self._pending_cannot and "Reason:" in stripped:
             drv, self._pending_cannot = self._pending_cannot, None
             if "builder failed" in stripped and drv in self._idx:

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -791,7 +791,9 @@ def test_scrapes_cannot_build_reason_wording() -> None:
     assert state["closure-info"] == "failed"
     assert "vm-test-run-nixbot-gitlab" not in state
     assert state["setup"] == "built"
-    assert cap.build_failure().drvs[0].name == "closure-info"
+    failure = cap.build_failure()
+    assert failure is not None
+    assert failure.drvs[0].name == "closure-info"
 
 
 def test_finalize_marks_setup_failed_on_pure_setup_error() -> None:

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -772,6 +772,37 @@ def test_structured_failure_excerpt_caps_many_failures() -> None:
     assert "3 more failed derivations" in excerpt
 
 
+def test_scrapes_cannot_build_reason_wording() -> None:
+    # Newer nix spreads a failure over "Cannot build '<drv>'." + "Reason:".
+    # Flag the leaf that carries the output, not the cascade parents that
+    # only report "1 dependency failed".
+    cap = StructuredCapture(clock=lambda: 1.0)
+    leaf = "/nix/store/x0w-closure-info.drv"
+    top = "/nix/store/195-vm-test-run-nixbot-gitlab.drv"
+    cap.start_build(1, leaf)
+    cap.log_line(1, "tribuchet worker error: build execution panicked")
+    cap.setup_line(f"error: Cannot build '{leaf}'.")
+    cap.setup_line("       Reason: builder failed with exit code 1.")
+    cap.setup_line(f"error: Cannot build '{top}'.")
+    cap.setup_line("       Reason: 1 dependency failed.")
+    cap.mark_failed(top)
+    state = {e["name"]: e["status"] for e in cap.state()}
+    # Leaf flagged with its output; no phantom top-level card, setup neutral.
+    assert state["closure-info"] == "failed"
+    assert "vm-test-run-nixbot-gitlab" not in state
+    assert state["setup"] == "built"
+    assert cap.build_failure().drvs[0].name == "closure-info"
+
+
+def test_finalize_marks_setup_failed_on_pure_setup_error() -> None:
+    # No build activity: the failure lands on the setup card.
+    cap = StructuredCapture(clock=lambda: 1.0)
+    cap.setup_line("error: cannot download foo from any mirror")
+    cap.mark_failed("/nix/store/aaa-top.drv")
+    setup = next(e for e in cap.state() if e["name"] == "setup")
+    assert setup["status"] == "failed"
+
+
 async def test_structured_capture_state_snapshot() -> None:
     cap = StructuredCapture(clock=lambda: 1.0)
     cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")


### PR DESCRIPTION
nix only names failing derivations in error prose, never as a structured per-activity status. The scraper matched the "build of" / "builder for" wording but missed newer nix's two-line "Cannot build '<drv>'." / "Reason: builder failed" form, so leaf failures went unnamed: the real failure went unflagged, the top-level drv was marked failed with no output, and the setup bucket holding the error prose rendered as succeeded.

Scrape the two-line form too, flagging the drv only when its reason is a real builder failure, not a dependency-failed cascade parent. On finalize, mark the top-level drv only if it actually ran; otherwise attribute a lone failure to the setup bucket, and skip the phantom no-output card when a leaf already carries the failure.