### PR TITLE
web: shareable per-derivation log pages and grouped live log view

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,3 @@
+{
+  "ignore": ["**/nixbot/db_gen/**"]
+}

--- a/nixbot/nixbot/config.py
+++ b/nixbot/nixbot/config.py
@@ -15,7 +15,7 @@ import re
 from collections.abc import Callable, Mapping  # noqa: TC003
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler, field_validator
 from pydantic_core import CoreSchema, core_schema
@@ -71,62 +71,55 @@ class Interpolate(BaseModel):
         super().__init__(nix_type="interpolate", value=value)
 
 
-class GiteaConfig(BaseModel):
-    instance_url: str
+class TokenForgeConfig(BaseModel):
+    """Shared token/OAuth/SSH options for token-authenticated forges
+    (Gitea, GitLab); subclasses only differ in defaults and the config
+    key used in error messages."""
+
+    _config_key: ClassVar[str]
+
     filters: RepoFilters = Field(default_factory=RepoFilters)
 
+    token_file: Path
+
+    oauth_id: str | None = None
+    oauth_secret_file: Path | None = None
+
+    ssh_private_key_file: Path | None = None
+    ssh_known_hosts_file: Path | None = None
+
+    @property
+    def token(self) -> str:
+        return read_secret_file(self.token_file)
+
+    @property
+    def oauth_secret(self) -> str:
+        if self.oauth_secret_file is None:
+            msg = (
+                f"{self._config_key}.oauth_id is set but "
+                f"{self._config_key}.oauth_secret_file is missing"
+            )
+            raise ConfigError(msg)
+        return read_secret_file(self.oauth_secret_file)
+
+    model_config = ConfigDict(
+        extra="forbid",
+        ignored_types=(property,),
+    )
+
+
+class GiteaConfig(TokenForgeConfig):
+    _config_key: ClassVar[str] = "gitea"
+
+    instance_url: str
     token_file: Path = Field(default=Path("gitea-token"))
 
-    oauth_id: str | None = None
-    oauth_secret_file: Path | None = None
 
-    ssh_private_key_file: Path | None = None
-    ssh_known_hosts_file: Path | None = None
+class GitlabConfig(TokenForgeConfig):
+    _config_key: ClassVar[str] = "gitlab"
 
-    @property
-    def token(self) -> str:
-        return read_secret_file(self.token_file)
-
-    @property
-    def oauth_secret(self) -> str:
-        if self.oauth_secret_file is None:
-            msg = "gitea.oauth_id is set but gitea.oauth_secret_file is missing"
-            raise ConfigError(msg)
-        return read_secret_file(self.oauth_secret_file)
-
-    model_config = ConfigDict(
-        extra="forbid",
-        ignored_types=(property,),
-    )
-
-
-class GitlabConfig(BaseModel):
     instance_url: str = "https://gitlab.com"
-    filters: RepoFilters = Field(default_factory=RepoFilters)
-
     token_file: Path = Field(default=Path("gitlab-token"))
-
-    oauth_id: str | None = None
-    oauth_secret_file: Path | None = None
-
-    ssh_private_key_file: Path | None = None
-    ssh_known_hosts_file: Path | None = None
-
-    @property
-    def token(self) -> str:
-        return read_secret_file(self.token_file)
-
-    @property
-    def oauth_secret(self) -> str:
-        if self.oauth_secret_file is None:
-            msg = "gitlab.oauth_id is set but gitlab.oauth_secret_file is missing"
-            raise ConfigError(msg)
-        return read_secret_file(self.oauth_secret_file)
-
-    model_config = ConfigDict(
-        extra="forbid",
-        ignored_types=(property,),
-    )
 
 
 class PullBasedRepository(BaseModel):

--- a/nixbot/nixbot/tests/e2e/test_browse.py
+++ b/nixbot/nixbot/tests/e2e/test_browse.py
@@ -45,7 +45,7 @@ def test_structured_log_viewer(page: Page) -> None:
     page.goto("/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad")
     # Failing derivation card is open with inline phase dividers; log rows
     # load lazily from /drv/{idx}.
-    card = page.locator('.log-card[data-pos="0"]')
+    card = page.locator('.log-card[data-idx="0"]')
     card.get_by_text("hello-2.12").wait_for()
     assert card.get_attribute("open") is not None
     card.locator(".phase-sep").first.wait_for()

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -16,7 +16,6 @@ import pytest
 from nixbot.api_tokens import ApiTokenStore
 from nixbot.auth import AuthzConfig, User
 from nixbot.bootstrap import build_service
