### PR TITLE
web: register webhook and reconcile when a project is enabled

### DIFF
--- a/nixbot/nixbot/discovery.py
+++ b/nixbot/nixbot/discovery.py
@@ -26,9 +26,34 @@ if TYPE_CHECKING:
 
     from .config import RepoFilters
     from .forge import DiscoveredRepo, GitHubAppClient
+    from .repos import RepoRecord
     from .service import CIService
 
 logger = logging.getLogger(__name__)
+
+
+async def _reconcile_project(s: CIService, project: RepoRecord) -> None:
+    try:
+        watermark = await s.repo_store.reconcile_watermark(project.id)
+        if project.forge == "github" and s.github is not None:
+            heads = await github_heads(s.github, project, watermark)
+        elif project.forge == "gitea" and s.gitea is not None:
+            heads = await gitea_heads(s.gitea, project, watermark)
+        elif project.forge == "gitlab" and s.gitlab is not None:
+            heads = await gitlab_heads(s.gitlab, project, watermark)
+        else:
+            return
+        await reconcile_repo(s.pool, project, heads, s)
+        # Only after all submits succeeded: a crash mid-reconcile
+        # must retry the same window on the next startup.
+        new_watermark = max_pr_updated(heads)
+        if new_watermark is not None:
+            await s.repo_store.set_reconcile_watermark(project.id, new_watermark)
+    except Exception:
+        logger.exception(
+            "reconciliation failed",
+            extra={"project": f"{project.owner}/{project.name}"},
+        )
 
 
 async def reconcile_once(s: CIService) -> None:
