### PR TITLE
web: serve eval errors through the log viewer and raw routes

### DIFF
--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -17,6 +17,7 @@ __all__: collections.abc.Sequence[str] = (
     "WebQueueRow",
     "WebRecentBuildsRow",
     "WebRepoOverviewRow",
+    "attribute_error",
     "attribute_status",
     "metrics_attribute_counts",
     "metrics_build_counts",
@@ -202,6 +203,10 @@ class WebRepoOverviewRow:
     median_secs: float
     pass_rate: int
 
+
+ATTRIBUTE_ERROR: typing.Final[str] = """-- name: AttributeError :one
+SELECT error FROM build_attributes WHERE build_id = $1 AND attr = $2
+"""
 
 ATTRIBUTE_STATUS: typing.Final[str] = """-- name: AttributeStatus :one
 SELECT status FROM build_attributes WHERE build_id = $1 AND attr = $2
@@ -436,6 +441,13 @@ class QueryResults(typing.Generic[T]):
             self._iterator = None
             raise
         return self._decode_hook(record)
+
+
+async def attribute_error(conn: ConnectionLike, *, build_id: int, attr: str) -> str | None:
+    row = await conn.fetchrow(ATTRIBUTE_ERROR, build_id, attr)
+    if row is None:
+        return None
+    return row[0]
 
 
 async def attribute_status(conn: ConnectionLike, *, build_id: int, attr: str) -> str | None:

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -155,6 +155,9 @@ ORDER BY b.status = 'pending', b.id;
 -- name: AttributeStatus :one
 SELECT status FROM build_attributes WHERE build_id = $1 AND attr = $2;
 
+-- name: AttributeError :one
+SELECT error FROM build_attributes WHERE build_id = $1 AND attr = $2;
+
 -- name: MetricsBuildCounts :many
 SELECT status, count(*) AS count FROM builds GROUP BY status;
 

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -65,9 +65,10 @@ FAILED_STATUS_STATES = frozenset(
     {"failed", "failed_eval", "dependency_failed", "cached_failure", "cancelled"}
 )
 
-# Statuses for which no per-attribute log is ever written: eval failed
-# before a build started, or the build was skipped because the output is
-# already present locally. Linking to /logs/{attr} for these would 404.
+# Statuses for which no per-attribute build log is ever written: eval
+# failed before a build started, or the build was skipped because the
+# output is already present locally. The log viewer falls back to the
+# stored eval error for failed_eval.
 NO_LOG_STATUSES = frozenset({"failed_eval", "skipped_local"})
 
 
@@ -848,9 +849,11 @@ def _build_plan(
         live = f"{build_url}/logs/{quote(attr)}"
         raw = f"{build_url}/logs/raw/{quote(attr)}"
         status = statuses.get(attr) if statuses is not None else None
-        has_log = status not in NO_LOG_STATUSES
-        attr_cell = f"[`{attr}`]({live})" if has_log else f"`{attr}`"
-        raw_cell = f"[raw]({raw})" if has_log else ""
+        # failed_eval attributes have no build log, but the viewer/raw
+        # routes serve their eval error, so they keep their links.
+        linkable = status != "skipped_local"
+        attr_cell = f"[`{attr}`]({live})" if linkable else f"`{attr}`"
+        raw_cell = f"[raw]({raw})" if linkable else ""
         if statuses is None:
             line = f"| {attr_cell} | {raw_cell} |"
         else:

--- a/nixbot/nixbot/tests/e2e/support.py
+++ b/nixbot/nixbot/tests/e2e/support.py
@@ -50,6 +50,34 @@ def _seed_container(*, failed: bool) -> bytes:
     return w.finalize()
 
 
+# A realistic multi-line nix eval trace (with ANSI colors) for the
+# failed_eval attribute; exercises the viewer/raw eval-error fallback.
+_EVAL_ERROR = """\
+\x1b[31;1merror:\x1b[0m attribute 'x86_64-linux.evalfail' failed to evaluate
+
+       … while calling the 'derivationStrict' builtin
+         at <nix/derivation-internal.nix>:34:12:
+           33|
+           34|   strict = derivationStrict drvAttrs;
+             |            ^
+
+       … while evaluating derivation 'widget-1.0'
+         whose name attribute is located at pkgs/stdenv/generic/make-derivation.nix:336:7
+
+       … while evaluating attribute 'buildInputs' of derivation 'widget-1.0'
+         at pkgs/stdenv/generic/make-derivation.nix:380:7:
+           379|       depsHostHost = elemAt (elemAt dependencies 1) 0;
+           380|       buildInputs = elemAt (elemAt dependencies 1) 1;
+             |       ^
+
+       \x1b[31;1merror:\x1b[0m undefined variable '\x1b[35;1mopenssl_1_1\x1b[0m'
+       at /build/source/default.nix:12:20:
+           11|   buildInputs = [
+           12|     openssl_1_1
+             |     ^
+           13|   ];"""
+
+
 async def seed(dsn: str, state_dir: Path | None = None) -> None:
     """One project with a succeeded, a failed, and a running build."""
     pool = await asyncpg.create_pool(dsn)
@@ -87,6 +115,15 @@ async def seed(dsn: str, state_dir: Path | None = None) -> None:
                 if status == "failed"
                 else None,
             )
+            if status == "failed":
+                await pool.execute(
+                    """
+                    INSERT INTO build_attributes (build_id, attr, system, status, error)
+                    VALUES ($1, 'x86_64-linux.evalfail', 'x86_64-linux', 'failed_eval', $2)
+                    """,
+                    build_id,
+                    _EVAL_ERROR,
+                )
             # Finished builds get a log for the prev/next navigation.
             if state_dir is not None and status != "building":
                 log_file = attribute_log_path(state_dir, build_id, "x86_64-linux.bad")

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -357,10 +357,10 @@ async def test_build_finished_table_groups_by_status_then_alpha() -> None:
     assert "`s`" not in text
 
 
-async def test_build_finished_table_omits_links_for_logless_statuses() -> None:
-    """failed_eval attributes never produce a log, so their viewer/raw
-    links would 404; render them without links. skipped_local rows are
-    dropped entirely."""
+async def test_build_finished_table_links_eval_failures_drops_skipped() -> None:
+    """failed_eval attributes keep their viewer/raw links (the web UI
+    serves their eval trace there). skipped_local rows are dropped
+    entirely."""
     reporter, poster, _ = make_reporter()
     await reporter.build_finished(
         EVENT,
@@ -384,12 +384,10 @@ async def test_build_finished_table_omits_links_for_logless_statuses() -> None:
         i for i, p in enumerate(poster.posts) if p.context == "nixbot/nix-build"
     )
     text = poster.extras[summary_idx]["text"]
-    assert "/builds/42/logs/e" not in text
-    assert "/builds/42/logs/raw/e" not in text
+    assert "/builds/42/logs/e" in text
+    assert "/builds/42/logs/raw/e" in text
     assert "/builds/42/logs/s" not in text
     assert "/builds/42/logs/raw/s" not in text
-    # failed_eval attribute still listed, just without links; readable label.
-    assert "`e`" in text
     assert "| ❌ failed eval |" in text
     # skipped_local attribute is not listed at all.
     assert "`s`" not in text

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -986,6 +986,29 @@ def test_log_viewer_unavailable_for_logless_status(client: WebHarness) -> None:
         client.loop.run_until_complete(restore())
 
 
+def test_eval_error_served_like_build_log(client: WebHarness) -> None:
+    """failed_eval attributes have no build log; the viewer and raw
+    routes serve the stored eval trace with the same UI as build logs."""
+    build_page = client.get("/repos/github/acme/widget/builds/2")
+    assert "/builds/2/logs/x86_64-linux.evalfail" in build_page.text
+
+    viewer = client.get("/repos/github/acme/widget/builds/2/logs/x86_64-linux.evalfail")
+    assert viewer.status_code == 200
+    assert "undefined variable" in viewer.text
+    # Line anchors and ANSI colors, same as build logs.
+    assert 'id="L1"' in viewer.text
+    assert "ansi-red" in viewer.text
+    assert "\x1b" not in viewer.text
+    assert "/logs/raw/x86_64-linux.evalfail" in viewer.text
+
+    raw = client.get(
+        "/repos/github/acme/widget/builds/2/logs/raw/x86_64-linux.evalfail"
+    )
+    assert raw.status_code == 200
+    assert "undefined variable 'openssl_1_1'" in raw.text
+    assert "\x1b" not in raw.text
+
+
 # --- JSON API ----------------------------------------------------------
 
 

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -427,6 +427,12 @@ class _LogRoutes:
         _, build, path = await self._resolve(request, forge, owner, name, number, attr)
         text = await _log_text(self.registry, build, attr, path)
         if text is None:
+            # No build log (e.g. failed_eval): fall back to the stored
+            # eval error so raw links work for every failure status.
+            text = await gen.attribute_error(
+                self.ctx.pool, build_id=build["id"], attr=attr
+            )
+        if text is None:
             raise HTTPException(status_code=404)
         if tail:
             return PlainTextResponse(
@@ -795,7 +801,15 @@ class _LogRoutes:
                 # log exists; show a waiting page instead of a 404.
                 waiting = True
             elif attr_status in NO_LOG_STATUSES:
-                unavailable = True
+                # No build log, but eval failures carry a trace: show it
+                # in the same viewer (line anchors, raw link) as build logs.
+                error = await gen.attribute_error(
+                    self.ctx.pool, build_id=build["id"], attr=attr
+                )
+                if error:
+                    content = await asyncio.to_thread(render_log_lines, error)
+                else:
+                    unavailable = True
             else:
                 raise HTTPException(status_code=404)
         prev_number, next_number = await self.ctx.queries.attribute_neighbors(

--- a/nixbot/nixbot/web/templates/_attr_rows.html
+++ b/nixbot/nixbot/web/templates/_attr_rows.html
@@ -3,7 +3,7 @@
   <tr data-attr="{{ a.attr | lower }}">
     <td class="attr-status">{{ status_icon(a.status) }}</td>
     <td class="attr-name">
-      {% if a.log_size or a.status in RUNNING_STATUSES %}
+      {% if a.log_size or a.status in RUNNING_STATUSES or (a.status == "failed_eval" and a.error) %}
         <a href="{{ build_path(project, build.number) }}/logs/{{ a.attr | urlencode }}"><code>{{ a.attr }}</code></a>
       {% else %}
         <code>{{ a.attr }}</code>


### PR DESCRIPTION

Per-attribute eval failures were only shown as a collapsed inline
excerpt on the build page: no permalinks, nothing to copy or open in a
new tab. Route failed_eval attributes through the same UI as build
logs: the viewer renders the stored eval trace with line anchors and
ANSI colors, /logs/raw/{attr} serves it as plain text, the build page
links the attribute name, and check-run tables keep viewer/raw links
for failed_eval attributes.

Fixes #77
