### PR TITLE
auth: refresh expired forge tokens with the OAuth refresh token

### DIFF
--- a/nixbot/nixbot/auth.py
+++ b/nixbot/nixbot/auth.py
@@ -315,10 +315,12 @@ def can_control_build(
 @dataclass(frozen=True)
 class ForgeToken:
     """Access token plus its advertised lifetime (None = the provider
-    did not say, e.g. classic GitHub OAuth tokens that never expire)."""
+    did not say, e.g. classic GitHub OAuth tokens that never expire)
+    and the refresh token, if the provider issued one."""
 
     access_token: str
     expires_in: int | None = None
+    refresh_token: str | None = None
 
 
 class OAuthError(Exception):
@@ -361,14 +363,9 @@ class OAuthProvider:
             )
         )
 
-    async def exchange_code(
-        self, http: httpx.AsyncClient, code: str, redirect_uri: str
-    ) -> tuple[User, ForgeToken]:
-        data = {
-            "code": code,
-            "grant_type": "authorization_code",
-            "redirect_uri": redirect_uri,
-        }
+    async def _token_request(
+        self, http: httpx.AsyncClient, data: dict[str, str]
+    ) -> ForgeToken:
         auth = (
             httpx.BasicAuth(self.client_id, self.client_secret)
             if self.client_auth == "basic"
@@ -401,9 +398,34 @@ class OAuthProvider:
         # so the stored forge token is not trusted past it.
         raw_expires = token_body.get("expires_in")
         expires_in = int(raw_expires) if isinstance(raw_expires, (int, float)) else None
+        refresh = token_body.get("refresh_token")
+        return ForgeToken(
+            access_token,
+            expires_in,
+            refresh_token=refresh if isinstance(refresh, str) and refresh else None,
+        )
+
+    async def refresh(self, http: httpx.AsyncClient, refresh_token: str) -> ForgeToken:
+        """RFC 6749 refresh-token grant."""
+        return await self._token_request(
+            http,
+            {"grant_type": "refresh_token", "refresh_token": refresh_token},
+        )
+
+    async def exchange_code(
+        self, http: httpx.AsyncClient, code: str, redirect_uri: str
+    ) -> tuple[User, ForgeToken]:
+        token = await self._token_request(
+            http,
+            {
+                "code": code,
+                "grant_type": "authorization_code",
+                "redirect_uri": redirect_uri,
+            },
+        )
         userinfo = await http.get(
             self.userinfo_url,
-            headers={"Authorization": f"Bearer {access_token}"},
+            headers={"Authorization": f"Bearer {token.access_token}"},
         )
         if userinfo.is_error:
             msg = f"userinfo endpoint returned HTTP {userinfo.status_code}"
@@ -430,7 +452,7 @@ class OAuthProvider:
             username=username,
             avatar_url=str(avatar) if avatar else None,
             groups=groups,
-        ), ForgeToken(access_token, expires_in)
+        ), token
 
 
 def github_oauth(

--- a/nixbot/nixbot/bootstrap.py
+++ b/nixbot/nixbot/bootstrap.py
@@ -43,7 +43,7 @@ from .forge import (
     GitlabClient,
     NetrcFetchCredentialsProvider,
 )
-from .forge_tokens import ForgeTokenStore
+from .forge_tokens import ForgeTokenRefresher, ForgeTokenStore
 from .gitrepo import (
     CredentialsProvider,
     RepoManager,
@@ -114,6 +114,24 @@ def _polled_repositories(config: Config) -> list[PolledRepository]:
         )
         for repo in config.pull_based.repositories.values()
     ]
+
+
+async def _login_and_oidc_providers(
+    config: Config,
+) -> tuple[dict[str, OAuthProvider], bool]:
+    """Login providers plus whether OIDC discovery must be retried in
+    the background."""
+    providers = await _login_providers(config)
+    oidc_pending = False
+    if config.oidc is not None:
+        try:
+            providers["oidc"] = await _oidc_login_provider(
+                config.oidc, httpx.AsyncClient
+            )
+        except Exception:
+            logger.exception("OIDC discovery failed; retrying in background")
+            oidc_pending = True
+    return providers, oidc_pending
 
 
 async def _login_providers(config: Config) -> dict[str, OAuthProvider]:
@@ -321,17 +339,16 @@ async def build_service(config: Config) -> tuple[CIService, FastAPI]:
         cache=AccessCache(config.repo_acl_cache_ttl),
     )
 
-    providers = await _login_providers(config)
-    oidc_pending = False
-    if config.oidc is not None:
-        try:
-            providers["oidc"] = await _oidc_login_provider(
-                config.oidc, httpx.AsyncClient
-            )
-        except Exception:
-            logger.exception("OIDC discovery failed; retrying in background")
-            oidc_pending = True
+    providers, oidc_pending = await _login_and_oidc_providers(config)
     if providers or oidc_pending:
+        # The providers dict is shared, so late OIDC registration is
+        # picked up automatically.
+        ctx.token_refresher = ForgeTokenRefresher(
+            ctx.forge_tokens,
+            providers,
+            httpx.AsyncClient(),
+            config.session_lifetime,
+        )
         app.include_router(
             create_auth_router(
                 providers,

--- a/nixbot/nixbot/db_gen/tokens.py
+++ b/nixbot/nixbot/db_gen/tokens.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 __all__: collections.abc.Sequence[str] = (
     "ApiTokenByHashRow",
     "ApiTokensForUserRow",
+    "GetForgeRefreshTokenRow",
     "QueryResults",
     "api_token_by_hash",
     "api_tokens_for_user",
     "create_api_token",
     "delete_forge_token",
+    "get_forge_refresh_token",
     "get_forge_token",
     "revoke_api_token",
     "revoke_session",
@@ -51,6 +53,12 @@ class ApiTokensForUserRow:
     expires_at: datetime.datetime | None
 
 
+@dataclasses.dataclass()
+class GetForgeRefreshTokenRow:
+    refresh_token: str | None
+    provider: str | None
+
+
 API_TOKEN_BY_HASH: typing.Final[str] = """-- name: ApiTokenByHash :one
 WITH pruned AS (
     DELETE FROM api_tokens WHERE expires_at < now()
@@ -77,6 +85,14 @@ DELETE_FORGE_TOKEN: typing.Final[str] = """-- name: DeleteForgeToken :exec
 DELETE FROM forge_tokens WHERE session_id = $1
 """
 
+GET_FORGE_REFRESH_TOKEN: typing.Final[str] = """-- name: GetForgeRefreshToken :one
+SELECT refresh_token, provider FROM forge_tokens
+WHERE session_id = $1
+  AND refresh_token IS NOT NULL
+  AND provider IS NOT NULL
+  AND COALESCE(refresh_expires_at, expires_at) > now()
+"""
+
 GET_FORGE_TOKEN: typing.Final[str] = """-- name: GetForgeToken :one
 SELECT token FROM forge_tokens
 WHERE session_id = $1 AND expires_at > now()
@@ -98,12 +114,25 @@ ON CONFLICT (session_id) DO UPDATE
 
 SAVE_FORGE_TOKEN: typing.Final[str] = """-- name: SaveForgeToken :exec
 WITH pruned AS (
-    DELETE FROM forge_tokens WHERE expires_at < now()
+    DELETE FROM forge_tokens
+    WHERE GREATEST(expires_at, COALESCE(refresh_expires_at, expires_at)) < now()
 )
-INSERT INTO forge_tokens (session_id, token, expires_at)
-VALUES ($1, $2, now() + make_interval(secs => $3::float))
+INSERT INTO forge_tokens
+    (session_id, token, expires_at, refresh_token, provider, refresh_expires_at)
+VALUES (
+    $1,
+    $2,
+    now() + make_interval(secs => $3::float),
+    $4,
+    $5,
+    now() + make_interval(secs => $6::float)
+)
 ON CONFLICT (session_id) DO UPDATE
-    SET token = EXCLUDED.token, expires_at = EXCLUDED.expires_at
+    SET token = EXCLUDED.token,
+        expires_at = EXCLUDED.expires_at,
+        refresh_token = EXCLUDED.refresh_token,
+        provider = EXCLUDED.provider,
+        refresh_expires_at = EXCLUDED.refresh_expires_at
 """
 
 SESSION_REVOKED: typing.Final[str] = """-- name: SessionRevoked :one
@@ -176,6 +205,13 @@ async def delete_forge_token(conn: ConnectionLike, *, session_id: str) -> None:
     await conn.execute(DELETE_FORGE_TOKEN, session_id)
 
 
+async def get_forge_refresh_token(conn: ConnectionLike, *, session_id: str) -> GetForgeRefreshTokenRow | None:
+    row = await conn.fetchrow(GET_FORGE_REFRESH_TOKEN, session_id)
+    if row is None:
+        return None
+    return GetForgeRefreshTokenRow(refresh_token=row[0], provider=row[1])
+
+
 async def get_forge_token(conn: ConnectionLike, *, session_id: str) -> str | None:
     row = await conn.fetchrow(GET_FORGE_TOKEN, session_id)
     if row is None:
@@ -194,8 +230,8 @@ async def revoke_session(conn: ConnectionLike, *, session_id: str, lifetime: flo
     await conn.execute(REVOKE_SESSION, session_id, lifetime)
 
 
-async def save_forge_token(conn: ConnectionLike, *, session_id: str, token: str, lifetime: float) -> None:
-    await conn.execute(SAVE_FORGE_TOKEN, session_id, token, lifetime)
+async def save_forge_token(conn: ConnectionLike, *, session_id: str, token: str, lifetime: float, refresh_token: str | None, provider: str | None, refresh_lifetime: float | None) -> None:
+    await conn.execute(SAVE_FORGE_TOKEN, session_id, token, lifetime, refresh_token, provider, refresh_lifetime)
 
 
 async def session_revoked(conn: ConnectionLike, *, session_id: str) -> bool | None:

--- a/nixbot/nixbot/forge_tokens.py
+++ b/nixbot/nixbot/forge_tokens.py
@@ -7,18 +7,46 @@ invalidate the token immediately.
 
 from __future__ import annotations
 
+import asyncio
+import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
+import httpx
+
+from .auth import OAuthError
 from .db_gen import tokens as q
 
 if TYPE_CHECKING:
     import asyncpg
 
+    from .auth import OAuthProvider
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RefreshCredentials:
+    """OAuth refresh token plus which login provider issued it."""
+
+    refresh_token: str
+    provider: str
+
 
 class TokenVault(Protocol):
-    async def save(self, session_id: str, token: str, lifetime: int) -> None: ...
+    async def save(
+        self,
+        session_id: str,
+        token: str,
+        lifetime: int,
+        *,
+        refresh: RefreshCredentials | None = None,
+        refresh_lifetime: int | None = None,
+    ) -> None: ...
 
     async def get(self, session_id: str) -> str | None: ...
+
+    async def get_refresh(self, session_id: str) -> RefreshCredentials | None: ...
 
     async def delete(self, session_id: str) -> None: ...
 
@@ -27,19 +55,108 @@ class ForgeTokenStore:
     def __init__(self, pool: asyncpg.Pool) -> None:
         self.pool = pool
 
-    async def save(self, session_id: str, token: str, lifetime: int) -> None:
+    async def save(
+        self,
+        session_id: str,
+        token: str,
+        lifetime: int,
+        *,
+        refresh: RefreshCredentials | None = None,
+        refresh_lifetime: int | None = None,
+    ) -> None:
         await q.save_forge_token(
             self.pool,
             session_id=session_id,
             token=token,
             lifetime=float(lifetime),
+            refresh_token=refresh.refresh_token if refresh else None,
+            provider=refresh.provider if refresh else None,
+            refresh_lifetime=float(refresh_lifetime)
+            if refresh_lifetime is not None
+            else None,
         )
 
     async def get(self, session_id: str) -> str | None:
         return await q.get_forge_token(self.pool, session_id=session_id)
 
+    async def get_refresh(self, session_id: str) -> RefreshCredentials | None:
+        row = await q.get_forge_refresh_token(self.pool, session_id=session_id)
+        if row is None or row.refresh_token is None or row.provider is None:
+            return None
+        return RefreshCredentials(
+            refresh_token=row.refresh_token, provider=row.provider
+        )
+
     async def delete(self, session_id: str) -> None:
         await q.delete_forge_token(self.pool, session_id=session_id)
+
+
+class ForgeTokenRefresher:
+    """Hands out a usable forge access token for a session, renewing
+    an expired one via the stored OAuth refresh token: Gitea/OIDC
+    access tokens expire after ~1h while the session cookie lives for
+    weeks."""
+
+    def __init__(
+        self,
+        vault: TokenVault,
+        providers: dict[str, OAuthProvider],
+        http: httpx.AsyncClient,
+        session_lifetime: int,
+    ) -> None:
+        self.vault = vault
+        self.providers = providers
+        self.http = http
+        self.session_lifetime = session_lifetime
+        # Serializes refreshes: providers rotate refresh tokens, so two
+        # concurrent requests refreshing the same session would
+        # invalidate each other's new refresh token.
+        self._lock = asyncio.Lock()
+
+    async def access_token(self, session_id: str) -> str | None:
+        token = await self.vault.get(session_id)
+        if token is not None:
+            return token
+        async with self._lock:
+            # Another request may have refreshed while we waited.
+            token = await self.vault.get(session_id)
+            if token is not None:
+                return token
+            return await self._refresh(session_id)
+
+    async def _refresh(self, session_id: str) -> str | None:
+        credentials = await self.vault.get_refresh(session_id)
+        if credentials is None:
+            return None
+        provider = self.providers.get(credentials.provider)
+        if provider is None:
+            return None
+        try:
+            token = await provider.refresh(self.http, credentials.refresh_token)
+        except (OAuthError, httpx.HTTPError):
+            # Revoked/expired refresh token or transient forge failure;
+            # visibility falls back to public.
+            logger.warning(
+                "failed to refresh forge token",
+                extra={"provider": credentials.provider},
+            )
+            return None
+        lifetime = self.session_lifetime
+        if token.expires_in is not None:
+            lifetime = min(lifetime, token.expires_in)
+        await self.vault.save(
+            session_id,
+            token.access_token,
+            lifetime,
+            # Providers may rotate the refresh token; keep the old one
+            # if the response omitted a new one.
+            refresh=RefreshCredentials(
+                token.refresh_token or credentials.refresh_token,
+                credentials.provider,
+            ),
+            refresh_lifetime=self.session_lifetime,
+        )
+        return token.access_token
 
 
 class SessionRevocations(Protocol):

--- a/nixbot/nixbot/migrations/0021_forge_refresh_tokens.sql
+++ b/nixbot/nixbot/migrations/0021_forge_refresh_tokens.sql
@@ -1,0 +1,9 @@
+-- Gitea/OIDC access tokens expire after ~1h while the session cookie
+-- lives ~30 days; store the OAuth refresh token (plus which login
+-- provider issued it) so an expired access token can be renewed.
+ALTER TABLE forge_tokens
+    ADD COLUMN refresh_token TEXT,
+    ADD COLUMN provider TEXT,
+    -- How long the refresh token itself may be used (capped at the
+    -- session lifetime); expires_at keeps meaning "access token expiry".
+    ADD COLUMN refresh_expires_at TIMESTAMPTZ;

--- a/nixbot/nixbot/queries/tokens.sql
+++ b/nixbot/nixbot/queries/tokens.sql
@@ -27,21 +27,45 @@ WHERE t.user_qualified = $1 ORDER BY t.id;
 DELETE FROM api_tokens WHERE id = $1 AND user_qualified = $2 RETURNING id;
 
 -- name: SaveForgeToken :exec
--- Lazy cleanup of expired rows piggybacks on every save.
+-- Lazy cleanup of expired rows piggybacks on every save. A row is
+-- only useless once both the access token AND its refresh token (if
+-- any) have expired.
 WITH pruned AS (
-    DELETE FROM forge_tokens WHERE expires_at < now()
+    DELETE FROM forge_tokens
+    WHERE GREATEST(expires_at, COALESCE(refresh_expires_at, expires_at)) < now()
 )
-INSERT INTO forge_tokens (session_id, token, expires_at)
-VALUES ($1, $2, now() + make_interval(secs => sqlc.arg(lifetime)::float))
+INSERT INTO forge_tokens
+    (session_id, token, expires_at, refresh_token, provider, refresh_expires_at)
+VALUES (
+    $1,
+    $2,
+    now() + make_interval(secs => sqlc.arg(lifetime)::float),
+    sqlc.narg(refresh_token),
+    sqlc.narg(provider),
+    now() + make_interval(secs => sqlc.narg(refresh_lifetime)::float)
+)
 -- The CTE's deletes are invisible to the INSERT in the same
 -- statement; an expired row under the same session id must be
 -- overwritten, not collide.
 ON CONFLICT (session_id) DO UPDATE
-    SET token = EXCLUDED.token, expires_at = EXCLUDED.expires_at;
+    SET token = EXCLUDED.token,
+        expires_at = EXCLUDED.expires_at,
+        refresh_token = EXCLUDED.refresh_token,
+        provider = EXCLUDED.provider,
+        refresh_expires_at = EXCLUDED.refresh_expires_at;
 
 -- name: GetForgeToken :one
 SELECT token FROM forge_tokens
 WHERE session_id = $1 AND expires_at > now();
+
+-- name: GetForgeRefreshToken :one
+-- Refresh credentials for a session whose access token may already
+-- be expired.
+SELECT refresh_token, provider FROM forge_tokens
+WHERE session_id = $1
+  AND refresh_token IS NOT NULL
+  AND provider IS NOT NULL
+  AND COALESCE(refresh_expires_at, expires_at) > now();
 
 -- name: DeleteForgeToken :exec
 DELETE FROM forge_tokens WHERE session_id = $1;

--- a/nixbot/nixbot/tests/test_auth.py
+++ b/nixbot/nixbot/tests/test_auth.py
@@ -29,6 +29,7 @@ from nixbot.auth import (
     relevant_groups,
     rotate_signing_key,
 )
+from nixbot.forge_tokens import ForgeTokenRefresher, RefreshCredentials
 from nixbot.web.auth_routes import (
     SESSION_COOKIE,
     STATE_COOKIE,
@@ -50,16 +51,33 @@ class DictVault:
     def __init__(self) -> None:
         self.tokens: dict[str, str] = {}
         self.lifetimes: dict[str, int] = {}
+        self.refresh: dict[str, RefreshCredentials] = {}
 
-    async def save(self, session_id: str, token: str, lifetime: int) -> None:
+    async def save(
+        self,
+        session_id: str,
+        token: str,
+        lifetime: int,
+        *,
+        refresh: RefreshCredentials | None = None,
+        refresh_lifetime: int | None = None,  # noqa: ARG002
+    ) -> None:
         self.tokens[session_id] = token
         self.lifetimes[session_id] = lifetime
+        if refresh is not None:
+            self.refresh[session_id] = refresh
+        else:
+            self.refresh.pop(session_id, None)
 
     async def get(self, session_id: str) -> str | None:
         return self.tokens.get(session_id)
 
+    async def get_refresh(self, session_id: str) -> RefreshCredentials | None:
+        return self.refresh.get(session_id)
+
     async def delete(self, session_id: str) -> None:
         self.tokens.pop(session_id, None)
+        self.refresh.pop(session_id, None)
 
 
 def test_session_roundtrip() -> None:
@@ -292,6 +310,118 @@ async def test_forge_token_lifetime_capped_by_expires_in() -> None:
         session_id = signer.session_id_from(callback.cookies[SESSION_COOKIE])
         assert session_id is not None
         assert vault.lifetimes[session_id] == 3600
+
+
+async def test_callback_stores_refresh_token() -> None:
+    """Gitea returns a refresh token; it must be persisted with the
+    provider name so the ~1h access token can be renewed later."""
+    provider = gitea_oauth("https://gitea.test", "cid", "cs")
+    vault = DictVault()
+    signer = SessionSigner([b"k"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/login/oauth/access_token":
+            return httpx.Response(
+                200,
+                json={"access_token": "at", "expires_in": 3600, "refresh_token": "rt"},
+            )
+        if request.url.path == "/api/v1/user":
+            return httpx.Response(200, json={"login": "alice"})
+        return httpx.Response(404)
+
+    app = FastAPI()
+    app.include_router(
+        create_auth_router(
+            {"gitea": provider},
+            signer,
+            "https://ci.test",
+            vault,
+            http=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="https://ci.test"
+    ) as client:
+        login = await client.get("/login/gitea")
+        state = parse_qs(urlparse(login.headers["location"]).query)["state"][0]
+        callback = await client.get(
+            f"/auth/gitea/callback?code=c&state={state}",
+            headers=cookie_header({f"nixbot_oauth_state_{state}": state}),
+        )
+        assert callback.status_code == 307
+        session_id = signer.session_id_from(callback.cookies[SESSION_COOKIE])
+        assert session_id is not None
+        assert vault.tokens[session_id] == "at"
+        assert vault.refresh[session_id] == RefreshCredentials("rt", "gitea")
+
+
+class ExpiringVault(DictVault):
+    """Simulates a vault whose access token has expired but whose
+    refresh credentials are still valid (the issue-81 situation)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.expired: set[str] = set()
+
+    async def get(self, session_id: str) -> str | None:
+        if session_id in self.expired:
+            return None
+        return await super().get(session_id)
+
+
+async def test_refresher_renews_expired_access_token() -> None:
+    """Regression for #81: the Gitea access token dies after ~1h while
+    the session cookie lives 30 days; the refresher must renew it via
+    the refresh token instead of degrading to public visibility."""
+    provider = gitea_oauth("https://gitea.test", "cid", "cs")
+    calls: list[dict[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/login/oauth/access_token"
+        calls.append(dict(parse_qs(request.content.decode())))  # type: ignore[arg-type]
+        return httpx.Response(
+            200,
+            json={"access_token": "at2", "expires_in": 3600, "refresh_token": "rt2"},
+        )
+
+    vault = ExpiringVault()
+    await vault.save("sid", "at1", 3600, refresh=RefreshCredentials("rt1", "gitea"))
+    vault.expired.add("sid")
+    refresher = ForgeTokenRefresher(
+        vault,
+        {"gitea": provider},
+        httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        session_lifetime=30 * 24 * 3600,
+    )
+    assert await refresher.access_token("sid") == "at2"
+    # Refresh-token grant, rotated refresh token stored for next time.
+    assert calls[0]["grant_type"] == ["refresh_token"]
+    assert calls[0]["refresh_token"] == ["rt1"]
+    assert vault.refresh["sid"] == RefreshCredentials("rt2", "gitea")
+
+    # No refresh credentials (e.g. classic GitHub tokens): stays None.
+    vault.expired.add("other")
+    assert await refresher.access_token("other") is None
+
+
+async def test_refresher_handles_provider_failure() -> None:
+    """A revoked refresh token must degrade gracefully (None), not
+    raise into every page render."""
+    provider = gitea_oauth("https://gitea.test", "cid", "cs")
+    vault = ExpiringVault()
+    await vault.save("sid", "at", 3600, refresh=RefreshCredentials("rt", "gitea"))
+    vault.expired.add("sid")
+    refresher = ForgeTokenRefresher(
+        vault,
+        {"gitea": provider},
+        httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(400, json={"error": "invalid_grant"})
+            )
+        ),
+        session_lifetime=3600,
+    )
+    assert await refresher.access_token("sid") is None
 
 
 async def test_concurrent_logins_do_not_clobber_oauth_state() -> None:

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -55,7 +55,11 @@ from .templating import STATIC_DIR, CachedStaticFiles, make_env
 if TYPE_CHECKING:
     from ..api_tokens import ApiTokenStore  # noqa: TID252
     from ..auth import AuthzConfig, SessionSigner, User  # noqa: TID252
-    from ..forge_tokens import SessionRevocations, TokenVault  # noqa: TID252
+    from ..forge_tokens import (  # noqa: TID252
+        ForgeTokenRefresher,
+        SessionRevocations,
+        TokenVault,
+    )
     from ..visibility import VisibilityService  # noqa: TID252
 
 if TYPE_CHECKING:
@@ -103,6 +107,8 @@ class WebContext:
         self.webhook_base_url: str | None = None
         self.token_store: ApiTokenStore | None = None
         self.forge_tokens: TokenVault | None = None
+        # Wired by bootstrap; renews expired forge access tokens.
+        self.token_refresher: ForgeTokenRefresher | None = None
         # Logout denylist: stateless cookies stay verifiable until
         # expiry, so revoked session ids are checked server-side.
         self.revoked_sessions: SessionRevocations | None = RevokedSessionStore(pool)
@@ -211,6 +217,8 @@ class WebContext:
         session_id = self.signer.session_id_from(request.cookies.get(SESSION_COOKIE))
         if session_id is None:
             return None
+        if self.token_refresher is not None:
+            return await self.token_refresher.access_token(session_id)
         return await self.forge_tokens.get(session_id)
 
     async def repo_or_404(

--- a/nixbot/nixbot/web/auth_routes.py
+++ b/nixbot/nixbot/web/auth_routes.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import RedirectResponse
 
 from ..auth import OAuthError, relevant_groups, same_origin  # noqa: TID252
+from ..forge_tokens import RefreshCredentials  # noqa: TID252
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -130,7 +131,15 @@ def create_auth_router(  # noqa: C901, PLR0913
         token_lifetime = signer.lifetime
         if token.expires_in is not None:
             token_lifetime = min(token_lifetime, token.expires_in)
-        await forge_tokens.save(session_id, token.access_token, token_lifetime)
+        await forge_tokens.save(
+            session_id,
+            token.access_token,
+            token_lifetime,
+            refresh=RefreshCredentials(token.refresh_token, provider_name)
+            if token.refresh_token
+            else None,
+            refresh_lifetime=signer.lifetime if token.refresh_token else None,
+        )
         response = RedirectResponse("/")
         response.delete_cookie(_state_cookie(state))
         response.set_cookie(


### PR DESCRIPTION

Gitea/OIDC access tokens expire after ~1h while the session cookie
lives ~30 days. Once the stored forge token expired, private-repo
visibility silently degraded to public and the CI page showed "no
repo connected" even though the user still appeared logged in
(avatar comes from the cookie). Only logging out and back in fixed it.

Capture the refresh_token from the token exchange, store it (with the
issuing provider) alongside the access token, and renew an expired
access token transparently via the RFC 6749 refresh-token grant on
the next request that needs it.

Fixes #81
