### PR TITLE
discovery: prune obsolete disabled repos

### DIFF
--- a/nixbot/nixbot/db_gen/projects.py
+++ b/nixbot/nixbot/db_gen/projects.py
@@ -17,6 +17,7 @@ __all__: collections.abc.Sequence[str] = (
     "project_by_id",
     "project_forge_ids",
     "project_visibility_rows",
+    "prune_missing_disabled_projects",
     "reconcile_watermark",
     "rotate_webhook_secret",
     "set_project_enabled",
@@ -100,6 +101,13 @@ SELECT id, forge, forge_repo_id FROM projects
 
 PROJECT_VISIBILITY_ROWS: typing.Final[str] = """-- name: ProjectVisibilityRows :many
 SELECT id, forge, forge_repo_id, owner, name, private FROM projects
+"""
+
+PRUNE_MISSING_DISABLED_PROJECTS: typing.Final[str] = """-- name: PruneMissingDisabledProjects :exec
+DELETE FROM projects
+WHERE forge = $1
+  AND NOT enabled
+  AND forge_repo_id <> ALL ($2::text[])
 """
 
 RECONCILE_WATERMARK: typing.Final[str] = """-- name: ReconcileWatermark :one
@@ -281,6 +289,10 @@ def project_visibility_rows(conn: ConnectionLike) -> QueryResults[ProjectVisibil
     def _decode_hook(row: asyncpg.Record) -> ProjectVisibilityRowsRow:
         return ProjectVisibilityRowsRow(id=row[0], forge=row[1], forge_repo_id=row[2], owner=row[3], name=row[4], private=row[5])
     return QueryResults[ProjectVisibilityRowsRow](conn, PROJECT_VISIBILITY_ROWS, _decode_hook)
+
+
+async def prune_missing_disabled_projects(conn: ConnectionLike, *, forge: str, forge_repo_ids: collections.abc.Sequence[str]) -> None:
+    await conn.execute(PRUNE_MISSING_DISABLED_PROJECTS, forge, forge_repo_ids)
 
 
 async def reconcile_watermark(conn: ConnectionLike, *, id_: int) -> datetime.datetime | None:

--- a/nixbot/nixbot/discovery.py
+++ b/nixbot/nixbot/discovery.py
@@ -77,13 +77,14 @@ async def discover_once(s: CIService) -> None:
                 for repo in s.config.pull_based.repositories.values()
             ]
         )
-    repos = []
+    # None marks a failed forge: its rows are neither synced nor pruned.
+    by_forge: dict[str, list[DiscoveredRepo] | None] = {}
     # The topic is only a legacy import aid (one-shot enablement in
     # sync_discovered); it must not hard-filter discovery, otherwise
     # untagged repos never appear in the admin UI.
     if s.github is not None and s.config.github is not None:
         await _warn_github_webhook_misconfig(s, s.github)
-        repos += await _discover_forge(
+        by_forge["github"] = await _discover_forge(
             "github", s.github.discover_repos(), s.config.github.filters
         )
     if s.gitea is not None and s.config.gitea is not None:
@@ -91,15 +92,16 @@ async def discover_once(s: CIService) -> None:
         fetch_topics = (
             s.config.gitea.filters.topic is not None and await s.repo_store.is_empty()
         )
-        repos += await _discover_forge(
+        by_forge["gitea"] = await _discover_forge(
             "gitea",
             s.gitea.discover_repos(fetch_topics=fetch_topics),
             s.config.gitea.filters,
         )
     if s.gitlab is not None and s.config.gitlab is not None:
-        repos += await _discover_forge(
+        by_forge["gitlab"] = await _discover_forge(
             "gitlab", s.gitlab.discover_repos(), s.config.gitlab.filters
         )
+    repos = [r for found in by_forge.values() if found is not None for r in found]
     topics = {
         forge: forge_config.filters.topic
         for forge, forge_config in (
@@ -110,6 +112,14 @@ async def discover_once(s: CIService) -> None:
         if forge_config is not None and forge_config.filters.topic is not None
     }
     await s.repo_store.sync_discovered(repos, legacy_import_topics=topics)
+    # Drop disabled repos a successful discovery no longer returned so
+    # the admin toggle list stays clean; a failed forge is skipped to
+    # avoid mass-deleting rows on a transient API error.
+    for forge, found in by_forge.items():
+        if found is not None:
+            await s.repo_store.prune_missing_disabled(
+                forge, [r.forge_repo_id for r in found]
+            )
     # Auto-register Gitea/GitLab webhooks for enabled projects.
     await register_hooks(s)
 
@@ -118,13 +128,14 @@ async def _discover_forge(
     forge: str,
     discovery: Awaitable[list[DiscoveredRepo]],
     filters: RepoFilters,
-) -> list[DiscoveredRepo]:
-    """One forge failing must not abort discovery for the others."""
+) -> list[DiscoveredRepo] | None:
+    """One forge failing must not abort discovery for the others;
+    returns None on failure so that forge is not pruned."""
     try:
         return filter_repos(replace(filters, topic=None), await discovery)
     except Exception:
         logger.exception("%s repo discovery failed", forge)
-        return []
+        return None
 
 
 async def register_hooks(s: CIService) -> None:

--- a/nixbot/nixbot/queries/projects.sql
+++ b/nixbot/nixbot/queries/projects.sql
@@ -66,6 +66,15 @@ WHERE (projects.default_branch, projects.url)
 -- name: SetProjectEnabled :exec
 UPDATE projects SET enabled = $2, updated_at = now() WHERE id = $1;
 
+-- name: PruneMissingDisabledProjects :exec
+-- Drop disabled repos of one forge that discovery no longer returned.
+-- Enabled projects are kept so build history survives transient
+-- visibility loss.
+DELETE FROM projects
+WHERE forge = $1
+  AND NOT enabled
+  AND forge_repo_id <> ALL (sqlc.arg(forge_repo_ids)::text[]);
+
 -- name: ToggleProjectEnabled :exec
 UPDATE projects SET enabled = NOT enabled, updated_at = now() WHERE id = $1;
 

--- a/nixbot/nixbot/repos.py
+++ b/nixbot/nixbot/repos.py
@@ -107,6 +107,15 @@ class RepoStore:
             urls=[url for _, _, url, _ in split],
         )
 
+    async def prune_missing_disabled(
+        self, forge: str, forge_repo_ids: Sequence[str]
+    ) -> None:
+        """Delete disabled repos of `forge` that discovery no longer
+        returned; enabled projects keep their build history."""
+        await q.prune_missing_disabled_projects(
+            self.pool, forge=forge, forge_repo_ids=list(forge_repo_ids)
+        )
+
     async def set_enabled(self, project_id: int, *, enabled: bool) -> None:
         await q.set_project_enabled(self.pool, id_=project_id, enabled=enabled)
 

--- a/nixbot/nixbot/tests/test_forge.py
+++ b/nixbot/nixbot/tests/test_forge.py
@@ -467,6 +467,28 @@ async def test_legacy_import_scopes_topics_per_forge(pool: asyncpg.Pool) -> None
     assert "cross" not in enabled
 
 
+async def test_prune_missing_disabled_projects(pool: asyncpg.Pool) -> None:
+    """Disabled repos missing from discovery are pruned; enabled and
+    pull-based rows survive."""
+
+    await pool.execute("TRUNCATE projects CASCADE")
+    store = RepoStore(pool)
+    kept_enabled = repo("acme", "kept-enabled")
+    gone_disabled = repo("acme", "gone-disabled")
+    still_there = repo("acme", "still-there")
+    await store.sync_discovered([kept_enabled, gone_disabled, still_there])
+    await store.sync_pull_based([("pull/one", "https://x/one.git", "main")])
+    enabled_row = await store.by_forge_id("github", kept_enabled.forge_repo_id)
+    assert enabled_row is not None
+    await store.set_enabled(enabled_row.id, enabled=True)
+
+    # Discovery no longer sees kept-enabled and gone-disabled.
+    await store.prune_missing_disabled("github", [still_there.forge_repo_id])
+
+    names = {r["name"] for r in await pool.fetch("SELECT name FROM projects")}
+    assert names == {"kept-enabled", "still-there", "one"}
+
+
 async def test_project_store_sync_skips_unchanged_rows(pool: asyncpg.Pool) -> None:
     """Re-syncing identical repo metadata must not rewrite rows:
     discovery runs every poll cycle over every repo, and unconditional


### PR DESCRIPTION

Repos deleted or hidden on the forge stayed in the projects table
forever and cluttered the admin's disabled-repo list (issue #76).
After each successful per-forge discovery cycle, delete disabled rows
that discovery no longer returned. Enabled projects are kept so build
history survives transient visibility loss, and a failed forge
discovery skips pruning to avoid mass-deleting rows on an API outage.

Fixes #76
