### PR TITLE
update ignored warning

### DIFF
--- a/nixbot/nixbot/live_warnings.py
+++ b/nixbot/nixbot/live_warnings.py
@@ -23,9 +23,7 @@ MAX_GROUPS = 50
 # Warning text is repo-controlled; keep single messages bounded.
 MAX_MESSAGE_LEN = 500
 
-_IGNORED_WARNINGS = (
-    "because it is a restricted setting and you are not a trusted user",
-)
+_IGNORED_WARNINGS = ("you are not a trusted user",)
 
 
 def normalize_warning(line: str) -> tuple[str, str]:


### PR DESCRIPTION
seems there are two different ignored, not trusted messages in nix

"ignoring untrusted substituter '%s', you are not a trusted user.\n"

"ignoring the client-specified setting '%s', because it is a restricted setting and you are not a trusted user"