-from nixbot.config import Config
 from nixbot.db_gen import builds as builds_q
 from nixbot.events import BuildResult, ChangeEvent, NullStatusReporter
 from nixbot.executor import attribute_log_path
@@ -40,6 +39,7 @@ from .support import (
     db_pool,
     insert_build,
     insert_project,
+    make_config,
     web_harness,
 )
 from .test_visibility import FakeFetcher
@@ -549,12 +549,7 @@ def test_api_token_controls_build(harness: WebHarness) -> None:
 
 
 async def test_build_service_composition(postgres_dsn: str, tmp_path: Path) -> None:
-    config = Config(
-        db_url=postgres_dsn,
-        build_systems=["x86_64-linux"],
-        url="http://ci.test",
-        state_dir=tmp_path / "state",
-    )
+    config = make_config(postgres_dsn, tmp_path / "state")
     service, app = await build_service(config)
     try:
         async with httpx.AsyncClient(
@@ -578,12 +573,7 @@ async def test_build_service_composition(postgres_dsn: str, tmp_path: Path) -> N
 async def test_restart_removes_stale_logs(postgres_dsn: str, tmp_path: Path) -> None:
     """A restart drops the previous run's log metadata and on-disk file
     at reset time, so the pending row does not show stale output."""
-    config = Config(
-        db_url=postgres_dsn,
-        build_systems=["x86_64-linux"],
-        url="http://ci.test",
-        state_dir=tmp_path / "state",
-    )
+    config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
     try:
@@ -616,12 +606,7 @@ async def test_restart_removes_stale_logs(postgres_dsn: str, tmp_path: Path) -> 
 async def test_restart_clears_failed_cache_immediately(
     postgres_dsn: str, tmp_path: Path
 ) -> None:
-    config = Config(
-        db_url=postgres_dsn,
-        build_systems=["x86_64-linux"],
-        url="http://ci.test",
-        state_dir=tmp_path / "state",
-    )
+    config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
     try:
@@ -756,12 +741,7 @@ async def test_report_retry(
     gives up after MAX_REPORT_ATTEMPTS instead of looping."""
     monkeypatch.setattr("nixbot.service.REPORT_BACKOFF_SECONDS", 0)
 
-    config = Config(
-        db_url=postgres_dsn,
-        build_systems=["x86_64-linux"],
-        url="http://ci.test",
-        state_dir=tmp_path / "state",
-    )
+    config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
     try:
@@ -825,12 +805,7 @@ async def test_effect_item_setup_failure_settles_row(
     """A fetch/checkout failure in an effect item must not leave the
     row pending forever."""
 
-    config = Config(
-        db_url=postgres_dsn,
-        build_systems=["x86_64-linux"],
-        url="http://ci.test",
-        state_dir=tmp_path / "state",
-    )
+    config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
     try:
@@ -868,12 +843,7 @@ async def test_restart_attribute_posts_pending(
 ) -> None:
     """Re-run on the forge must flip the check to pending immediately,
     not only when the async rebuild finishes."""
-    config = Config(
-        db_url=postgres_dsn,
-        build_systems=["x86_64-linux"],
-        url="http://ci.test",
-        state_dir=tmp_path / "state",
-    )
+    config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
     try:
@@ -911,12 +881,7 @@ async def test_recovery_reports_interrupted_effects(
     """An effect left running by a crash is settled failed but never
     re-runs; recovery must post that failure so the check run does not
     stay pending forever (issue #58)."""
-    config = Config(
-        db_url=postgres_dsn,
-        build_systems=["x86_64-linux"],
-        url="http://ci.test",
-        state_dir=tmp_path / "state",
-    )
+    config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
     try:
@@ -971,12 +936,7 @@ async def test_recovery_reports_interrupted_effects(
 async def test_work_dispatch(postgres_dsn: str, tmp_path: Path) -> None:
     """The dispatcher reconstructs payloads and fails unknown kinds."""
 
-    config = Config(
-        db_url=postgres_dsn,
-        build_systems=["x86_64-linux"],
-        url="http://ci.test",
-        state_dir=tmp_path / "state",
-    )
+    config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
     try:
@@ -1014,12 +974,7 @@ async def test_restart_resets_effects(postgres_dsn: str, tmp_path: Path) -> None
     """A full restart re-runs effects: clear the started-flag and the
     previous run's rows, or the page keeps showing stale results."""
 
-    config = Config(
-        db_url=postgres_dsn,
-        build_systems=["x86_64-linux"],
-        url="http://ci.test",
-        state_dir=tmp_path / "state",
-    )
+    config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
     try:

--- a/nixbot/nixbot/tests/test_service.py
+++ b/nixbot/nixbot/tests/test_service.py
@@ -73,6 +73,33 @@ async def service(make_service: ServiceFactory) -> CIService:
     return service
 
 
+def capture_run_build(service: CIService) -> list[int]:
+    """Replace orchestrator.run_build with a stub recording build ids."""
+    build_ids: list[int] = []
+
+    async def fake_run_build(
+        event: Any, build: Any, worktree_path: Path, credentials: Any = None
+    ) -> None:
+        build_ids.append(build.id)
+
+    service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
+    return build_ids
+
+
+def capture_resume(service: CIService) -> list[int]:
+    """Replace orchestrator.rerun_pending_attributes with a stub
+    recording build ids."""
+    build_ids: list[int] = []
+
+    async def fake_resume(
+        info: Any, build: Any, jobs: Any, credentials: Any = None
+    ) -> None:
+        build_ids.append(build.id)
+
+    service.orchestrator.rerun_pending_attributes = fake_resume  # type: ignore[method-assign, assignment]
+    return build_ids
+
+
 # --- pure helpers ------------------------------------------------------
 
 
@@ -232,17 +259,7 @@ async def test_restart_gitlab_mr_build_fetches_mr_refs(
             error="eval boom",
         )
 
-        reevals: list[int] = []
-
-        async def fake_run_build(
-            event: Any,
-            build: Any,
-            worktree_path: Path,
-            credentials: Any = None,
-        ) -> None:
-            reevals.append(build.id)
-
-        service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
+        reevals = capture_run_build(service)
         await service.restart_build(build_id)
         await service.drain_work()
         await asyncio.gather(*service._tasks)  # noqa: SLF001
@@ -309,15 +326,7 @@ async def test_restart_clears_stale_error_and_warnings(
         build_id,
     )
 
-    async def fake_run_build(
-        event: Any,
-        build: Any,
-        worktree_path: Path,
-        credentials: Any = None,
-    ) -> None:
-        pass
-
-    service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
+    capture_run_build(service)
     await service.restart_build(build_id)
     await service.drain_work()
     await asyncio.gather(*service._tasks)  # noqa: SLF001
@@ -347,17 +356,7 @@ async def test_restart_unknown_attribute_is_a_noop(
         build_id,
     )
 
-    reruns: list[int] = []
-
-    async def fake_run_build(
-        event: Any,
-        build: Any,
-        worktree_path: Path,
-        credentials: Any = None,
-    ) -> None:
-        reruns.append(build.id)
-
-    service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
+    reruns = capture_run_build(service)
     await service.restart_attribute(build_id, "ghost")
     await service.drain_work()
     await asyncio.gather(*service._tasks)  # noqa: SLF001
@@ -389,17 +388,7 @@ async def test_restart_failed_eval_attribute_reevaluates(
         build_id,
     )
 
-    reevals: list[int] = []
-
-    async def fake_run_build(
-        event: Any,
-        build: Any,
-        worktree_path: Path,
-        credentials: Any = None,
-    ) -> None:
-        reevals.append(build.id)
-
-    service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
+    reevals = capture_run_build(service)
     await service.restart_build(build_id)
     status = await pool.fetchval("SELECT status FROM builds WHERE id = $1", build_id)
     assert status == "pending"
@@ -488,21 +477,8 @@ async def test_restart_cancelled_mid_eval_reevaluates(
         build_id,
     )
 
-    reevals: list[int] = []
-    resumes: list[int] = []
-
-    async def fake_run_build(
-        event: Any, build: Any, worktree_path: Path, credentials: Any = None
-    ) -> None:
-        reevals.append(build.id)
-
-    async def fake_resume(
-        info: Any, build: Any, jobs: Any, credentials: Any = None
-    ) -> None:
-        resumes.append(build.id)
-
-    service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
-    service.orchestrator.rerun_pending_attributes = fake_resume  # type: ignore[method-assign, assignment]
+    reevals = capture_run_build(service)
+    resumes = capture_resume(service)
     await restart_dispatch.rerun(service, build_id)
 
     assert resumes == []
@@ -828,17 +804,7 @@ async def test_startup_reevaluates_interrupted_eval(
     project_id = await seed_project(pool, str(repo))
     build_id = await insert_build(pool, project_id, commit_sha=sha, status="evaluating")
 
-    reevals: list[int] = []
-
-    async def fake_run_build(
-        event: Any,
-        build: Any,
-        worktree_path: Path,
-        credentials: Any = None,
-    ) -> None:
-        reevals.append(build.id)
-
-    service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
+    reevals = capture_run_build(service)
     await _startup(service)
     await service.drain_work()
     await asyncio.gather(*service._tasks)  # noqa: SLF001
@@ -867,24 +833,8 @@ async def test_rerun_of_interrupted_eval_reevaluates(
         build_id,
     )
 
-    reevals: list[int] = []
-    resumes: list[int] = []
-
-    async def fake_run_build(
-        event: Any,
-        build: Any,
-        worktree_path: Path,
-        credentials: Any = None,
-    ) -> None:
-        reevals.append(build.id)
-
-    async def fake_resume(
-        info: Any, build: Any, jobs: Any, credentials: Any = None
-    ) -> None:
-        resumes.append(build.id)
-
-    service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
-    service.orchestrator.rerun_pending_attributes = fake_resume  # type: ignore[method-assign, assignment]
+    reevals = capture_run_build(service)
+    resumes = capture_resume(service)
     await restart_dispatch.rerun(service, build_id)
 
     assert resumes == []
@@ -914,23 +864,14 @@ async def test_rerun_resumes_building_rows_and_keeps_finished(
         build_id,
     )
 
-    reevals: list[int] = []
+    reevals = capture_run_build(service)
     resumed_attrs: list[str] = []
-
-    async def fake_run_build(
-        event: Any,
-        build: Any,
-        worktree_path: Path,
-        credentials: Any = None,
-    ) -> None:
-        reevals.append(build.id)
 
     async def fake_resume(
         info: Any, build: Any, jobs: Any, credentials: Any = None
     ) -> None:
         resumed_attrs.extend(job.attr for job in jobs)
 
-    service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
     service.orchestrator.rerun_pending_attributes = fake_resume  # type: ignore[method-assign, assignment]
     await restart_dispatch.rerun(service, build_id)
 
@@ -961,24 +902,8 @@ async def test_rerun_reevaluates_when_drv_paths_were_garbage_collected(
         build_id,
     )
 
-    reevals: list[int] = []
-    resumes: list[int] = []
-
-    async def fake_run_build(
-        event: Any,
-        build: Any,
-        worktree_path: Path,
-        credentials: Any = None,
-    ) -> None:
-        reevals.append(build.id)
-
-    async def fake_resume(
-        info: Any, build: Any, jobs: Any, credentials: Any = None
-    ) -> None:
-        resumes.append(build.id)
-
-    service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
-    service.orchestrator.rerun_pending_attributes = fake_resume  # type: ignore[method-assign, assignment]
+    reevals = capture_run_build(service)
+    resumes = capture_resume(service)
     # The real path checker: /nix/store/gcd.drv does not exist.
     await restart_dispatch.rerun(service, build_id)
 

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -756,11 +756,6 @@ def test_structured_log_endpoints(client: WebHarness, tmp_path: Path) -> None:
     base = "/repos/github/acme/widget/builds/2"
     attr = "x86_64-linux.bad"
 
-    toc = client.get(f"{base}/logs/{attr}/toc").json()
-    assert toc["format"] == "nbl1"
-    assert toc["derivations"][0]["name"] == "qtbase-5.0"
-    assert toc["derivations"][0]["ph"] == [["build", 0]]
-
     rows = client.get(f"{base}/logs/{attr}/drv/0").text
     assert 'id="d0-L1"' in rows
     assert "CC main.o" in rows
@@ -782,7 +777,6 @@ def test_structured_log_endpoints(client: WebHarness, tmp_path: Path) -> None:
     assert "\x1b" not in raw
     # A zero-line derivation still has a valid (empty) raw endpoint.
     assert client.get(f"{base}/logs/{attr}/drv/1/raw").text == ""
-    assert toc["derivations"][1]["n"] == 0
     assert client.get(f"{base}/logs/{attr}/drv/9/raw").status_code == 404
 
     # Search now returns rendered HTML the client swaps in.
@@ -834,14 +828,6 @@ def test_structured_log_window_caps_huge_derivation(
     assert 'id="d0-L4000"' in chunk
     assert "line03999" in chunk
     assert "start=4000" in chunk  # next marker for the remaining gap
-
-
-def test_log_toc_legacy_without_container(client: WebHarness, tmp_path: Path) -> None:
-    seed_log(client, tmp_path)
-    toc = client.get(
-        "/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad/toc"
-    ).json()
-    assert toc["format"] == "legacy"
 
 
 def test_attr_named_dot_txt_not_shadowed_by_raw_route(

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -765,6 +765,16 @@ def test_structured_log_endpoints(client: WebHarness, tmp_path: Path) -> None:
     assert 'id="d0-L1"' in rows
     assert "CC main.o" in rows
 
+    # Standalone, shareable page for one derivation, linked from the viewer.
+    viewer = client.get(f"{base}/logs/{attr}").text
+    assert f"/logs/{attr}/drv/0/view" in viewer
+    page = client.get(f"{base}/logs/{attr}/drv/0/view")
+    assert page.status_code == 200
+    assert "qtbase-5.0" in page.text
+    assert 'id="d0-L1"' in page.text
+    assert f"/logs/{attr}/drv/0/raw" in page.text
+    assert client.get(f"{base}/logs/{attr}/drv/9/view").status_code == 404
+
     # Per-derivation raw: plain text, ANSI stripped.
     raw = client.get(f"{base}/logs/{attr}/drv/0/raw").text
     # Phase markers reconstructed from `ph` so raw readers keep context.
@@ -1161,6 +1171,12 @@ def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
         try:
             base = "/repos/github/acme/widget/builds/3/logs/x86_64-linux.ok"
             viewer = (await client.http.get(base)).text
+            # The shareable drv page also serves the running attribute,
+            # rendered from the live capture.
+            drv_page = (await client.http.get(f"{base}/drv/1/view")).text
+            assert "qtbase-5.0" in drv_page
+            assert "CC main.o" in drv_page
+            assert "format=structured" in drv_page  # follows the stream
             task = asyncio.ensure_future(
                 client.http.get(f"{base}/stream?format=structured")
             )
@@ -1176,6 +1192,13 @@ def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
     viewer, stream = client.loop.run_until_complete(run())
     assert "const LIVE = true" in viewer
     assert "format=structured" in viewer  # data-stream on #drv-list
+    # Live page groups cards by status like the finished view.
+    assert 'id="failed-cards"' in viewer
+    assert 'id="building-cards"' in viewer
+    assert 'id="succeeded-list"' in viewer
+    # Live cards link the drv page but not raw (container-backed only).
+    assert "/drv/1/view" in stream
+    assert "/drv/1/raw" not in stream
     assert "event: state" in stream
     assert '"name":"qtbase-5.0"' in stream  # snapshot burst
     # Rows are rendered server-side (ANSI applied), not shipped as raw text.

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -654,6 +654,56 @@ class _LogRoutes:
         html = await asyncio.to_thread(render_drv_window, reader, idx, base, start, end)
         return HTMLResponse(html)
 
+    async def log_drv_viewer(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        attr: str,
+        idx: int,
+    ) -> HTMLResponse:
+        """Standalone, shareable page for one derivation's log. The
+        embedded card view caps its height; this page shows the same
+        rows full-width with working line permalinks. While the attribute
+        is still running the rows come from the live capture (the client
+        follows the structured stream); once finished, from the container.
+        Capture and container assign indices in the same registration
+        order, so a link shared during the build stays valid after it."""
+        project, build, path = await self._resolve(
+            request, forge, owner, name, number, attr
+        )
+        base = request.url.path.removesuffix("/view").rsplit("/drv/", 1)[0]
+        writer = self.registry.get(build["id"], attr)
+        capture = writer.capture if writer else None
+        if capture is not None:
+            entry = next((e for e in capture.state() if e["idx"] == idx), None)
+            if entry is None:
+                raise HTTPException(status_code=404)
+            content = render_rows(
+                idx, 1, entry["lines"], phases=_phase_at(entry["ph"])
+            )[0]
+            live = True
+        else:
+            reader = await _load_container(path)
+            if reader is None or not (0 <= idx < len(reader)):
+                raise HTTPException(status_code=404)
+            entry = reader.entry(idx)
+            content = await asyncio.to_thread(render_drv_window, reader, idx, base)
+            live = False
+        return await self.ctx.render(
+            "drv.html",
+            request=request,
+            project=project,
+            build=build,
+            attr=attr,
+            idx=idx,
+            live=live,
+            drv={k: entry[k] for k in ("name", "status", "n", "t0", "t1")},
+            content=content,
+        )
+
     async def log_drv_raw(  # noqa: PLR0913
         self,
         request: Request,
@@ -802,6 +852,9 @@ def create_log_router(ctx: WebContext, registry: LogRegistry) -> APIRouter:
     router.get(f"{_BASE}/logs/{{attr}}.txt")(routes.log_raw_text_legacy)
     router.get(f"{_BASE}/logs/{{attr:path}}/stream")(routes.log_stream)
     router.get(f"{_BASE}/logs/{{attr:path}}/toc")(routes.log_toc)
+    router.get(
+        f"{_BASE}/logs/{{attr:path}}/drv/{{idx}}/view", response_class=HTMLResponse
+    )(routes.log_drv_viewer)
     router.get(f"{_BASE}/logs/{{attr:path}}/drv/{{idx}}/raw")(routes.log_drv_raw)
     router.get(f"{_BASE}/logs/{{attr:path}}/drv/{{idx}}", response_class=HTMLResponse)(
         routes.log_drv_lines
@@ -894,7 +947,11 @@ async def _structured_events(
     so a later line delta continues the same color."""
 
     def card(d: dict) -> str:
-        return str(drv_card(d, base, open=d["status"] in ("running", "failed")))
+        # live=True: rows arrive over the SSE, so no htmx fetch attrs and
+        # no raw link (the container behind it does not exist yet).
+        return str(
+            drv_card(d, base, open=d["status"] in ("running", "failed"), live=True)
+        )
 
     if capture is None:
         yield "event: done\ndata: \n\n"

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -614,23 +614,6 @@ class _LogRoutes:
         _, build = await self._build_or_404(request, forge, owner, name, number)
         return await _failure_summary(self.ctx, self.registry, build, tail)
 
-    async def log_toc(  # noqa: PLR0913
-        self,
-        request: Request,
-        forge: str,
-        owner: str,
-        name: str,
-        number: int,
-        attr: str,
-    ) -> dict:
-        """Per-derivation table of contents; `{format: "legacy"}` when no
-        container exists (old or running builds) so the client falls back."""
-        _, _, path = await self._resolve(request, forge, owner, name, number, attr)
-        reader = await _load_container(path)
-        if reader is None:
-            return {"format": "legacy"}
-        return {"format": "nbl1", "derivations": _toc_entries(reader)}
-
     async def log_drv_lines(  # noqa: PLR0913
         self,
         request: Request,
@@ -800,7 +783,7 @@ class _LogRoutes:
             reader = await _load_container(path)
             if reader is not None:
                 # Structured viewer: per-derivation cards render lazily
-                # from /toc + /drv/{idx}; no flat body needed.
+                # from /drv/{idx}; no flat body needed.
                 toc = _toc_entries(reader)
             elif path is not None and path.exists():
                 data = await asyncio.to_thread(read_log, path)
@@ -851,7 +834,6 @@ def create_log_router(ctx: WebContext, registry: LogRegistry) -> APIRouter:
     router.get(f"{_BASE}/logs/raw/{{attr:path}}")(routes.log_raw_text)
     router.get(f"{_BASE}/logs/{{attr}}.txt")(routes.log_raw_text_legacy)
     router.get(f"{_BASE}/logs/{{attr:path}}/stream")(routes.log_stream)
-    router.get(f"{_BASE}/logs/{{attr:path}}/toc")(routes.log_toc)
     router.get(
         f"{_BASE}/logs/{{attr:path}}/drv/{{idx}}/view", response_class=HTMLResponse
     )(routes.log_drv_viewer)

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -144,15 +144,40 @@
     const iconState = (s) =>
       s === "failed" ? "failed" : s === "running" ? "running" : "succeeded";
 
+    // Cards live in the status groups the template renders (Failures /
+    // Building / Succeeded panel), mirroring the finished page.
+    /** @param {string} s @returns {HTMLElement} */
+    const groupFor = (s) =>
+      must(
+        s === "failed"
+          ? "failed-cards"
+          : s === "running"
+          ? "building-cards"
+          : "succeeded-list",
+      );
+
+    function updateGroups() {
+      for (const id of ["failed", "building", "succeeded"]) {
+        const group = must(`group-${id}`);
+        const n = pick(group, ".group-cards").childElementCount;
+        group.hidden = n === 0;
+        for (const c of group.querySelectorAll(".count")) {
+          c.textContent = `${n}`;
+        }
+      }
+    }
+
     /** Insert the server-rendered card shell (same drv_card macro as the
      * finished page).
      * @param {Drv} d @returns {HTMLDetailsElement} */
     function ensureCard(d) {
       const existing = cardOf.get(d.idx);
       if (existing) return existing;
-      list.insertAdjacentHTML("beforeend", d.card ?? "");
-      const el = /** @type {HTMLDetailsElement} */ (list.lastElementChild);
+      const target = groupFor(d.status);
+      target.insertAdjacentHTML("beforeend", d.card ?? "");
+      const el = /** @type {HTMLDetailsElement} */ (target.lastElementChild);
       cardOf.set(d.idx, el);
+      updateGroups();
       return el;
     }
 
@@ -161,9 +186,14 @@
       const el = ensureCard(d);
       pick(el, ".status-icon").className = "status-icon " + iconState(d.status);
       el.classList.toggle("ok", d.status !== "failed");
-      pick(el, ".meta").textContent = d.status === "running"
+      pick(el, ".meta-status").textContent = d.status === "running"
         ? "building…"
         : d.status;
+      const target = groupFor(d.status);
+      if (el.parentElement !== target) {
+        target.appendChild(el);
+        updateGroups();
+      }
       return el;
     }
 
@@ -213,9 +243,10 @@
 
     /** @param {Drv[]} state */
     function reset(state) {
-      list.innerHTML = "";
+      for (const el of list.querySelectorAll(".log-card")) el.remove();
       byIdx.clear();
       cardOf.clear();
+      updateGroups();
       for (const e of state) {
         const d = {
           idx: e.idx,

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -1004,6 +1004,14 @@ details.webhook-setup summary {
 		max-height: 14rem;
 	}
 }
+/* Standalone derivation page (drv.html): the whole page is the log,
+   so drop the embedded-card height cap and let the window scroll. */
+.drv-page .log-lines {
+	max-height: none;
+	overflow: visible;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+}
 /* Whole log stays in the DOM (Ctrl-F, anchors, selection, a11y);
    content-visibility skips off-screen layout/paint. Fixed 20px row +
    matching contain-intrinsic-size keeps the scrollbar honest and lets

--- a/nixbot/nixbot/web/templates/_macros.html
+++ b/nixbot/nixbot/web/templates/_macros.html
@@ -71,7 +71,6 @@
       {%- set meta = "failed" if failed else (["built", dur] | select | join(" · ")) -%}
       {%- set fetch = (not live) and d.n > 0 -%}
       <details class="log-card{{ '' if failed else ' ok' }}"
-               data-pos="{{ d.idx }}"
                data-idx="{{ d.idx }}"
                data-n="{{ d.n }}"
                {% if open %}open{% endif %}

--- a/nixbot/nixbot/web/templates/_macros.html
+++ b/nixbot/nixbot/web/templates/_macros.html
@@ -80,31 +80,37 @@
           <span class="status-icon {{ state }}" aria-hidden="true"></span>
           <span class="card-text">
             <span class="card-name">{{ d.name }}</span>
-            <span class="meta">{{ meta }}
-              {% if d.n > 0 %}
-                · <a href="{{ base }}/drv/{{ d.idx }}/raw"
+            {# .meta-status is what the live JS rewrites; the links stay. #}
+            <span class="meta"><span class="meta-status">{{ meta }}</span>
+            {% if live or d.n > 0 %}
+              · <a href="{{ base }}/drv/{{ d.idx }}/view"
+    class="raw"
+    onclick="event.stopPropagation()">open&nbsp;↗</a>
+            {% endif %}
+            {% if not live and d.n > 0 %}
+              · <a href="{{ base }}/drv/{{ d.idx }}/raw"
     class="raw"
     onclick="event.stopPropagation()">raw&nbsp;↗</a>
-              {% endif %}
-            </span>
+            {% endif %}
           </span>
-        </summary>
-        <div class="card-body">
-          {% if d.n == 0 and d.status != "running" %}
-            <p class="log-empty">no output</p>
-          {% else %}
-            <div class="log-lines" aria-busy="true"></div>
-          {% endif %}
-        </div>
-      </details>
-    {%- endmacro %}
-    {% macro error_row(error, colspan=3) -%}
-      <tr>
-        <td colspan="{{ colspan }}">
-          <details class="error">
-            <summary>{{ error | plain | excerpt(160) }}</summary>
-            <pre class="error">{{ error | ansi }}</pre>
-          </details>
-        </td>
-      </tr>
-    {%- endmacro %}
+        </span>
+      </summary>
+      <div class="card-body">
+        {% if d.n == 0 and d.status != "running" %}
+          <p class="log-empty">no output</p>
+        {% else %}
+          <div class="log-lines" aria-busy="true"></div>
+        {% endif %}
+      </div>
+    </details>
+  {%- endmacro %}
+  {% macro error_row(error, colspan=3) -%}
+    <tr>
+      <td colspan="{{ colspan }}">
+        <details class="error">
+          <summary>{{ error | plain | excerpt(160) }}</summary>
+          <pre class="error">{{ error | ansi }}</pre>
+        </details>
+      </td>
+    </tr>
+  {%- endmacro %}

--- a/nixbot/nixbot/web/templates/drv.html
+++ b/nixbot/nixbot/web/templates/drv.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% from "_macros.html" import status_icon %}
+{% block title %}
+  {{ drv.name }} log
+{% endblock title %}
+{% block body %}
+  <main id="main">
+    <section class="content">
+      <div class="build-header">
+        <h2>
+          {{ status_icon(drv.status if drv.status in ("failed", "running") else "succeeded") }}
+          <code>{{ drv.name }}</code>
+          <small>
+            <a href="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}"><code>{{ attr }}</code></a>
+            · <a href="{{ build_path(project, build.number) }}">build #{{ build.number }}</a>
+            · <a href="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}/drv/{{ idx }}/raw">raw</a>
+          </small>
+        </h2>
+      </div>
+      {% if drv.n == 0 and not live %}
+        <p class="muted">no output</p>
+      {% else %}
+        <div class="drv-page">
+          <div class="log-lines" id="drv-lines">{{ content | safe }}</div>
+        </div>
+      {% endif %}
+    </section>
+  </main>
+  {% if live %}
+    {# Follow the running derivation over the attribute's structured
+       stream, filtered to this idx; a terminal status reloads into the
+       finished (container-backed) page. #}
+    {% set stream_url = build_path(project, build.number) ~ "/logs/" ~ (attr | urlencode) ~ "/stream?format=structured" %}
+    <script>
+      const IDX = {{ idx | tojson }};
+      const vp = document.getElementById("drv-lines");
+      const src = new EventSource({{ stream_url | tojson }});
+      const append = (html) => {
+        if (!html) return;
+        const follow = innerHeight + scrollY >= document.body.scrollHeight - 40;
+        vp.insertAdjacentHTML("beforeend", html);
+        if (follow) scrollTo(0, document.body.scrollHeight);
+      };
+      src.addEventListener("state", (ev) => {
+        const e = JSON.parse(ev.data).find((d) => d.idx === IDX);
+        vp.innerHTML = "";
+        append(e?.html ?? "");
+      });
+      src.addEventListener("delta", (ev) => {
+        const d = JSON.parse(ev.data);
+        if (d.idx !== IDX) return;
+        if (d.t === "line" || d.t === "phase") append(d.html);
+        else if (d.t === "status" && d.status !== "running") location.reload();
+      });
+      src.addEventListener("done", () => {
+        src.close();
+        location.reload();
+      });
+    </script>
+  {% endif %}
+{% endblock body %}

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -59,6 +59,37 @@
         {% endif %}
         <div id="drv-list"
              {% if live_structured %}data-stream="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}/stream?format=structured"{% endif %}>
+          {% if live_structured %}
+            {# Status groups matching the finished page; the JS moves
+               cards between them on status deltas. #}
+            <div class="live-group" id="group-failed" hidden>
+              <h2 class="section">
+                Failures (<span class="count">0</span>)
+              </h2>
+              <div class="group-cards" id="failed-cards"></div>
+            </div>
+            <div class="live-group" id="group-building" hidden>
+              <h2 class="section">
+                Building (<span class="count">0</span>)
+              </h2>
+              <div class="group-cards" id="building-cards"></div>
+            </div>
+            <div class="live-group" id="group-succeeded" hidden>
+              <h2 class="section">
+                Succeeded (<span class="count">0</span>)
+              </h2>
+              <details class="succeeded-panel" id="succeeded-panel">
+                <summary>
+                  <span class="status-icon succeeded" aria-hidden="true"></span>
+                  <span class="card-text">
+                    <span class="card-name"><span class="count">0</span> built</span>
+                    <span class="meta browse-hint"></span>
+                  </span>
+                </summary>
+                <div class="group-cards" id="succeeded-list"></div>
+              </details>
+            </div>
+          {% endif %}
           {% if toc %}
             {% set base = build_path(project, build.number) ~ "/logs/" ~ (attr | urlencode) %}
             {% set failed = toc | selectattr("status", "equalto", "failed") | list %}


### PR DESCRIPTION
The embedded log cards cap their height, so long logs are painful to browse and there was no URL to share a single derivation's output. During a build the flat card list also diverged from the finished view, which folds succeeded derivations away.

- Add a per-derivation page (`…/logs/{attr}/drv/{idx}/view`, linked as "open ↗" from each card): full-height log with line permalinks. Works while the attribute is still running (rendered from the live capture, follows the structured stream) and after (container-backed); links stay valid across the transition.
- Group the live viewer like the finished page: Failures / Building / Succeeded (folded), cards move between groups on status deltas.
- Drop the unused `/logs/{attr}/toc` endpoint and the duplicate `data-pos` attribute.