### PR TITLE
executor: scrape failure prose per physical line

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,146 @@
+# New log viewer — implementation plan
+
+Per-derivation build logs: structured storage, phase tracking, global search,
+`content-visibility` rendering. Prototypes: `~/.claude/outputs/logstore/`
+(storage + search) and `~/.claude/outputs/logviz-mockups/scale.html` (frontend).
+
+## Reality of the current pipeline
+
+`nix build {drv}^*` runs **one invocation per attribute**; logs are keyed per
+`(build_id, attr)`, one zstd file each, streamed independently. The "250
+derivations" of the mockup are **attributes** — the build page already lists
+them from the DB (`queries.attributes`), each linking to its own log.
+
+Within one attribute's invocation the log may still contain several derivations
+(the attr's own drv plus any uncached deps), interleaved by `internal-json`
+activity id — but the common case is a single derivation with phases. So
+structure lives _inside_ the per-attr log; there is no per-build container.
+
+## Goals
+
+- Structured per-attr log: per-derivation frames, phases, timings; existing
+  `(build, attr)` keying and independent streaming unchanged.
+- Build page stays the DB attribute list; each attr expands to its log.
+- Viewer scales to 250+ attributes / large logs: whole-log DOM with
+  `content-visibility` (native find/anchors kept), lazy card expansion, global
+  search; manual virtualization only for monster logs.
+- No eager migration: new format for new builds, dual-read for old.
+
+Not now: cross-build search index, backfill, changes to raw/grep endpoints.
+
+## Storage format (adapted from the prototype)
+
+Per-`(build, attr)` file, replacing the current flat `.zst`:
+`<frames><TOC json><u32 len><NBL1>`.
+
+- One frame per derivation (grouped only when an invocation builds several small
+  deps), zstd level 12. Ratio (~11x per-attr) is not a design driver; logs are
+  small. L19 costs 12x the CPU for ~18% ratio; trained dicts hurt per-frame
+  compression — both unused.
+- TOC entry per derivation:
+  ```jsonc
+  {
+    "name": "...", "status": "built|failed",
+    "off": <frame offset>, "clen": <frame len>,
+    "bs": <byte start in frame>, "bn": <byte len>, "n": <lines>,
+    "ph": [["build", <first line>], ...],
+    "t0": <start ms>, "t1": <stop ms>
+  }
+  ```
+- Read a derivation: decompress its frame (cached), slice `[bs:bs+bn]`,
+  `splitlines`. Slice by byte range rather than splitting the whole frame (3x
+  faster reads).
+- Monster drvs (>4 MB text): split into multiple frames + sub-line index. The 64
+  MB head+tail cap still applies per log; the viewer must show a truncation gap.
+- Format optimizes write CPU and read latency, not ratio.
+
+## Phase 1 — Storage library
+
+`nixbot/nixbot/logstore.py` (port prototype):
+
+- `LogContainerWriter`: `(drv, phase, line, ts)` records → per-group buffers →
+  64 KB frames + TOC.
+- `LogContainerReader`: tail-parse TOC; `drv(i)`, `phases(i)`, `drv_all()`.
+- `search(reader, query, per_drv_cap)`: frame fast-reject + position-locate
+  - byte-bisect attribution. Scoped to one log, no index.
+
+Tests (`tests/test_logstore.py`, TDD): byte-identical round-trip; TOC phase
+indices / line counts / byte ranges; search across rare/common/phrase terms with
+line-number accuracy; write/read latency guards.
+
+## Phase 2 — Ingest: capture structure
+
+`nixbot/nixbot/executor.py`:
+
+- `render_log_event`: add `SetPhase` (result type 104) per activity id, and
+  activity `stop` timestamps for durations.
+- Key frames by full drv path (`ACT_BUILD` `fields[0]`), not the truncated
+  display name — fixes collisions when an invocation builds several drvs.
+- `_pump_output` / `LogWriter`: within each attr's existing stream, demux by
+  activity id into per-derivation buffers feeding `LogContainerWriter`;
+  unprefixed nix output → a synthetic `driver` frame.
+
+Tests: `internal-json` fixtures → assert per-derivation grouping, phase ranges,
+driver bucket. Keep transient-error detection and `failure_excerpt` working off
+the demuxed stream.
+
+## Phase 3 — Web
+
+`nixbot/nixbot/web/logs.py`:
+
+- Format dispatch in `_resolve`: `NBL1` container → serve from it; else the
+  legacy flat renderer. Runs the whole mixed-format retention window.
+- Endpoints extend the existing per-attr routes (`.../builds/{n}/logs/{attr}`):
+  - `.../logs/{attr}` — TOC (derivations + phases + timings) for the shell.
+  - `.../logs/{attr}/lines` — a derivation's text; whole log by default,
+    `?from=&to=` only for monster logs past the render cap.
+  - `.../builds/{n}/search?q=` — build-scoped global search across the build's
+    per-attr containers; returns per-derivation hit groups.
+- Raw text: project the log from frames in timestamp order; legacy raw route
+  unchanged.
+- SSE unchanged (still per attr); demux happens on the write side.
+
+## Phase 4 — Frontend
+
+Port `scale.html` into nixbot templates/static:
+
+- Build page: attribute list from the DB, failures first, successes behind a
+  count + expand-to-browse. Each row is a unified card (disclosure → inline
+  log). Reuse nixbot tokens.
+- Rendering: whole log as real DOM rows with `content-visibility: auto` (fixed
+  20 px rows). Native Ctrl-F, `#L` anchors, selection and screen readers all
+  work; the browser skips off-screen layout. Manual virtualization +
+  `?from=&to=` fetch only past a large line/byte cap (monster logs), with the
+  raw log as the accessible path there.
+- Phase bar from the container TOC `ph`; hidden when empty (legacy logs).
+- Search: one global box (names + log content), results grouped by derivation,
+  failures first, keyboard-navigable; a hit jumps to the card + line. No per-log
+  find UI — within a log is native Ctrl-F.
+- Touch: 44 px targets under `pointer: coarse`, 14 rem log cap on phones.
+- A11y: semantic disclosures, ARIA, native find/anchors from real DOM rows.
+
+## Phase 5 — Migration
+
+- No backfill, no eager conversion. Old builds serve via dual-read; retention
+  retires them over one window.
+- UI degrades on legacy builds: no phase bar, no durations, log + find still
+  work.
+- Flag the new writer; roll new builds on, watch ingest CPU and sizes, remove
+  the flag.
+
+## Sequencing & risk
+
+1. Phase 1: self-contained, offline-testable — start here.
+2. Phase 2: riskiest (rewrites the hot output path). Flag it, keep the legacy
+   writer until parity is proven on real builds.
+3. Phases 3–4: build against Phase 1 with synthetic containers before Phase 2
+   lands.
+4. Watch: byte-accurate demux when several drvs interleave in one invocation;
+   the `driver` bucket catching all unprefixed output; monster-drv sub-framing.
+
+## Deferred
+
+- Cross-build search: per-log trigram/bloom in the TOC to pick candidate attrs,
+  then scan; or real FTS.
+- Timeline view (timings now captured).
+- zstd long-distance matching for monster drvs.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,142 @@
+# Review: "TC: Lightweight Container Image for Cross-Platform Deployment"
+
+## Summary
+
+TC ships a container "image" that contains only the identifiers of an
+application's direct dependencies. Instead of a fully built, platform-specific
+environment, a lazy-builder on the deployment host resolves those identifiers
+into concrete "uniform components" and overlays them into a container at deploy
+time. Every package manager (apt, nix, pip, npm, conda, docker) is reduced to
+two functions, version selection and environment selection, and a CDCL resolver
+handles cross-manager dependencies on top of a central component registry.
+
+The reported wins are 95% smaller images, 76-86% faster builds, 44-50% less
+network traffic, and 40-60% faster deployment than Docker, Buildah and
+Apptainer.
+
+I think the direction is sound for interpreted-language apps that need to run on
+many platforms, and I believe the measurements. What I don't buy is how much of
+this is new versus a repackaging of what Nix and conda already do, and several
+of the headline numbers only look that good because of how the baseline was set
+up. Supply-chain trust, which would decide whether anyone actually adopts this,
+is not discussed at all.
+
+## What the paper does well
+
+A few things stand out and should be said before the criticism.
+
+The headline result is genuinely surprising: lazy-building a container from a
+thin manifest ends up _faster_ than pulling a pre-built image (199.1 s to 12.7 s
+on YOLO11, §Motivation). Beating a plain `docker pull` is not what I expected
+going in, and if it holds up it is the most interesting claim in the paper.
+
+The VS/ES abstraction is clean. Collapsing apt, nix, pip, npm, conda and docker
+into just version selection plus environment selection, with a shared building
+context carrying host facts across managers, is a tidy framing that makes
+cross-manager dependencies (a pip package pulling apt libraries, ABI facts
+propagating between them) expressible in one resolver. Even if the pieces exist
+elsewhere, stating them this uniformly is useful.
+
+The component-level sharing analysis (Table 1) is a real contribution, not just
+a size claim. It shows a better sharing rate (21.6%) than file-level (14.6%) or
+chunk-level (19.9%) approaches while producing far fewer objects (3302), and the
+active-sharing variant pushes reuse to 46-69% on CPU/GPU servers. That is a
+concrete argument for the granularity choice.
+
+This is also a real system, not a prototype: ~13k LOC of Go, a registry with
+50,000+ packages, containerd/CRI-O compatibility, and runtime performance
+identical to Docker since both use containerd. Correctness is checked properly
+too, by running each app's official functional tests and diffing the installed
+apt/pip package sets against conventional builders. The hardware coverage is
+good, spanning two CPU architectures and two GPU vendors including a Jetson edge
+device, and the authors are honest that lazy pulling is complementary rather
+than competing (about 32% extra when combined).
+
+## The motivation argues against a strawman
+
+The paper justifies building its own machinery like this:
+
+> If the lazy-builder were to directly reuse existing environment managers such
+> as nix, pip or apt on the deployment platform, the build process would be
+> slower than pulling a pre-built image, and the results could be incorrect or
+> inconsistent due to the instability of upstream software registries.
+
+Registry instability is largely a problem you opt into. Anyone deploying at
+scale mirrors their registries internally (Artifactory, Nexus, private channels,
+binary caches). Pin that mirror and the instability argument disappears, and a
+pinned, warm registry is exactly what TC itself relies on.
+
+The "reusing Nix would be slower" claim is asserted, not shown. In our own
+experience Nix tends to beat the OCI model rather than lose to it: it shares
+data at the store-path level instead of per layer, and it does not invalidate
+everything downstream when an early build step changes, the way a Dockerfile
+does. nix-snapshotter (https://github.com/pdtpartners/nix-snapshotter) already
+mounts store paths lazily as container content, which is the very thing the
+paper claims existing managers cannot do fast enough.
+
+## The obvious baselines are missing
+
+Everything is compared against image builders (Docker, Buildah, Apptainer). The
+systems that actually resemble TC are not. Bazel and Nix (`dockerTools`,
+`nix2container`, or on-demand serving like Nixery) already build images, or skip
+OCI entirely, from a single declarative description, and can materialise them
+lazily. That is TC's own "declare once, build per platform" pitch, and it is not
+evaluated against any of them. The two contributions the paper claims, unified
+cross-manager resolution and deterministic selection, are mostly already there
+in these tools.
+
+The size trade-off against them is also worth pinning down. Nix-based serving
+keeps the full image in the registry while TC ships a thin manifest, but at
+scale bandwidth costs more than storage, so keeping the bytes central and
+cutting per-client transfer is often the better deal, and cross-image sharing at
+package granularity already exists there. TC only wins clearly when
+build-time-only files never reach runtime, and the paper assumes this rather
+than measuring it.
+
+## The evaluation is set up in TC's favour
+
+The 95% size number compares a manifest against a full image. TC is small only
+because the ~1.8 GB of components live in a registry the host still has to pull.
+The paper's own figures have the host fetching 188 MB of TC plus 1822 MB of
+components, so the real end-to-end saving is about 65%.
+
+The build-time advantage is pre-computation, not networking, and to their credit
+the authors say so: external registries and the component registry sit on the
+same server behind a shared 1 Gbps link (§5.1), so the baselines pull from a
+local mirror too. The difference is structural. On the host the lazy-builder
+only resolves and overlays; conversion and compilation happened earlier, once,
+centrally, in the 1.6 TB registry. Docker reruns apt install, compilation and
+linking on every build. That shows up as the roughly 100 s gap in §5.4 that
+Docker spends compiling and TC does not. It is a fair design choice, but the
+work was moved to the central service, not removed, and a like-for-like
+comparison would hand Docker a warm BuildKit layer cache so both sides amortise
+their build steps.
+
+Cross-platform portability (§5.2) is shown on a single app, YOLO11, not the full
+nine-app suite used elsewhere.
+
+## Storage is relocated, not saved
+
+The registry is 1.6 TB now, and the paper estimates another 20 TB for all of
+Debian and 10 TB for all of PyPI, times the number of architectures. So the
+client saves storage and bandwidth by pushing both onto a central service that
+has to convert the world ahead of time. The "less network usage" claim is
+per-client and says nothing about that aggregate cost, which is the number that
+matters if bandwidth is your bottleneck.
+
+## Nothing about trust
+
+Resolving identifiers into components at deploy time is a much larger attack
+surface than pulling one fixed, signed image. There is no mention of signing,
+verification, or being able to reproduce a specific audited artifact. That is a
+notable omission for a paper that lists data security among its motivations.
+
+## What would change my mind
+
+- End-to-end transfer numbers (client plus components), not manifest-only sizes.
+- Baselines that build from a single description: Nix (nix-snapshotter,
+  nix2container), Nixery, Bazel.
+- Docker with a warm layer cache, so build steps are amortised on both sides.
+- A trust story: signing and auditable artifacts.
+- Portability across the whole suite, not just YOLO11.
+- The aggregate registry storage and bandwidth cost at scale.

--- a/REVIEW2.md
+++ b/REVIEW2.md
@@ -1,0 +1,93 @@
+# Review: "TC: Lightweight Container Image for Cross-Platform Deployment"
+
+## Summary
+
+TC ships a container "image" that contains only the identifiers of an
+application's direct dependencies. Instead of a fully built, platform-specific
+environment, a lazy-builder on the deployment host resolves those identifiers
+into concrete "uniform components" and overlays them into a container at deploy
+time. Every package manager (apt, nix, pip, npm, conda, docker) is reduced to
+two functions, version selection and environment selection, and a CDCL resolver
+handles cross-manager dependencies on top of a central component registry.
+
+The reported wins are 95% smaller images, 76-86% faster builds, 44-50% less
+network traffic, and 40-60% faster deployment than Docker, Buildah and
+Apptainer.
+
+I think the direction is sound for interpreted-language apps that need to run on
+many platforms, and I believe the measurements. What I don't buy is how much of
+this is new versus a repackaging of what Nix and conda already do, and several
+of the headline numbers only look that good because of how the baseline was set
+up.
+
+## Strengths
+
+A few things stand out and should be said before the criticism.
+
+The headline result is genuinely surprising: lazy-building a container from a
+thin manifest ends up _faster_ than pulling a pre-built image (199.1 s to 12.7 s
+on YOLO11, §Motivation). Beating a plain `docker pull` is not what I expected
+going in, and if it holds up it is the most interesting claim in the paper.
+
+The VS/ES abstraction is clean. Collapsing apt, nix, pip, npm, conda and docker
+into just version selection plus environment selection, with a shared building
+context carrying host facts across managers, is a tidy framing that makes
+cross-manager dependencies (a pip package pulling apt libraries, ABI facts
+propagating between them) expressible in one resolver. Even if the pieces exist
+elsewhere, stating them this uniformly is useful.
+
+The component-level sharing analysis (Table 1) is a real contribution, not just
+a size claim. It shows a better sharing rate (21.6%) than file-level (14.6%) or
+chunk-level (19.9%) approaches while producing far fewer objects (3302), and the
+active-sharing variant pushes reuse to 46-69% on CPU/GPU servers. That is a
+concrete argument for the granularity choice.
+
+## Motivation
+
+The paper justifies building its own machinery like this:
+
+> If the lazy-builder were to directly reuse existing environment managers such
+> as nix, pip or apt on the deployment platform, the build process would be
+> slower than pulling a pre-built image, and the results could be incorrect or
+> inconsistent due to the instability of upstream software registries.
+
+Registry instability is largely a problem you opt into. Anyone deploying at
+scale mirrors their registries internally (Artifactory, Nexus, private channels,
+binary caches). Pin that mirror and the instability argument disappears, and a
+pinned, warm registry is exactly what TC itself relies on.
+
+The "reusing Nix would be slower" claim is asserted, not shown. In our own
+experience Nix tends to beat the OCI model rather than lose to it: it shares
+data at the store-path level instead of per layer, and it does not invalidate
+everything downstream when an early build step changes, the way a Dockerfile
+does. [nix-snapshotter](https://github.com/pdtpartners/nix-snapshotter) already
+mounts store paths lazily as container content, which is the very thing the
+paper claims existing managers cannot do fast enough.
+
+## Missing baselines
+
+Everything is compared against image builders (Docker, Buildah, Apptainer). The
+systems that actually resemble TC are not. Bazel and Nix (`dockerTools`,
+`nix2container`, or on-demand serving like Nixery) already build images, or skip
+OCI entirely, from a single declarative description, and can materialise them
+lazily. That is TC's own "declare once, build per platform" pitch, and it is not
+evaluated against any of them. The two contributions the paper claims, unified
+cross-manager resolution and deterministic selection, are mostly already there
+in these tools.
+
+## Evaluation setup
+
+The 95% size number compares a manifest against a full image. TC is small only
+because the ~1.8 GB of components live in a registry the host still has to pull.
+The paper's own figures have the host fetching 188 MB of TC plus 1822 MB of
+components, so the real end-to-end saving is about 65%.
+
+The build-time advantage is pre-computation, not networking, as the authors note
+(§5.1): the host only resolves and overlays, while conversion and compilation
+happened earlier and centrally in the 1.6 TB registry, whereas Docker reruns apt
+install, compilation and linking every build. That is the ~100 s gap in §5.4.
+Fair design choice, but the work was moved to the central service, not removed;
+a like-for-like comparison would give Docker a warm BuildKit layer cache.
+
+Cross-platform portability (§5.2) is shown on a single app, YOLO11, not the full
+nine-app suite used elsewhere.

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -619,19 +619,24 @@ class StructuredCapture:
         self._emit(
             {"t": "line", "idx": 0, "from": self._bump(self.SETUP), "text": text}
         )
-        stripped = strip_ansi(text)
+        # A nix error block arrives as one multiline msg event; scrape per
+        # line so the "Cannot build" and its "Reason:" line pair up.
+        for line in strip_ansi(text).splitlines():
+            self._scrape_failure(line)
+
+    def _scrape_failure(self, line: str) -> None:
         # --keep-going: mark every failed drv, not just the top-level one.
-        for m in _BUILD_FAILED.finditer(stripped):
+        for m in _BUILD_FAILED.finditer(line):
             drv = m.group(1)
             if drv in self._idx:
                 self.set_status(drv, "failed")
         # Two-line form: flag the drv only once its "Reason:" says the
         # builder failed, not a dependency (a cascade parent).
-        if cannot := _CANNOT_BUILD.search(stripped):
+        if cannot := _CANNOT_BUILD.search(line):
             self._pending_cannot = cannot.group(1)
-        elif self._pending_cannot and "Reason:" in stripped:
+        elif self._pending_cannot and "Reason:" in line:
             drv, self._pending_cannot = self._pending_cannot, None
-            if "builder failed" in stripped and drv in self._idx:
+            if "builder failed" in line and drv in self._idx:
                 self.set_status(drv, "failed")
 
     def set_status(self, drv_path: str, status: str) -> None:

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -837,6 +837,10 @@ def _build_plan(
     if not attrs:
         return None
     lines = [header, "", head, sep]
+    # +1 per line for the newline join() inserts; undercounting lets the
+    # joined text exceed the budget, and _check_run_output then chops it
+    # mid-row into invalid markdown.
+    used = sum(len(line) + 1 for line in lines)
     for i, attr in enumerate(attrs):
         live = f"{build_url}/logs/{quote(attr)}"
         raw = f"{build_url}/logs/raw/{quote(attr)}"
@@ -849,8 +853,11 @@ def _build_plan(
         else:
             cell = _status_cell(status or "unknown")
             line = f"| {attr_cell} | {cell} | {raw_cell} |"
-        if sum(map(len, lines)) + len(line) > CHECK_RUN_TEXT_LIMIT:
-            lines.append(f"| … {len(attrs) - i} more {trunc.format(build_url)}")
+        trunc_line = f"| … {len(attrs) - i} more {trunc.format(build_url)}"
+        # Reserve room for the trailing row so it always fits.
+        if used + len(line) + 1 + len(trunc_line) + 1 > CHECK_RUN_TEXT_LIMIT:
+            lines.append(trunc_line)
             break
         lines.append(line)
+        used += len(line) + 1
     return "\n".join(lines)

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -773,7 +773,8 @@ def test_structured_failure_excerpt_caps_many_failures() -> None:
 
 
 def test_scrapes_cannot_build_reason_wording() -> None:
-    # Newer nix spreads a failure over "Cannot build '<drv>'." + "Reason:".
+    # Newer nix spreads a failure over "Cannot build '<drv>'." + "Reason:",
+    # emitted as a single multiline `msg` event (one setup_line call).
     # Flag the leaf that carries the output, not the cascade parents that
     # only report "1 dependency failed".
     cap = StructuredCapture(clock=lambda: 1.0)
@@ -781,10 +782,13 @@ def test_scrapes_cannot_build_reason_wording() -> None:
     top = "/nix/store/195-vm-test-run-nixbot-gitlab.drv"
     cap.start_build(1, leaf)
     cap.log_line(1, "tribuchet worker error: build execution panicked")
-    cap.setup_line(f"error: Cannot build '{leaf}'.")
-    cap.setup_line("       Reason: builder failed with exit code 1.")
-    cap.setup_line(f"error: Cannot build '{top}'.")
-    cap.setup_line("       Reason: 1 dependency failed.")
+    cap.setup_line(
+        f"error: Cannot build '{leaf}'.\n"
+        "       Reason: builder failed with exit code 1.\n"
+        "       Output paths:\n"
+        "         /nix/store/7bs-closure-info"
+    )
+    cap.setup_line(f"error: Cannot build '{top}'.\n       Reason: 1 dependency failed.")
     cap.mark_failed(top)
     state = {e["name"]: e["status"] for e in cap.state()}
     # Leaf flagged with its output; no phantom top-level card, setup neutral.

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -34,6 +34,7 @@ from nixbot.status import (
     GitHubCheckRunPoster,
     GitlabStatusPoster,
     StatusState,
+    _build_plan,
     _check_run_output,
     attr_status_context,
     effect_status_context,
@@ -724,6 +725,18 @@ def test_check_run_output_title_and_truncate() -> None:
     out = _check_run_output("ctx", "s", "x" * (CHECK_RUN_TEXT_LIMIT + 100))
     assert "truncated" in out["text"]
     assert "text" not in _check_run_output("ctx", "s", None)
+
+
+def test_build_plan_truncation_stays_within_check_run_budget() -> None:
+    """A huge attribute table must fit the check-run budget itself; if it
+    overshoots, _check_run_output chops it mid-row into invalid markdown."""
+    attrs = [f"a{i:05d}" for i in range(20000)]
+    statuses = dict.fromkeys(attrs, "succeeded")
+    table = _build_plan(attrs, "https://ci/b/1", statuses)
+    assert table is not None
+    assert len(table) <= CHECK_RUN_TEXT_LIMIT
+    assert _check_run_output("c", "s", table)["text"] == table
+    assert table.rstrip().endswith("|")
 
 
 # --- GitHub check-run poster -----------------------------------------------


### PR DESCRIPTION

nix emits an error block ("Cannot build '<drv>'." then a "Reason:" line)
as one multiline msg event, so setup_line got it in a single call. The
scraper set the pending drv from "Cannot build" but never reached the
"Reason:" branch in the same call, so the failing derivation was never
flagged and mark_failed marked the whole setup bucket failed instead.

Split the text into physical lines so the two lines pair up.