@@ -37,27 +62,7 @@ async def reconcile_once(s: CIService) -> None:
     per-project watermark bounds the PR listing to PRs updated
     since the last successful reconcile."""
     for project in await s.repo_store.enabled_repos():
-        try:
-            watermark = await s.repo_store.reconcile_watermark(project.id)
-            if project.forge == "github" and s.github is not None:
-                heads = await github_heads(s.github, project, watermark)
-            elif project.forge == "gitea" and s.gitea is not None:
-                heads = await gitea_heads(s.gitea, project, watermark)
-            elif project.forge == "gitlab" and s.gitlab is not None:
-                heads = await gitlab_heads(s.gitlab, project, watermark)
-            else:
-                continue
-            await reconcile_repo(s.pool, project, heads, s)
-            # Only after all submits succeeded: a crash mid-reconcile
-            # must retry the same window on the next startup.
-            new_watermark = max_pr_updated(heads)
-            if new_watermark is not None:
-                await s.repo_store.set_reconcile_watermark(project.id, new_watermark)
-        except Exception:
-            logger.exception(
-                "reconciliation failed",
-                extra={"project": f"{project.owner}/{project.name}"},
-            )
+        await _reconcile_project(s, project)
 
 
 async def _warn_github_webhook_misconfig(s: CIService, github: GitHubAppClient) -> None:
@@ -138,29 +143,55 @@ async def _discover_forge(
         return None
 
 
-async def register_hooks(s: CIService) -> None:
+def _hook_registrars(
+    s: CIService,
+) -> dict[str, tuple[Any, Callable[..., Awaitable[None]]]]:
     registrars: dict[str, tuple[Any, Callable[..., Awaitable[None]]]] = {}
     if s.gitea is not None:
         registrars["gitea"] = (s.gitea, register_repo_hook)
     if s.gitlab is not None:
         registrars["gitlab"] = (s.gitlab, register_gitlab_repo_hook)
+    return registrars
+
+
+async def _register_project_hook(
+    s: CIService,
+    project: RepoRecord,
+    registrars: dict[str, tuple[Any, Callable[..., Awaitable[None]]]],
+) -> None:
+    if project.forge not in registrars:
+        return
+    client, register = registrars[project.forge]
     base = s.config.webhook_base_url or s.config.url
+    try:
+        await register(
+            client,
+            WebhookSecrets(s.pool, project.forge),
+            project.id,
+            project.owner,
+            project.name,
+            base,
+        )
+    except Exception:
+        logger.exception(
+            "%s hook registration failed",
+            project.forge,
+            extra={"project": f"{project.owner}/{project.name}"},
+        )
+
+
+async def register_hooks(s: CIService) -> None:
+    registrars = _hook_registrars(s)
     for project in await s.repo_store.enabled_repos():
-        if project.forge not in registrars:
-            continue
-        client, register = registrars[project.forge]
-        try:
-            await register(
-                client,
-                WebhookSecrets(s.pool, project.forge),
-                project.id,
-                project.owner,
-                project.name,
-                base,
-            )
-        except Exception:
-            logger.exception(
-                "%s hook registration failed",
-                project.forge,
-                extra={"project": f"{project.owner}/{project.name}"},
-            )
+        await _register_project_hook(s, project, registrars)
+
+
+async def activate_project(s: CIService, project_id: int) -> None:
+    """Register the webhook and reconcile a single, freshly enabled
+    project so it starts building without waiting for the next
+    discovery cycle or a service restart (issue #82)."""
+    project = await s.repo_store.by_id(project_id)
+    if project is None or not project.enabled:
+        return
+    await _register_project_hook(s, project, _hook_registrars(s))
+    await _reconcile_project(s, project)

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -320,6 +320,9 @@ class CIService:
 
     # -- ControlBackend ---------------------------------------------------
 
+    async def project_activated(self, project_id: int) -> None:
+        await discovery.activate_project(self, project_id)
+
     async def refresh_projects(self) -> None:
         async with self._discovery_lock:
             if time.monotonic() - self._last_discovery < REFRESH_COOLDOWN:

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -69,6 +69,7 @@ class FakeBackend:
     attr_cancels: list[tuple[int, str]] = field(default_factory=list)
     scheduled_runs: list[tuple[int, str, str, str]] = field(default_factory=list)
     refreshes: int = 0
+    activated: list[int] = field(default_factory=list)
 
     async def restart_build(self, build_id: int) -> None:
         self.restarted.append(build_id)
@@ -87,6 +88,9 @@ class FakeBackend:
 
     async def refresh_projects(self) -> None:
         self.refreshes += 1
+
+    async def project_activated(self, project_id: int) -> None:
+        self.activated.append(project_id)
 
     async def run_scheduled_now(
         self, project_id: int, schedule_name: str, effect: str, when_spec: str
@@ -344,6 +348,25 @@ def test_admin_project_toggle(harness: WebHarness) -> None:
     assert response.headers["location"] == "/?q=wid%20get"
 
 
+def test_toggle_activates_newly_enabled_project(harness: WebHarness) -> None:
+    """Regression for #82: enabling a repo must immediately register
+    its webhook and reconcile it, not wait for the next restart."""
+    BACKEND.activated.clear()
+    # Ensure the project starts disabled.
+    if project_enabled(harness):
+        assert harness.post("/admin/repos/1/toggle", ROOT).status_code == 303
+    BACKEND.activated.clear()
+
+    assert harness.post("/admin/repos/1/toggle", ROOT).status_code == 303
+    assert project_enabled(harness) is True
+    assert BACKEND.activated == [1]
+
+    # Disabling must not trigger activation.
+    assert harness.post("/admin/repos/1/toggle", ROOT).status_code == 303
+    assert project_enabled(harness) is False
+    assert BACKEND.activated == [1]
+
+
 def test_run_schedule(harness: WebHarness) -> None:
     url = "/repos/github/acme/widget/schedules/run"
     data = {"schedule": "nightly", "effect": "deploy"}
@@ -399,8 +422,11 @@ def test_api_enable_disable(harness: WebHarness) -> None:
     assert (
         harness.post("/api/repos/github/acme/widget/disable", ROOT).status_code == 200
     )
+    BACKEND.activated.clear()
     assert harness.post("/api/repos/github/acme/widget/enable", ROOT).status_code == 200
     assert project_enabled(harness) is True
+    # Enabling via the API activates the project (webhook + reconcile).
+    assert BACKEND.activated == [1]
     assert harness.post("/api/repos/github/acme/nope/enable", ROOT).status_code == 404
 
 

--- a/nixbot/nixbot/web/control_routes.py
+++ b/nixbot/nixbot/web/control_routes.py
@@ -43,6 +43,8 @@ class ControlBackend(Protocol):
 
     async def refresh_projects(self) -> None: ...
 
+    async def project_activated(self, project_id: int) -> None: ...
+
     async def run_scheduled_now(
         self, project_id: int, schedule_name: str, effect: str, when_spec: str
     ) -> None: ...
@@ -207,6 +209,8 @@ class _ControlRoutes:
         await proj_gen.set_project_enabled(
             self.ctx.pool, id_=project["id"], enabled=enabled
         )
+        if enabled:
+            await self.backend.project_activated(project["id"])
         return {"owner": owner, "name": name, "enabled": enabled}
 
     async def refresh_repos(
@@ -229,6 +233,9 @@ class _ControlRoutes:
     ) -> RedirectResponse:
         await self._require_repo_admin(request, project_id)
         await proj_gen.toggle_project_enabled(self.ctx.pool, id_=project_id)
+        project = await proj_gen.project_by_id(self.ctx.pool, id_=project_id)
+        if project is not None and project.enabled:
+            await self.backend.project_activated(project_id)
         # Back to the dashboard with the project filter intact.
         return RedirectResponse(f"/?q={quote(q)}" if q else "/", status_code=303)
 


### PR DESCRIPTION

Enabling a repository via the admin toggle or the /enable API only
flipped the database flag; webhook registration and reconciliation
only ran at startup or on the hourly discovery cycle, so a freshly
enabled project stayed silent until the service was restarted.

Activate the project right after enabling: register its webhook and
reconcile its default branch and open PRs.

Fixes #82
