### PR TITLE
web: wrap long log lines

### DIFF
--- a/nixbot/nixbot/ansi.py
+++ b/nixbot/nixbot/ansi.py
@@ -7,7 +7,7 @@ import re
 
 # One token per escape sequence. Colons in SGR: ITU T.416 syntax for
 # extended colors (38:5:185), used by systemd among others. OSC is
-# BEL- or ST-terminated; charset selects and other two-character
+# BEL- or ST-terminated. Charset selects and other two-character
 # escapes are matched so their final byte does not leak as text.
 ANSI_TOKEN_RE = re.compile(
     r"\x1b\[(?P<sgr>[0-9;:]*)m"

--- a/nixbot/nixbot/api_tokens.py
+++ b/nixbot/nixbot/api_tokens.py
@@ -1,8 +1,8 @@
 """Personal API tokens.
 
 Tokens are generated in the UI after login, shown exactly once, and
-stored only as SHA-256 hashes. Optional expiry; revocation deletes the
-row and takes effect immediately; expired rows are pruned
+stored only as SHA-256 hashes. Optional expiry. Revocation deletes the
+row and takes effect immediately. Expired rows are pruned
 opportunistically. A valid token authenticates as its owner for both
 read and control API usage.
 """
@@ -83,7 +83,7 @@ class ApiTokenStore:
         ]
 
     async def revoke(self, user: User, token_id: int) -> bool:
-        """Immediate revocation; only the owner may revoke."""
+        """Immediate revocation. Only the owner may revoke."""
         result = await q.revoke_api_token(
             self.pool, id_=token_id, user_qualified=user.qualified
         )

--- a/nixbot/nixbot/auth.py
+++ b/nixbot/nixbot/auth.py
@@ -2,7 +2,7 @@
 
 Login: GitHub OAuth, Gitea OAuth, and generic OIDC. Sessions are
 signed cookies (HMAC-SHA256 over a JSON payload with expiry) with a
-two-key rotation window; the signing key is auto-generated in the
+two-key rotation window. The signing key is auto-generated in the
 state directory and can be overridden via LoadCredential. CSRF: all
 state-changing endpoints require a same-origin check
 (Origin/Sec-Fetch-Site) on top of SameSite=Lax cookies.
@@ -11,7 +11,7 @@ Authorization (port of the authz.py semantics): admin and allowlist
 entries are provider-qualified (`github:alice`, `gitea:bob`,
 `oidc:<issuer>:<sub>` — the OIDC identity claim defaults to the
 stable `sub` and is configurable via `mapping.username`) — the same
-username on a different provider never matches. Admins control everything; a PR author (matched by
+username on a different provider never matches. Admins control everything. A PR author (matched by
 forge identity on the same forge) may restart/cancel builds of their
 own PR; `allowUnauthenticatedControl` opens control for VPN/local-dev
 instances.
@@ -47,7 +47,7 @@ class User:
     provider: str  # "github" | "gitea" | "oidc:<issuer>"
     username: str
     avatar_url: str | None = None
-    # OIDC groups claim; drives "provider:group:<name>" viewer rules.
+    # OIDC groups claim. Drives "provider:group:<name>" viewer rules.
     groups: tuple[str, ...] = ()
 
     @property
@@ -115,7 +115,7 @@ class SessionSigner:
         if user.groups:
             payload["groups"] = list(user.groups)
         if session_id is not None:
-            # References the server-side forge-token row; the cookie is
+            # References the server-side forge-token row. The cookie is
             # signed, not encrypted, so the token itself never goes here.
             payload["sid"] = session_id
         return self.sign(payload)
@@ -208,7 +208,7 @@ def same_origin(request: Request, own_url: str) -> bool:
         return fetch_site in ("same-origin", "none")
     origin = request.headers.get("origin")
     if origin is None:
-        # Non-browser client (API token usage); cookies don't apply.
+        # Non-browser client (API token usage). Cookies don't apply.
         return True
     return origin.rstrip("/") == own_url.rstrip("/")
 
@@ -220,7 +220,7 @@ def same_origin(request: Request, own_url: str) -> bool:
 class AuthzConfig:
     admins: list[str]  # provider-qualified
     allow_unauthenticated_control: bool = False
-    # Per-repo private visibility rules; see can_view_private.
+    # Per-repo private visibility rules. See can_view_private.
     private_repo_viewers: dict[str, list[str]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -247,7 +247,7 @@ def matches_rule(user: User, rule: str) -> bool:
         return rest in ("*", user.username)
     group_provider, group_sep, group_marker = provider.rpartition(":")
     if group_sep and group_marker == "group":
-        # provider:group:<name>; rest is the group name
+        # provider:group:<name>. Rest is the group name
         return group_provider == user.provider and rest in user.groups
     return False
 
@@ -256,7 +256,7 @@ def relevant_groups(
     groups: tuple[str, ...], viewers: dict[str, list[str]]
 ) -> tuple[str, ...]:
     """Groups any viewer rule can match. The session cookie carries
-    these; the full OIDC claim can be dozens of LDAP groups and a
+    these. The full OIDC claim can be dozens of LDAP groups and a
     signed cookie past ~4KB hits header limits."""
     referenced = {
         rule.rpartition(":")[2]
@@ -274,7 +274,7 @@ def can_view_private(
     owner: str,
     name: str,
 ) -> bool:
-    """Per-repo private visibility; the most specific key wins
+    """Per-repo private visibility. The most specific key wins
     ("forge:owner/repo" > "forge:owner/*" > "*"), like the per-repo
     effects secrets."""
     if user is None:
@@ -381,7 +381,7 @@ class OAuthProvider:
             headers={"Accept": "application/json"},
         )
         # GitHub returns token-exchange errors (expired/reused code) as
-        # HTTP 200 with an {"error": ...} body; other providers use 4xx.
+        # HTTP 200 with an {"error": ...} body. Other providers use 4xx.
         if response.is_error:
             msg = f"token endpoint returned HTTP {response.status_code}"
             raise OAuthError(msg)
@@ -394,7 +394,7 @@ class OAuthProvider:
         if not access_token:
             msg = f"token exchange failed: {token_body.get('error', 'no access_token')}"
             raise OAuthError(msg)
-        # Gitea/OIDC tokens expire (typically 1h); record the lifetime
+        # Gitea/OIDC tokens expire (typically 1h). Record the lifetime
         # so the stored forge token is not trusted past it.
         raw_expires = token_body.get("expires_in")
         expires_in = int(raw_expires) if isinstance(raw_expires, (int, float)) else None
@@ -477,7 +477,7 @@ def github_oauth(
         client_secret=client_secret,
         # Private-repo visibility (GET /user/repos listing private
         # repositories) requires "repo", which GitHub only offers with
-        # write access; instances without private repos should not hold
+        # write access. Instances without private repos should not hold
         # write-capable tokens, so it is opt-in.
         scope="read:user repo" if private_repo_scope else "read:user",
         username_field="login",
@@ -539,7 +539,7 @@ async def oidc_provider(  # noqa: PLR0913
     response.raise_for_status()
     doc = response.json()
     issuer = doc["issuer"].removeprefix("https://").rstrip("/")
-    # Absent means client_secret_basic per OIDC discovery spec; only
+    # Absent means client_secret_basic per OIDC discovery spec. Only
     # fall back to body credentials if basic is explicitly not offered.
     methods = doc.get("token_endpoint_auth_methods_supported")
     client_auth: Literal["body", "basic"] = "basic"

--- a/nixbot/nixbot/bootstrap.py
+++ b/nixbot/nixbot/bootstrap.py
@@ -421,7 +421,7 @@ async def _run_startup(service: CIService) -> None:
 
 
 # timeout_graceful_shutdown: open SSE event streams never close on
-# their own; without the cap uvicorn waits for them forever and
+# their own. Without the cap uvicorn waits for them forever and
 # systemd SIGKILLs the service on every stop.
 # lifespan="off": _serve runs the app lifespan once for all listeners.
 _UVICORN_OPTS: dict[str, Any] = {
@@ -475,7 +475,7 @@ async def _serve(app: FastAPI, configs: list[uvicorn.Config]) -> None:
     (per-server lifespans would start the app once per listener:
     duplicate LISTEN connection, double SSE event delivery).
 
-    Returns when the first server exits (signal); the rest are
+    Returns when the first server exits (signal). The rest are
     cancelled. Each uvicorn server installs its own signal handlers;
     with two servers only the last one wins, so the other would never
     stop on its own.
@@ -500,7 +500,7 @@ async def run_service(config: Config) -> None:
     # that a running dispatcher legitimately claimed in the meantime.
     await WorkQueue(service.pool).settle_interrupted()
 
-    # Startup can take minutes; it must not keep uvicorn from binding.
+    # Startup can take minutes. It must not keep uvicorn from binding.
     tasks = [
         asyncio.create_task(_run_startup(service)),
         asyncio.create_task(service.maintenance_loop()),

--- a/nixbot/nixbot/build_reuse.py
+++ b/nixbot/nixbot/build_reuse.py
@@ -54,7 +54,7 @@ async def replay_terminal_status(
     o: Orchestrator, event: ChangeEvent, build: BuildRecord
 ) -> None:
     """Re-post the final eval and build statuses of an already
-    terminal build for a new context; without this the context's
+    terminal build for a new context. Without this the context's
     nix-eval/nix-build checks stay pending forever. A succeeded
     build with zero attributes is a genuine empty-but-green eval,
     not an eval failure."""
@@ -106,7 +106,7 @@ async def finish_linked(
     eval_success: bool | None = None,
 ) -> None:
     """Final status fan-out for second contexts attached to this
-    build; eval_success is None when no eval result exists."""
+    build. eval_success is None when no eval result exists."""
     for linked in o.linked_events.pop(build.id, []):
         if eval_success is not None:
             await o.reporter.eval_finished(
@@ -172,7 +172,7 @@ async def reuse_terminal_build(  # noqa: PLR0913
         try:
             await _post_process_existing(o, event, build)
             if build.effects_started:
-                # Effects already ran and will not re-run; replay their
+                # Effects already ran and will not re-run. Replay their
                 # statuses so the reusing commit is not left blank.
                 await replay_effect_statuses(o, event, build)
             else:

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -55,7 +55,7 @@ async def record_attributes(
     pool: asyncpg.Pool, build_id: int, jobs: Sequence[NixEvalJob]
 ) -> None:
     """Persist eval results as pending rows (with statically-known
-    outputs) so crash recovery can resume without a re-eval; eval
+    outputs) so crash recovery can resume without a re-eval. Eval
     failures are settled by the scheduler."""
     successes = [job for job in jobs if isinstance(job, NixEvalJobSuccess)]
     if not successes:
@@ -106,7 +106,7 @@ async def run_build(
     worktree_path: Path,
     credentials: FetchCredentials | None = None,
 ) -> None:
-    """Evaluate and build; every attribute completion is one
+    """Evaluate and build. Every attribute completion is one
     transactional DB write, then the result is re-aggregated."""
     try:
         await _run_build_inner(o, event, build, worktree_path, credentials)
@@ -130,7 +130,7 @@ async def run_build(
         if current is None or current.status not in BuildStatus.TERMINAL:
             await _settle_aborted(o, event, build, BuildStatus.FAILED, error=str(e))
     finally:
-        # Eval gc-roots only need to outlive the build; without
+        # Eval gc-roots only need to outlive the build. Without
         # cleanup the nix store grows unboundedly.
         shutil.rmtree(o.gcroots_dir(build), ignore_errors=True)
 
@@ -142,7 +142,7 @@ def _eval_settings(
     credentials: FetchCredentials | None,
 ) -> EvalSettings:
     # Auto-sized workers come with a matching per-worker memory
-    # limit; the configured limit acts as a ceiling. An explicit
+    # limit. The configured limit acts as a ceiling. An explicit
     # worker count keeps the configured limit as-is.
     if o.config.eval_worker_count:
         worker_count = o.config.eval_worker_count
@@ -154,7 +154,7 @@ def _eval_settings(
             o.config.eval_max_memory_size, worker_config.max_memory_mib
         )
     # PR-controlled eval can fetch arbitrary flake inputs with the
-    # netrc; an instance-wide token (Gitea/GitLab) would let a
+    # netrc. An instance-wide token (Gitea/GitLab) would let a
     # malicious PR read any private repo on the forge. Only
     # repo-scoped tokens (GitHub) reach PR evals.
     netrc_file = None
@@ -167,7 +167,7 @@ def _eval_settings(
         max_memory_size_mib=eval_max_memory,
         show_trace=o.config.show_trace_on_failure,
         netrc_file=netrc_file,
-        # The worktree's .git points into the central clone; the
+        # The worktree's .git points into the central clone. The
         # sandboxed evaluator needs to read it.
         extra_ro_paths=[o.repos.clone_path(event.repo.key)],
     )
@@ -302,7 +302,7 @@ async def _run_build_inner(
         await db.set_build_status(o.pool, build.id, BuildStatus.BUILDING)
         # Idempotent backstop for the streaming inserts above;
         # pending rows are what crash recovery resumes from. The
-        # scheduler drops unsupported systems; their pending rows
+        # scheduler drops unsupported systems. Their pending rows
         # would never turn terminal, so don't record them.
         buildable = [
             job
@@ -311,7 +311,7 @@ async def _run_build_inner(
             and job.system in o.config.build_systems
         ]
         await record_attributes(o.pool, build.id, buildable)
-        # The full eval result is recorded in build_attributes; a later
+        # The full eval result is recorded in build_attributes. A later
         # build of the same tree may reuse it instead of re-evaluating.
         await q.mark_eval_completed(o.pool, id_=build.id)
         await o.reporter.eval_finished(
@@ -491,7 +491,7 @@ class _ReadOnlyFailedBuildCache:
 
     Recovery/restart reruns rebuild jobs from DB rows without dependency
     closures, so dependents of one broken drv fail with their own build
-    error; recording those would poison the cache."""
+    error. Recording those would poison the cache."""
 
     def __init__(self, inner: FailedBuildCache) -> None:
         self._inner = inner
@@ -544,7 +544,7 @@ class _OrchestratorExecutor:
 
     async def _build_inner(self, job: NixEvalJobSuccess) -> BuildOutcome:
         # Flip to 'building' and stamp started_at so the web UI can
-        # distinguish running attributes from queued ones; returns no
+        # distinguish running attributes from queued ones. Returns no
         # row when the attribute is already terminal.
         marked = await q.mark_attribute_building(
             self.o.pool,

--- a/nixbot/nixbot/build_scheduler.py
+++ b/nixbot/nixbot/build_scheduler.py
@@ -13,10 +13,10 @@ Port of the behavioral core of nixbot/build_trigger.py
   previously failed status); `cached` jobs are scheduled so nix
   substitutes them,
 - per-attribute failed-eval records,
-- opt-in failed-build cache skip (storage interface; wired in 2.3).
+- opt-in failed-build cache skip (storage interface. Wired in 2.3).
 
 Build execution and the global concurrency cap live behind the
-BuildExecutor protocol; status reporting is layered on top
+BuildExecutor protocol. Status reporting is layered on top
 by forge integration.
 """
 
@@ -86,7 +86,7 @@ class BuildOutcome(StrEnum):
 
 
 class BuildExecutor(Protocol):
-    """Builds one attribute; implements the global concurrency cap."""
+    """Builds one attribute. Implements the global concurrency cap."""
 
     async def build(self, job: NixEvalJobSuccess) -> BuildOutcome: ...
 
@@ -250,7 +250,7 @@ class _ResultEmitter:
 
 
 def _fail_unresolvable(state: _State) -> None:
-    """Dependency cycle or external dep: should not happen; fail the
+    """Dependency cycle or external dep: should not happen. Fail the
     remainder instead of spinning."""
     for job in state.pending:
         state.result.results.append(
@@ -465,7 +465,7 @@ class JobScheduler:
                 await self._finish_job(state, state.running.pop(task), task.result())
                 await flush()
         elif done_get is not None:
-            done_get.cancel()  # a batch arrived first; no build consumed
+            done_get.cancel()  # a batch arrived first. No build consumed
         return get_task
 
     def _on_queue_item(
@@ -474,7 +474,7 @@ class JobScheduler:
         queue: asyncio.Queue[list[NixEvalJob] | None],
         batch: list[NixEvalJob] | None,
     ) -> asyncio.Task[list[NixEvalJob] | None] | None:
-        """Ingest one queue item; returns the next reader task, or None
+        """Ingest one queue item. Returns the next reader task, or None
         on the end-of-input sentinel."""
         if batch is None:
             return None
@@ -508,7 +508,7 @@ class JobScheduler:
                 blocking = deps & state.failed_drvs
                 if blocking:
                     state.failed_drvs.add(job.drv_path)
-                    # A genuine failure among the deps wins; only purely
+                    # A genuine failure among the deps wins. Only purely
                     # cancelled deps propagate cancellation.
                     if blocking <= state.cancelled_drvs:
                         state.cancelled_drvs.add(job.drv_path)
@@ -521,7 +521,7 @@ class JobScheduler:
                     remaining.append(job)
             candidates = remaining
         state.pending = candidates
-        # Only pending jobs get closures; running builds (which can be in
+        # Only pending jobs get closures. Running builds (which can be in
         # the thousands) merely stay in the intersection set. Keeps each
         # batch O(pending), not O(pending + running).
         running_drvs = frozenset(j.drv_path for j in state.running.values())

--- a/nixbot/nixbot/canceller.py
+++ b/nixbot/nixbot/canceller.py
@@ -36,7 +36,7 @@ def has_skip_ci_marker(commit_message: str) -> bool:
 
 
 def branch_key(branch: str, pr_number: int | None = None) -> str:
-    """Context key for supersede tracking; one in-flight build per key.
+    """Context key for supersede tracking. One in-flight build per key.
 
     Ports branch_key_for_pr: PRs collapse to one key regardless of
     merge/head ref form.
@@ -88,12 +88,12 @@ class CancellationManager:
 
         `incoming_is_ancestor_of_running` should be the result of a
         `git merge-base --is-ancestor <incoming> <running>` check by the
-        caller; when true the event is out-of-order and ignored.
+        caller. When true the event is out-of-order and ignored.
         """
         build = self._builds.get(build_id)
         if build is not None:
             # Re-registration (e.g. crash recovery) comes with a fresh
-            # cancel event; keeping the old one would make the build
+            # cancel event. Keeping the old one would make the build
             # uncancellable via supersede.
             build.cancel_event = cancel_event
         context = (project_id, context_key)

--- a/nixbot/nixbot/config.py
+++ b/nixbot/nixbot/config.py
@@ -40,7 +40,7 @@ def read_secret_file(secret_file: Path) -> str:
 
 
 def resolve_credential_path(path: Path | None) -> Path | None:
-    """Relative secret paths are systemd LoadCredential names; resolve
+    """Relative secret paths are systemd LoadCredential names. Resolve
     them against $CREDENTIALS_DIRECTORY (mirrors read_secret_file)."""
     if path is None or path.is_absolute():
         return path
@@ -51,14 +51,14 @@ def resolve_credential_path(path: Path | None) -> Path | None:
 
 
 # Note that serialization isn't correct, as there is no way to *rename* the
-# field `nix_type` to `_type`; one must always specify `by_alias=True`, such
+# field `nix_type` to `_type`. One must always specify `by_alias=True`, such
 # as `model_dump(by_alias=True)`. Relevant issue:
 # https://github.com/pydantic/pydantic/issues/8379
 class Interpolate(BaseModel):
     """A string with placeholder interpolation, set from repo config.
 
     Kept for config-format compatibility with the buildbot-era
-    `Interpolate` (`{"_type": "interpolate", "value": ...}`); the service
+    `Interpolate` (`{"_type": "interpolate", "value": ...}`). The service
     substitutes placeholders itself when running post-build steps.
     """
 
@@ -73,7 +73,7 @@ class Interpolate(BaseModel):
 
 class TokenForgeConfig(BaseModel):
     """Shared token/OAuth/SSH options for token-authenticated forges
-    (Gitea, GitLab); subclasses only differ in defaults and the config
+    (Gitea, GitLab). Subclasses only differ in defaults and the config
     key used in error messages."""
 
     _config_key: ClassVar[str]
@@ -138,7 +138,7 @@ class PullBasedConfig(BaseModel):
 
 
 class GitHubConfig(BaseModel):
-    """GitHub App configuration (App auth only; token mode was dropped)."""
+    """GitHub App configuration (App auth only. Token mode was dropped)."""
 
     id: int
     secret_key_file: Path
@@ -304,7 +304,7 @@ class Config(BaseModel):
     @field_validator("url", "webhook_base_url")
     @classmethod
     def _strip_trailing_slash(cls, value: str | None) -> str | None:
-        # Joined with absolute paths everywhere; a trailing slash
+        # Joined with absolute paths everywhere. A trailing slash
         # produces double-slash URLs (the state API 404s on them).
         return value.rstrip("/") if value is not None else None
 
@@ -313,11 +313,11 @@ class Config(BaseModel):
 
     eval_max_memory_size: int = 4096
     admins: list[str] = []
-    # Private visibility for non-forge logins; key/rule syntax in
+    # Private visibility for non-forge logins. Key/rule syntax in
     # docs/OIDC.md, semantics in auth.can_view_private.
     private_repo_viewers: dict[str, list[str]] = {}
     eval_worker_count: int | None = None
-    # Concurrent evaluations (global); default matches today's global eval lock.
+    # Concurrent evaluations (global). Default matches today's global eval lock.
     eval_concurrency: int = 1
     # Global cap on concurrent attribute builds; None = derive from CPU count.
     build_concurrency: int | None = None
@@ -332,7 +332,7 @@ class Config(BaseModel):
     failed_build_report_limit: int = (
         47  # Default: 50 total - 3 reserved for eval/build/effects
     )
-    # Commit status context prefix; buildbot-nix migrations can set
+    # Commit status context prefix. Buildbot-nix migrations can set
     # "buildbot" to keep existing branch protection rules working.
     status_context_prefix: str = "nixbot"
     branches: BranchConfigDict = BranchConfigDict({})
@@ -352,11 +352,11 @@ class Config(BaseModel):
     allow_unauthenticated_control: bool = False
     build_max_silent_time: int = 60 * 20  # stop stuck builds after 20 minutes
     build_timeout: int = 60 * 60 * 3  # 3 hours default for nix build
-    # Wall-clock limit for one nix-eval-jobs run; a hung evaluation
+    # Wall-clock limit for one nix-eval-jobs run. A hung evaluation
     # would otherwise hold the global eval slot forever.
     eval_timeout: int = 60 * 60
 
-    # Per-attribute log size cap in bytes; head and tail kept on truncation.
+    # Per-attribute log size cap in bytes. Head and tail kept on truncation.
     log_size_limit: int = 64 * 1024 * 1024
     # Build/log retention horizon in days.
     retention_days: int = 90
@@ -367,7 +367,7 @@ class Config(BaseModel):
 
     http_port: int = 8010
     http_unix_socket: Path | None = None
-    # Also bind the TCP port when a unix socket is configured; off by
+    # Also bind the TCP port when a unix socket is configured. Off by
     # default because the TCP listener would bypass the TLS proxy.
     http_listen: bool = False
 
@@ -397,7 +397,7 @@ class ScheduleWhen(BaseModel):
         """Resolve to concrete cron-like fields.
 
         An unset minute gets a deterministic pseudo-random default
-        seeded by the schedule name (thundering-herd avoidance); an
+        seeded by the schedule name (thundering-herd avoidance). An
         unset hour means every hour, like Hercules.
         Day-of-week names are normalized to integers (Mon=0 .. Sun=6).
         """

--- a/nixbot/nixbot/db.py
+++ b/nixbot/nixbot/db.py
@@ -1,6 +1,6 @@
 """Shared build persistence (sqlc-generated queries over asyncpg).
 
-Only multi-caller operations with real invariants live here; modules
+Only multi-caller operations with real invariants live here. Modules
 with a single call site use db_gen directly. The SQL lives in
 queries/builds.sql; `sqlc generate` produces db_gen/builds.py.
 
@@ -181,7 +181,7 @@ async def aggregate_build(pool: asyncpg.Pool, build_id: int) -> tuple[str, int]:
     """Recompute the build's aggregate result from its attributes.
 
     Serialized per build via a row lock taken before the statuses
-    are read (see LockBuildRow); bumps the monotonic status
+    are read (see LockBuildRow). Bumps the monotonic status
     generation. Returns (status, generation).
     """
     async with pool.acquire() as conn, conn.transaction():

--- a/nixbot/nixbot/discovery.py
+++ b/nixbot/nixbot/discovery.py
@@ -85,7 +85,7 @@ async def discover_once(s: CIService) -> None:
     # None marks a failed forge: its rows are neither synced nor pruned.
     by_forge: dict[str, list[DiscoveredRepo] | None] = {}
     # The topic is only a legacy import aid (one-shot enablement in
-    # sync_discovered); it must not hard-filter discovery, otherwise
+    # sync_discovered). It must not hard-filter discovery, otherwise
     # untagged repos never appear in the admin UI.
     if s.github is not None and s.config.github is not None:
         await _warn_github_webhook_misconfig(s, s.github)
@@ -118,7 +118,7 @@ async def discover_once(s: CIService) -> None:
     }
     await s.repo_store.sync_discovered(repos, legacy_import_topics=topics)
     # Drop disabled repos a successful discovery no longer returned so
-    # the admin toggle list stays clean; a failed forge is skipped to
+    # the admin toggle list stays clean. A failed forge is skipped to
     # avoid mass-deleting rows on a transient API error.
     for forge, found in by_forge.items():
         if found is not None:

--- a/nixbot/nixbot/effects.py
+++ b/nixbot/nixbot/effects.py
@@ -3,12 +3,12 @@
 Ported from nixbot_effects.py + the effects parts of nix_eval.py:
 
 - effects run per the DEFAULT BRANCH's repo config: default branch
-  always; PRs when `effects_on_pull_requests`; branches matching
+  always; PRs when `effects_on_pull_requests`. Branches matching
   `effects_branches` globs,
 - effects are listed via `nixbot-effects list` and each effect run
   via `nixbot-effects run <name>`,
 - per-repo secret resolution supports exact `forge:owner/repo` and org
-  wildcard `forge:owner/*` entries; the secret JSON is written next to
+  wildcard `forge:owner/*` entries. The secret JSON is written next to
   the checkout as ../secrets.json for the duration of the run,
 - `effects.extraSandboxPaths` are forwarded.
 
@@ -42,10 +42,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Deploy tooling emits arbitrarily long lines; asyncio's 64 KiB
+# Deploy tooling emits arbitrarily long lines. Asyncio's 64 KiB
 # StreamReader default would abort the read loop on them.
 STREAM_LIMIT = 16 * 1024 * 1024
-# Deploys can hang on the network; same cap as attribute builds.
+# Deploys can hang on the network. Same cap as attribute builds.
 DEFAULT_TIMEOUT = 60 * 60 * 3
 
 
@@ -117,7 +117,7 @@ def effects_context(  # noqa: PLR0913
     git_token: str | None,
     task_token: str | None,
 ) -> EffectsContext:
-    """Context with the service-level configuration filled in; shared
+    """Context with the service-level configuration filled in. Shared
     by push and scheduled effect runs."""
     return EffectsContext(
         worktree_path=worktree_path,
@@ -262,7 +262,7 @@ async def run_effect_command(
     targets: list[str],
     log_write: LogWrite | None = None,
 ) -> bool:
-    """Run one (push or scheduled) effect; returns success. The secrets
+    """Run one (push or scheduled) effect. Returns success. The secrets
     file is written outside the checkout (parent directory, like the
     buildbot setup) and removed afterwards."""
     side_files: list[Path] = []

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -97,7 +97,7 @@ async def maybe_run_effects(
     try:
         names = await list_effects(ctx)
     except (EffectsError, OSError):
-        # OSError: nixbot-effects not installed; effects are
+        # OSError: nixbot-effects not installed. Effects are
         # best-effort and must not fail the (already reported) build.
         logger.exception("effects discovery failed", extra={"build_id": build.id})
         return
@@ -113,7 +113,7 @@ async def _enqueue_effects(
     o: Orchestrator, event: ChangeEvent, build: BuildRecord, names: list[str]
 ) -> None:
     """One queue item per effect, on the build's dedup key."""
-    # Effect names are repo-controlled; a duplicate inside one batch
+    # Effect names are repo-controlled. A duplicate inside one batch
     # would make ON CONFLICT DO UPDATE fail with "cannot affect row a
     # second time".
     names = list(dict.fromkeys(names))
@@ -139,7 +139,7 @@ async def run_effect_item(
     """Dispatcher entry for one queued effect."""
     row = await q.effect_status(o.pool, build_id=build.id, name=name)
     if row != "pending":
-        # Swept after a crash mid-run, or already terminal; started
+        # Swept after a crash mid-run, or already terminal. Started
         # effects never auto-re-run (deploys are not idempotent).
         return
     async with o.rerun_worktree(info, build, "effect", credentials) as (
@@ -169,7 +169,7 @@ async def run_effect_item(
 async def post_effects_summary(
     o: Orchestrator, event: ChangeEvent, build: BuildRecord
 ) -> None:
-    """Post the aggregate status once all effects settle; the items run
+    """Post the aggregate status once all effects settle. The items run
     independently, so the last to finish reports it."""
     statuses = [e.status for e in await web_q.web_effects(o.pool, build_id=build.id)]
     if any(s in ("pending", "running") for s in statuses):
@@ -192,7 +192,7 @@ async def _run_one_effect(
     """One effect with its own row and log."""
     # A rerun resets the existing effect row.
     await builds_q.start_effect(o.pool, build_id=build.id, name=name, status="running")
-    # A green commit status on a failed deploy hides the failure; report
+    # A green commit status on a failed deploy hides the failure. Report
     # per-effect status so the forge reflects the real outcome.
     await o.reporter.effect_started(event, build, name)
     async with o.open_log(build.id, f"effect:{name}") as writer:

--- a/nixbot/nixbot/effects_state.py
+++ b/nixbot/nixbot/effects_state.py
@@ -2,7 +2,7 @@
 
 Effects persist small files between runs (`getStateFile`/
 `putStateFile` in hercules-ci-effects: nixops state, ssh known
-hosts). The agent proxies these to hercules-ci; we serve them from
+hosts). The agent proxies these to hercules-ci. We serve them from
 the state directory, scoped per project, authorized by a per-run
 bearer token that the service mints for each effect invocation.
 """
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 class TaskTokens:
-    """In-memory per-run tokens; an effect only runs while the service
+    """In-memory per-run tokens. An effect only runs while the service
     is up, so restart-safety is not needed."""
 
     def __init__(self) -> None:
@@ -37,7 +37,7 @@ class TaskTokens:
 
 
 def state_file_path(state_dir: Path, project_id: int, name: str) -> Path:
-    """State names come from untrusted flakes; percent-encode so they
+    """State names come from untrusted flakes. Percent-encode so they
     cannot escape the per-project directory. quote() keeps dots, so
     "." and ".." (the directory and its parent) need rejecting."""
     if name in {".", ".."}:

--- a/nixbot/nixbot/events.py
+++ b/nixbot/nixbot/events.py
@@ -39,7 +39,7 @@ class ChangeEvent:
     repo: RepoInfo
     branch: str
     commit_sha: str
-    # PR-only fields; base_sha is the base branch head to merge into.
+    # PR-only fields. base_sha is the base branch head to merge into.
     pr_number: int | None = None
     pr_author: str | None = None
     base_sha: str | None = None
@@ -48,7 +48,7 @@ class ChangeEvent:
 
 def event_for_build(repo: RepoInfo, build: BuildRecord) -> ChangeEvent:
     """The triggering event of a build, reconstructed from its stored
-    fields; used by rerun and out-of-band reporting paths."""
+    fields. Used by rerun and out-of-band reporting paths."""
     return ChangeEvent(
         repo=repo,
         branch=build.branch,
@@ -60,7 +60,7 @@ def event_for_build(repo: RepoInfo, build: BuildRecord) -> ChangeEvent:
 def effects_event_for_build(repo: RepoInfo, build: BuildRecord) -> ChangeEvent:
     """Effects report on the ref that triggered them (e.g. a
     default-branch merge that reused a PR build), recorded at
-    mark_effects_started; pre-0018 builds fall back to the build ref."""
+    mark_effects_started. Pre-0018 builds fall back to the build ref."""
     if build.effects_commit_sha is None:
         return event_for_build(repo, build)
     return ChangeEvent(
@@ -74,7 +74,7 @@ def effects_event_for_build(repo: RepoInfo, build: BuildRecord) -> ChangeEvent:
 @dataclass(frozen=True)
 class EvalReport:
     """Evaluation-phase outcome reported to a forge. warnings and jobs
-    are populated on success; error carries the evaluator's log tail on
+    are populated on success. Error carries the evaluator's log tail on
     failure."""
 
     success: bool
@@ -95,7 +95,7 @@ class BuildResult:
 
 
 class StatusReporter(Protocol):
-    """Receives lifecycle events; forge integration implements this."""
+    """Receives lifecycle events. Forge integration implements this."""
 
     async def build_started(self, event: ChangeEvent, build: BuildRecord) -> None: ...
 

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -11,8 +11,8 @@ Runs `nix build` per derivation with:
   once cancellation is requested,
 - process-group kill on cancel/timeout,
 - frame-chunked zstd log capture: one zstd frame per flush so live
-  tailing only decompresses new frames; a single reader fans out to all
-  subscribers; compression runs off the event loop; logs are capped
+  tailing only decompresses new frames. A single reader fans out to all
+  subscribers. Compression runs off the event loop. Logs are capped
   (default 64 MB) keeping head and tail.
 
 The eval gc-roots directory is owned by the orchestrator and held for
@@ -55,12 +55,12 @@ logger = logging.getLogger(__name__)
 STREAM_LIMIT = 16 * 1024 * 1024
 
 # Cap per-subscriber backlog so a stalled SSE client cannot buffer the
-# whole build output in memory; the oldest chunks are dropped.
+# whole build output in memory. The oldest chunks are dropped.
 SUBSCRIBER_QUEUE_MAXSIZE = 256
 STRUCTURED_QUEUE_MAXSIZE = 4096  # per-line deltas, chattier than byte chunks
 RECENT_BUFFER_SIZE = 4096
 
-# Batch log output into zstd frames of at least this size; one frame
+# Batch log output into zstd frames of at least this size. One frame
 # per output line would make "compressed" logs larger than plaintext.
 FRAME_FLUSH_THRESHOLD = 64 * 1024
 
@@ -100,7 +100,7 @@ async def iter_lines(
 
     readline() raises LimitOverrunError on lines over the StreamReader
     limit, killing the pump while nix blocks on the full pipe. Reading
-    chunks never raises; lines beyond max_line are flushed in pieces so
+    chunks never raises. Lines beyond max_line are flushed in pieces so
     one pathological line cannot buffer unboundedly.
     """
     buffer = bytearray()
@@ -235,7 +235,7 @@ class LogWriter:
 
     @staticmethod
     def _offer(queue: asyncio.Queue[bytes | None], item: bytes | None) -> None:
-        """Enqueue without blocking; drop the oldest chunk when the
+        """Enqueue without blocking. Drop the oldest chunk when the
         subscriber has stalled (no backpressure toward the writer)."""
         while True:
             try:
@@ -267,7 +267,7 @@ class LogWriter:
 
         Subscribe first, then snapshot: a chunk written during the
         snapshot's await points would otherwise be in neither. Chunks
-        written during the snapshot land in both; the overlap is
+        written during the snapshot land in both. The overlap is
         dropped from the queue by byte count."""
         queue = self.subscribe()
         start_offset = self.bytes_seen
@@ -278,10 +278,10 @@ class LogWriter:
                 chunk = queue.get_nowait()
             except asyncio.QueueEmpty:
                 # A stalled-queue drop during the snapshot: fewer bytes
-                # queued than written; nothing left to dedupe.
+                # queued than written. Nothing left to dedupe.
                 break
             if chunk is None:
-                break  # close() ran during the snapshot; re-signalled below
+                break  # close() ran during the snapshot, re-signalled below
             overlap -= len(chunk)
         if self.closed:
             # Closed but not yet unregistered: terminate immediately
@@ -319,7 +319,7 @@ class LogWriter:
 
     async def _append_frame(self, data: bytes) -> None:
         # Batch into frames so tiny writes (one per output line) don't
-        # blow up storage with per-frame overhead; compression runs off
+        # blow up storage with per-frame overhead. Compression runs off
         # the event loop.
         self._frame_buffer += data
         if len(self._frame_buffer) >= FRAME_FLUSH_THRESHOLD:
@@ -376,7 +376,7 @@ def build_nix_command(
         "build",
         # internal-json keeps the ANSI colors that the terminal loggers
         # strip from non-tty output and tags every build-log line with
-        # its derivation; render_log_event turns that back into
+        # its derivation. render_log_event turns that back into
         # attributed, colored text.
         "--log-format",
         "internal-json",
@@ -387,7 +387,7 @@ def build_nix_command(
         "--max-silent-time",
         str(settings.max_silent_time),
         # Hosts without flakes enabled in nix.conf (single-user
-        # installs, containers) must still build; the eval command
+        # installs, containers) must still build. The eval command
         # carries the same override.
         "--option",
         "extra-experimental-features",
@@ -425,11 +425,11 @@ _LINE_CHAR_LIMIT = 650
 
 def _limit_line(line: str, limit: int = _LINE_CHAR_LIMIT) -> str:
     """Cap a line at `limit` visible characters, escapes not counted and
-    never severed; a dropped tail's SGR reset is re-appended so color
+    never severed. A dropped tail's SGR reset is re-appended so color
     does not bleed into later lines."""
     visible = 0
     pos = 0
-    # ANSI_TOKEN_RE spans are escapes; the gaps between them are text.
+    # ANSI_TOKEN_RE spans are escapes, the gaps between them are text.
     for start, end in [(m.start(), m.end()) for m in ANSI_TOKEN_RE.finditer(line)] + [
         (len(line), len(line))
     ]:
@@ -447,7 +447,7 @@ def _limit_line(line: str, limit: int = _LINE_CHAR_LIMIT) -> str:
 def failure_excerpt(tail: str, max_lines: int = 8) -> str:
     """The interesting part of a failed build's output: the builder's
     log lines (name>-prefixed from internal-json, deduped against
-    nix's bare-'>' prose re-quote) plus one Reason line; without any,
+    nix's bare-'>' prose re-quote) plus one Reason line. Without any,
     the tail minus nix's boilerplate. Lines are matched ANSI-stripped
     but emitted raw, so colors survive."""
     quoted: dict[str, str] = {}
@@ -482,7 +482,7 @@ def _drv_display_name(drv_path: str) -> str:
 class StructuredCapture:
     """Demux the internal-json stream into a per-derivation container.
 
-    Activity ids map to full drv paths; log lines, phases and stop
+    Activity ids map to full drv paths. Log lines, phases and stop
     timestamps attach to the owning derivation. Unattributed output (nix's
     own evaluation/scheduling/copy messages) collects under a synthetic
     ``setup`` entry.
@@ -518,7 +518,7 @@ class StructuredCapture:
     @staticmethod
     def _put(q: asyncio.Queue[dict | None], item: dict | None) -> None:
         # Drop the oldest delta for a stalled subscriber rather than grow
-        # unbounded; the missing line is a cosmetic gap the finish reload
+        # unbounded. The missing line is a cosmetic gap the finish reload
         # heals. Matches LogWriter's stalled-subscriber policy.
         while True:
             try:
@@ -534,7 +534,7 @@ class StructuredCapture:
             self._put(q, delta)
 
     def subscribe(self) -> asyncio.Queue[dict | None]:
-        """Live deltas for a viewer; a full snapshot comes from state().
+        """Live deltas for a viewer. A full snapshot comes from state().
         Subscribe then snapshot with no await between so no delta is lost
         or duplicated (single event loop, atomic)."""
         q: asyncio.Queue[dict | None] = asyncio.Queue(maxsize=STRUCTURED_QUEUE_MAXSIZE)
@@ -583,7 +583,7 @@ class StructuredCapture:
     def log_line(self, act_id: int, text: str) -> None:
         drv = self._act.get(act_id, self.SETUP)
         if strip_ansi(text).startswith(_PHASE_ECHO):
-            # RES_SET_PHASE already records this; drop stdenv's echo.
+            # RES_SET_PHASE already records this. Drop stdenv's echo.
             return
         self._w.line(drv, text, ts=self._ts())
         self._emit(
@@ -619,7 +619,7 @@ class StructuredCapture:
         self._emit(
             {"t": "line", "idx": 0, "from": self._bump(self.SETUP), "text": text}
         )
-        # A nix error block arrives as one multiline msg event; scrape per
+        # A nix error block arrives as one multiline msg event. Scrape per
         # line so the "Cannot build" and its "Reason:" line pair up.
         for line in strip_ansi(text).splitlines():
             self._scrape_failure(line)
@@ -661,7 +661,7 @@ class StructuredCapture:
             # else the setup bucket keeps its default "built" (succeeded).
             self._w.status(self.SETUP, "failed")
             self._emit({"t": "status", "idx": 0, "status": "failed"})
-        # else: a leaf drv already carries the failure; adding the
+        # else: a leaf drv already carries the failure. Adding the
         # top-level as a phantom "no output" card only duplicates it.
 
     def build_failure(
@@ -931,6 +931,6 @@ def read_log(path: Path) -> bytes:
     """Decompress a frame-chunked zstd log file (one frame per flush)."""
     data = path.read_bytes()
     dctx = zstandard.ZstdDecompressor()
-    # One streaming pass; re-slicing unused_data per frame is quadratic.
+    # One streaming pass. Re-slicing unused_data per frame is quadratic.
     with dctx.stream_reader(io.BytesIO(data), read_across_frames=True) as reader:
         return reader.read()

--- a/nixbot/nixbot/failed_builds.py
+++ b/nixbot/nixbot/failed_builds.py
@@ -1,6 +1,6 @@
 """Postgres-backed failed-build cache (opt-in via cacheFailedBuilds).
 
-Storage port of db/failed_builds.py onto the service schema; the skip
+Storage port of db/failed_builds.py onto the service schema. The skip
 semantics live in build_scheduler.py (cached failures skip the build,
 report with a link to the first failure, and propagate to dependents;
 an explicit rebuild deletes the rows up front in service.py and

--- a/nixbot/nixbot/forge/base.py
+++ b/nixbot/nixbot/forge/base.py
@@ -118,11 +118,11 @@ def filter_repos(
     filters: RepoFilters, repos: list[DiscoveredRepo]
 ) -> list[DiscoveredRepo]:
     """Port of common.filter_repos: allow everything when both
-    allowlists are unset; otherwise a repo passes if its owner is in
+    allowlists are unset. Otherwise a repo passes if its owner is in
     the user allowlist or its full name in the repo allowlist.
 
     The topic is deliberately not a discovery filter: it is only the
-    one-shot legacy enablement import aid (projects.py); filtering on
+    one-shot legacy enablement import aid (projects.py). Filtering on
     it here would keep non-topic repos out of the projects table and
     thus impossible to enable in the web UI."""
     no_allowlists = filters.user_allowlist is None and filters.repo_allowlist is None

--- a/nixbot/nixbot/forge/gitea.py
+++ b/nixbot/nixbot/forge/gitea.py
@@ -18,7 +18,7 @@ class GiteaClient(TokenForgeClient):
         return {"Authorization": f"token {self.token}"}
 
     async def paginated_pages(self, url: str) -> AsyncIterator[list[dict[str, Any]]]:
-        # Gitea does not emit RFC 5988 Link headers reliably; walk
+        # Gitea does not emit RFC 5988 Link headers reliably. Walk
         # ?page=N until an empty page.
         page = 1
         while True:

--- a/nixbot/nixbot/forge/github.py
+++ b/nixbot/nixbot/forge/github.py
@@ -1,5 +1,5 @@
 """GitHub App auth and discovery. App JWTs are signed via openssl
-with the operator-supplied private key; short-lived installation
+with the operator-supplied private key. Short-lived installation
 tokens are minted per installation and cached until shortly before
 expiry. Private-repo fetches get per-fetch credentials through the
 gitrepo CredentialsProvider interface (netrc with x-access-token)."""
@@ -103,7 +103,7 @@ class GitHubAppClient:
         ] = {}
         # Per-key mint locks so concurrent misses collapse into one API call.
         self._token_locks: dict[tuple[int, tuple[str, ...] | None], asyncio.Lock] = {}
-        # owner/repo (lowercase) -> installation id; filled by discovery.
+        # owner/repo (lowercase) -> installation id. Filled by discovery.
         self.repo_installations: dict[str, int] = {}
 
     async def _app_jwt(self) -> str:
@@ -118,7 +118,7 @@ class GitHubAppClient:
         self, installation_id: int, repositories: tuple[str, ...] | None = None
     ) -> str:
         """Mint (or reuse) an installation token. `repositories` limits
-        the token to those repo names; pass it for any token that can
+        the token to those repo names. Pass it for any token that can
         leak into PR-controlled paths (e.g. fetch credentials)."""
         cache_key = (installation_id, repositories)
         cached = self._installation_tokens.get(cache_key)
@@ -149,7 +149,7 @@ class GitHubAppClient:
             msg = f"failed to mint installation token: {response.status_code} {response.text}"
             raise ForgeError(msg, status_code=response.status_code)
         token = response.json()["token"]
-        # GitHub installation tokens last 60 minutes; refresh at 80%.
+        # GitHub installation tokens last 60 minutes. Refresh at 80%.
         self._installation_tokens[cache_key] = _CachedToken(
             token, datetime.now(tz=UTC) + timedelta(minutes=48)
         )
@@ -250,7 +250,7 @@ class GitHubAppClient:
             try:
                 repos.extend(await self._discover_installation(installation_id))
             except (ForgeError, httpx.HTTPError):
-                # e.g. suspended installation; keep discovering the rest.
+                # e.g. suspended installation. Keep discovering the rest.
                 logger.exception(
                     "repo discovery failed for installation %s", installation_id
                 )

--- a/nixbot/nixbot/forge/gitlab.py
+++ b/nixbot/nixbot/forge/gitlab.py
@@ -17,7 +17,7 @@ class GitlabClient(TokenForgeClient):
 
     def project_api_url(self, owner: str, repo: str) -> str:
         # GitLab accepts the URL-encoded full path wherever it takes a
-        # numeric project id; namespaces may be nested (a/b/c).
+        # numeric project id. Namespaces may be nested (a/b/c).
         return (
             f"{self.instance_url}/api/v4/projects/{quote(f'{owner}/{repo}', safe='')}"
         )

--- a/nixbot/nixbot/forge/retry.py
+++ b/nixbot/nixbot/forge/retry.py
@@ -28,7 +28,7 @@ def retry_after_seconds(response: httpx.Response) -> float | None:
     if value is not None:
         try:
             seconds = float(value)
-            # float() accepts nan/inf; nan would poison every later
+            # float() accepts nan/inf. Nan would poison every later
             # min/max comparison down to asyncio.sleep.
             if math.isfinite(seconds):
                 return max(0.0, seconds)
@@ -72,7 +72,7 @@ class RetryTransport(httpx.AsyncBaseTransport):
                     raise
             else:
                 # A Retry-After hint (on 429 or 503) always wins over the
-                # backoff schedule; otherwise retry only transient 5xx.
+                # backoff schedule. Otherwise retry only transient 5xx.
                 hint = retry_after_seconds(response)
                 delay = max(backoff, hint or 0.0)
                 retryable = (

--- a/nixbot/nixbot/forge_tokens.py
+++ b/nixbot/nixbot/forge_tokens.py
@@ -148,7 +148,7 @@ class ForgeTokenRefresher:
             session_id,
             token.access_token,
             lifetime,
-            # Providers may rotate the refresh token; keep the old one
+            # Providers may rotate the refresh token. Keep the old one
             # if the response omitted a new one.
             refresh=RefreshCredentials(
                 token.refresh_token or credentials.refresh_token,

--- a/nixbot/nixbot/gcroots.py
+++ b/nixbot/nixbot/gcroots.py
@@ -29,7 +29,7 @@ def safe_attr_filename(attr: str) -> str:
     """Encode a flake attribute name as a single safe path component.
 
     Attribute names are repository-controlled and may contain `/` and
-    `..` via quoted Nix attributes; used verbatim in paths they allow
+    `..` via quoted Nix attributes. Used verbatim in paths they allow
     traversal outside the intended directory. Typical attribute names
     (letters, digits, `.`, `-`, `_`) are preserved unchanged.
     """

--- a/nixbot/nixbot/gitea_hooks.py
+++ b/nixbot/nixbot/gitea_hooks.py
@@ -47,7 +47,7 @@ async def register_repo_hook(  # noqa: PLR0913
     repo: str,
     webhook_base_url: str,
 ) -> None:
-    """Idempotently register our webhook; remove legacy buildbot hooks
+    """Idempotently register our webhook. Remove legacy buildbot hooks
     only when they point at our own webhook base URL."""
     secret = await secrets_store.get_or_create(project_id)
     target_url = hook_url(webhook_base_url)

--- a/nixbot/nixbot/gitlab_hooks.py
+++ b/nixbot/nixbot/gitlab_hooks.py
@@ -3,7 +3,7 @@
 Same flow as gitea_hooks.py: the service stores a per-repository secret
 (hook_secrets.py) and registers a webhook pointing at
 `<webhook_base_url>/webhooks/gitlab`. Hook management needs Maintainer
-on the project; without it the hook must be created manually.
+on the project. Without it the hook must be created manually.
 """
 
 from __future__ import annotations

--- a/nixbot/nixbot/gitrepo.py
+++ b/nixbot/nixbot/gitrepo.py
@@ -1,6 +1,6 @@
 """Git clone and worktree management.
 
-One central persistent bare clone per project; each build gets its own
+One central persistent bare clone per project. Each build gets its own
 git worktree from that clone so concurrent builds of the same project
 never re-fetch. Worktrees are removed after the build. Clones are a
 cache: on corruption they are deleted and re-cloned. A per-project lock
@@ -8,7 +8,7 @@ serializes fetches; `git worktree prune` plus an orphan sweep runs at
 startup and periodically, as does `git gc`.
 
 PR builds merge the PR head into the base branch locally in the
-worktree; a conflict is a failed build. Build identity is the
+worktree. A conflict is a failed build. Build identity is the
 post-merge tree hash (`HEAD^{tree}`).
 
 Fetch credentials come from a provider interface. The static/netrc
@@ -34,7 +34,7 @@ from .environ import passthrough_env
 logger = logging.getLogger(__name__)
 
 # PR/MR refs are fetched per PR and never covered by --prune of later
-# fetches; without an age-based sweep they accumulate forever.
+# fetches. Without an age-based sweep they accumulate forever.
 PR_REF_MAX_AGE = 90 * 86400
 # Crash-leaked plain files next to worktrees (e.g. effects side-files)
 # are swept once clearly older than any running build.
@@ -70,7 +70,7 @@ class FetchCredentials:
     """Credentials for fetching a repository.
 
     `netrc_file` is bind-mounted/read for the duration of one fetch or
-    eval only; it must be scoped to the repository being fetched.
+    eval only. It must be scoped to the repository being fetched.
     SSH key/known-hosts files cover per-repo SSH fetch (pull-based
     repos and the gitea.sshPrivateKeyFile option).
     """
@@ -141,7 +141,7 @@ async def run_git(
         if ssh_command is not None:
             env["GIT_SSH_COMMAND"] = ssh_command
     if credentials is not None and credentials.netrc_file is not None:
-        # git's libcurl reads $HOME/.netrc (CURL_NETRC_OPTIONAL); point
+        # git's libcurl reads $HOME/.netrc (CURL_NETRC_OPTIONAL). Point
         # HOME at a throwaway directory containing only the scoped netrc.
         home = Path(tempfile.mkdtemp(prefix="git-netrc-"))
         (home / ".netrc").symlink_to(credentials.netrc_file)
@@ -198,7 +198,7 @@ class Worktree:
     ) -> None:
         """Merge `head_sha` into the currently checked-out base branch.
 
-        Raises MergeConflictError on conflict; the caller fails the
+        Raises MergeConflictError on conflict. The caller fails the
         build and reports the status on the head SHA.
         """
         try:
@@ -219,7 +219,7 @@ class Worktree:
             )
         except GitError as e:
             # Only a genuine content conflict (unmerged index entries)
-            # is a permanent MergeConflictError; everything else
+            # is a permanent MergeConflictError. Everything else
             # (index.lock contention, missing objects, disk full) must
             # stay a GitError so callers treat it as transient/infra.
             conflicted = False
@@ -249,7 +249,7 @@ class RepoManager:
         self._active_worktrees: set[Path] = set()
 
     def clone_path(self, project_key: str) -> Path:
-        # project_key like "github/owner/repo"; one directory per project.
+        # project_key like "github/owner/repo". One directory per project.
         return self.clones_dir / project_key / "clone.git"
 
     def _lock(self, project_key: str) -> asyncio.Lock:
@@ -371,7 +371,7 @@ class RepoManager:
                 await run_git(["worktree", "prune"], cwd=worktree.clone_path)
 
     async def cleanup(self) -> None:
-        """Prune stale worktrees/PR refs and sweep orphans; run at
+        """Prune stale worktrees/PR refs and sweep orphans. Run at
         startup and periodically."""
         for clone in self.clones_dir.rglob("clone.git"):
             await self._prune_stale_pr_refs(clone)
@@ -465,7 +465,7 @@ class RepoManager:
                     credentials=submodule_credentials,
                 )
         except BaseException:
-            # Callers only remove worktrees they received; a failed
+            # Callers only remove worktrees they received. A failed
             # merge or submodule checkout (or cancellation) must not
             # leak a registered worktree.
             await self.remove_worktree(worktree)

--- a/nixbot/nixbot/hook_registration.py
+++ b/nixbot/nixbot/hook_registration.py
@@ -34,7 +34,7 @@ async def register_hook(  # noqa: PLR0913
     except ForgeError as e:
         if e.status_code != 403:  # noqa: PLR2004
             raise
-        # Hook management needs elevated repo permission; the project
+        # Hook management needs elevated repo permission. The project
         # still works if the webhook is created manually.
         logger.warning(permission_warning, extra={"repo": repo_name, "url": target_url})
         return
@@ -45,7 +45,7 @@ async def register_hook(  # noqa: PLR0913
     )
     if existing_id is not None:
         # The existing hook may carry a stale secret (e.g. after a
-        # database reset) and the forge never exposes it; re-sync in place.
+        # database reset) and the forge never exposes it. Re-sync in place.
         response = await update_hook(existing_id)
         if response.status_code >= 400:  # noqa: PLR2004
             logger.error(

--- a/nixbot/nixbot/hook_secrets.py
+++ b/nixbot/nixbot/hook_secrets.py
@@ -20,7 +20,7 @@ class WebhookSecrets:
 
     def __init__(self, pool: asyncpg.Pool, forge: str | None = None) -> None:
         self.pool = pool
-        # Only lookups by forge repo id need the forge scope; rotation
+        # Only lookups by forge repo id need the forge scope. Rotation
         # and creation are keyed by project id.
         self.forge = forge
 
@@ -45,7 +45,7 @@ class WebhookSecrets:
         )
 
     async def rotate(self, project_id: int) -> str:
-        """Replace the secret; the old one stops verifying immediately.
+        """Replace the secret. The old one stops verifying immediately.
         Auto-managed hooks re-sync on the next discovery cycle."""
         secret = secrets.token_hex(32)
         return expect(

--- a/nixbot/nixbot/live_warnings.py
+++ b/nixbot/nixbot/live_warnings.py
@@ -20,7 +20,7 @@ _PREFIX_RE = re.compile(r"^(?:evaluation warning:|warning:|error:)\s*")
 _WS_RE = re.compile(r"\s+")
 
 MAX_GROUPS = 50
-# Warning text is repo-controlled; keep single messages bounded.
+# Warning text is repo-controlled. Keep single messages bounded.
 MAX_MESSAGE_LEN = 500
 
 _IGNORED_WARNINGS = (
@@ -43,7 +43,7 @@ def normalize_warning(line: str) -> tuple[str, str]:
 
 
 class LiveWarningAggregator:
-    """Counts occurrences per normalized warning; bounded group count."""
+    """Counts occurrences per normalized warning. Bounded group count."""
 
     def __init__(self, max_groups: int = MAX_GROUPS) -> None:
         self._groups: dict[tuple[str, str], int] = {}

--- a/nixbot/nixbot/log.py
+++ b/nixbot/nixbot/log.py
@@ -13,7 +13,7 @@ import sys
 import time
 from typing import Any
 
-# Attributes present on every LogRecord; everything else is user-supplied
+# Attributes present on every LogRecord. Everything else is user-supplied
 # via `extra=` and gets serialized into the JSON line.
 _RESERVED = frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__) | {
     "message",

--- a/nixbot/nixbot/logstore.py
+++ b/nixbot/nixbot/logstore.py
@@ -121,7 +121,7 @@ class LogContainerWriter:
         return [(d.name, d.lines) for d in self._drvs.values() if d.status == "failed"]
 
     def state(self) -> list[dict]:
-        """Current per-derivation state for a live snapshot burst; mirrors
+        """Current per-derivation state for a live snapshot burst. Mirrors
         the finalized TOC plus the lines seen so far."""
         return [
             {
@@ -190,7 +190,7 @@ def is_container(blob: bytes) -> bool:
 
 
 class LogContainerReader:
-    """Random-access reader; decompresses one group frame (cached) per drv."""
+    """Random-access reader. Decompresses one group frame (cached) per drv."""
 
     def __init__(self, blob: bytes) -> None:
         (tlen,) = struct.unpack("<I", blob[-8:-4])
@@ -235,7 +235,7 @@ class LogContainerReader:
 
     def search(self, query: str, per_drv_cap: int = 100) -> list[dict]:
         """Case-insensitive scan, grouped by drv. Fast-rejects frames
-        lacking the term; attributes matches by byte bisect. No index."""
+        lacking the term. Attributes matches by byte bisect. No index."""
         qb = query.lower().encode()
         toc = self.toc
         groups: dict[int, list[tuple[int, int]]] = {}

--- a/nixbot/nixbot/memory.py
+++ b/nixbot/nixbot/memory.py
@@ -76,7 +76,7 @@ def calculate_eval_workers(
     if memory_info is None:
         memory_info = get_memory_info()
 
-    # ZFS ARC can shrink under pressure; treat 75% of it as reclaimable.
+    # ZFS ARC can shrink under pressure. Treat 75% of it as reclaimable.
     effective_available_memory = memory_info.available_memory_mib
     if memory_info.zfs_arc_used > 0:
         reclaimable_arc = int(memory_info.zfs_arc_used * 0.75)

--- a/nixbot/nixbot/migrations.py
+++ b/nixbot/nixbot/migrations.py
@@ -1,7 +1,7 @@
 """Schema migrations: versioned SQL scripts applied at startup.
 
 Scripts live in the `migrations/` package directory and are named
-`NNNN_description.sql`. Each script runs in its own transaction; the
+`NNNN_description.sql`. Each script runs in its own transaction. The
 whole run is guarded by a Postgres advisory lock so concurrent service
 starts cannot race. Applied versions are recorded in
 `schema_migrations`.
@@ -110,7 +110,7 @@ async def apply_migrations(dsn: str) -> None:
                     raise
                 await tx.commit()
         finally:
-            # A failed migration usually killed the connection too; the
+            # A failed migration usually killed the connection too. The
             # unlock error would replace the real failure. The lock is
             # session-scoped, so closing the connection releases it.
             try:

--- a/nixbot/nixbot/models.py
+++ b/nixbot/nixbot/models.py
@@ -36,7 +36,7 @@ class NixEvalJobSuccess(BaseModel):
     # nix-eval-jobs emits null output paths for impure and some
     # content-addressed derivations: it cannot know their store paths
     # without actually building them. Accept None so the whole eval step
-    # does not crash; downstream consumers already treat a missing
+    # does not crash. Downstream consumers already treat a missing
     # out path as "not statically known".
     outputs: dict[str, str | None]
     system: str

--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -10,7 +10,7 @@ only the worktree, the nix store, the gc-roots dir, the nix daemon
 socket, and an optional per-build repo-scoped credential file are
 mounted — never $CREDENTIALS_DIRECTORY. Network stays available for
 flake input fetching. The process is launched in a transient systemd
-scope with a cgroup memory limit; eval OOM is a permanent failure.
+scope with a cgroup memory limit. Eval OOM is a permanent failure.
 A semaphore caps concurrent evaluations (default 1).
 """
 
@@ -77,9 +77,9 @@ class EvalSettings:
     worker_count: int = 1
     max_memory_size_mib: int = 4096
     show_trace: bool = False
-    # bwrap sandbox; disable only in tests.
+    # bwrap sandbox. Disable only in tests.
     sandbox: bool = True
-    # Transient systemd scope with MemoryMax; needs a systemd session.
+    # Transient systemd scope with MemoryMax. Needs a systemd session.
     systemd_scope: bool = True
     # Repo-scoped credential file mounted as $HOME/.netrc in the sandbox.
     netrc_file: Path | None = None
@@ -101,7 +101,7 @@ def build_eval_command(
     flake = f"{branch_config.flake_dir}#{branch_config.attribute}"
     return [
         "nix-eval-jobs",
-        # The service drives nix entirely through flakes; on hosts where
+        # The service drives nix entirely through flakes. On hosts where
         # the system nix.conf hasn't enabled them (single-user installs,
         # containers) the eval would crash on the first --flake.
         "--option",
@@ -151,7 +151,7 @@ SANDBOX_ETC_PATHS = (
 
 def build_sandbox_command(worktree_path: Path, settings: EvalSettings) -> list[str]:
     """bwrap wrapper: worktree + nix store + gc-roots dir + daemon socket
-    + per-build credential file only; never $CREDENTIALS_DIRECTORY."""
+    + per-build credential file only. Never $CREDENTIALS_DIRECTORY."""
     cmd = [
         "bwrap",
         "--unshare-all",
@@ -175,7 +175,7 @@ def build_sandbox_command(worktree_path: Path, settings: EvalSettings) -> list[s
             "--ro-bind",
             str(settings.nix_daemon_socket),
             str(settings.nix_daemon_socket),
-            # The db bind is read-only; always go through the daemon.
+            # The db bind is read-only. Always go through the daemon.
             "--setenv",
             "NIX_REMOTE",
             "daemon",
@@ -211,7 +211,7 @@ def build_sandbox_command(worktree_path: Path, settings: EvalSettings) -> list[s
 
 async def systemd_scope_available() -> bool:
     """Whether transient scopes can be created (running as root or with a
-    user session); system users without one fall back to no scope."""
+    user session). System users without one fall back to no scope."""
     try:
         proc = await asyncio.create_subprocess_exec(
             "systemd-run",
@@ -459,7 +459,7 @@ def cgroup_oom_killed(eval_cgroup: Path | None) -> bool:
 
 def _kill_process_tree(proc: asyncio.subprocess.Process) -> None:
     """Kill the evaluator and its children (systemd-run/bwrap wrap the
-    real evaluator); the process group exists because the subprocess is
+    real evaluator). The process group exists because the subprocess is
     started with start_new_session=True."""
     with contextlib.suppress(ProcessLookupError):
         try:
@@ -476,7 +476,7 @@ class EvalRunner:
     ) -> None:
         self._semaphore = asyncio.Semaphore(concurrency)
         self.limiter = limiter
-        # Probed on first use; system users without a session can't
+        # Probed on first use. System users without a session can't
         # create transient scopes.
         self._systemd_scope_ok: bool | None = None
 

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -114,20 +114,20 @@ class Orchestrator:
     eval_runner: EvalRunnerLike
     executor: AttributeExecutor
     reporter: StatusReporter = field(default_factory=NullStatusReporter)
-    # Project id -> cache; scoped so one project's failures cannot
+    # Project id -> cache. Scoped so one project's failures cannot
     # affect another's builds.
     failed_build_cache: Callable[[int], FailedBuildCache] | None = None
     # build id -> cancel event, set by the cancellation manager.
     cancel_events: dict[int, asyncio.Event] = field(default_factory=dict)
     # (build id, attr) -> cancel event for a single queued/running
-    # attribute; registered for the lifetime of the executor job.
+    # attribute. Registered for the lifetime of the executor job.
     attr_cancel_events: dict[tuple[int, str], asyncio.Event] = field(
         default_factory=dict
     )
-    # Injectable for tests; defaults to the real implementations.
+    # Injectable for tests. Defaults to the real implementations.
     register_gcroot: GcrootRegistrar = gcroots.register_gcroot
     write_output_path: OutputWriter = outputs.write_output_path
-    # Store-path validity probe for eval reuse; injectable for tests.
+    # Store-path validity probe for eval reuse. Injectable for tests.
     check_store_paths: Callable[[list[str]], Awaitable[set[str]]] = (
         recovery.check_store_paths
     )
@@ -145,7 +145,7 @@ class Orchestrator:
     def reset_build_logs(self, build_id: int, attr: str | None) -> None:
         """Drop the previous run's log files when a build is reset to
         pending. A full restart (attr None) also re-runs effects, so it
-        clears the whole build log directory; a single-attribute restart
+        clears the whole build log directory. A single-attribute restart
         removes only that attribute's log."""
         if attr is None:
             shutil.rmtree(self._log_dir(build_id), ignore_errors=True)
@@ -323,13 +323,13 @@ class Orchestrator:
         worktree_path: Path,
         credentials: FetchCredentials | None = None,
     ) -> None:
-        """Evaluate and build; every attribute completion is one
+        """Evaluate and build. Every attribute completion is one
         transactional DB write, then the result is re-aggregated."""
         await build_run.run_build(self, event, build, worktree_path, credentials)
 
     async def refresh_schedules(self, event: ChangeEvent) -> None:
         """Queue `onSchedule` re-discovery after a successful
-        default-branch build; the service's scheduled-effects loop only
+        default-branch build. The service's scheduled-effects loop only
         sweeps what the executor stores."""
         if event.pr_number is not None or event.branch != event.repo.default_branch:
             return
@@ -347,7 +347,7 @@ class Orchestrator:
         credentials: FetchCredentials | None,
     ) -> AbstractAsyncContextManager[tuple[ChangeEvent, Path]]:
         """Event reconstruction plus a fresh worktree at the recorded
-        commit; shared by the rerun paths."""
+        commit. Shared by the rerun paths."""
         return rerun_exec.rerun_worktree(self, info, build, prefix, credentials)
 
     async def rerun_pending_attributes(
@@ -404,7 +404,7 @@ class Orchestrator:
 
     @asynccontextmanager
     async def open_log(self, build_id: int, key: str) -> AsyncIterator[LogWriter]:
-        """LogWriter registered for live streaming; closed and
+        """LogWriter registered for live streaming. Closed and
         unregistered on exit. Shared by attribute and effect runs."""
         path = log_path_for_key(self.config.state_dir, build_id, key)
         writer = LogWriter(path=path, size_limit=self.config.log_size_limit)
@@ -423,7 +423,7 @@ class Orchestrator:
         eval_success: bool | None = None,
     ) -> None:
         """Final status fan-out for second contexts attached to this
-        build; eval_success is None when no eval result exists."""
+        build. eval_success is None when no eval result exists."""
         await build_reuse.finish_linked(self, build, result, eval_success=eval_success)
 
     async def post_process_skipped(

--- a/nixbot/nixbot/outputs.py
+++ b/nixbot/nixbot/outputs.py
@@ -3,7 +3,7 @@
 For push events on branches with `updateOutputs`, the store path of
 each attribute result is written to
 <outputs_path>/<forge>/<owner>/<repo>/<branch>/<attr> (URL-quoted,
-traversal-safe; forge-scoped so the same owner/repo on two forges
+traversal-safe. Forge-scoped so the same owner/repo on two forges
 cannot overwrite each other) so external tooling (e.g. deploys, nginx autoindex) can find the
 latest outputs. Per-branch gating (`match_glob`/`update_outputs`/
 `register_gcroots`) lives in config.BranchConfigDict.

--- a/nixbot/nixbot/polling.py
+++ b/nixbot/nixbot/polling.py
@@ -80,7 +80,7 @@ class PollingService:
         self._tasks: list[asyncio.Task[None]] = []
 
     async def poll_repo_once(self, repo: PolledRepository) -> bool:
-        """Poll one repository; returns True when a new head was seen."""
+        """Poll one repository. Returns True when a new head was seen."""
         sha = await poll_head(repo)
         if sha is None or self._last_seen.get(repo.name) == sha:
             return False

--- a/nixbot/nixbot/proc.py
+++ b/nixbot/nixbot/proc.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from pathlib import Path
 
-# asyncio's StreamReader default; callers with long-line output (nix
+# asyncio's StreamReader default. Callers with long-line output (nix
 # build logs, deploy tooling) pass a larger limit.
 DEFAULT_STREAM_LIMIT = 2**16
 

--- a/nixbot/nixbot/reconcile.py
+++ b/nixbot/nixbot/reconcile.py
@@ -1,7 +1,7 @@
 """Startup reconciliation: after downtime, build the
 default-branch head and open-PR heads that have no build record yet.
 
-Runs after crash recovery; duplicates are resolved by the
+Runs after crash recovery. Duplicates are resolved by the
 supersede rules. "Built" means any build record exists for the head
 commit in that project, regardless of result — exact merge-tree
 checking happens once the orchestrator computes the tree.
@@ -37,12 +37,12 @@ class RemoteHead:
     pr_number: int | None = None
     pr_author: str | None = None
     base_sha: str | None = None
-    # Forge-clock PR update time; feeds the reconcile watermark.
+    # Forge-clock PR update time. Feeds the reconcile watermark.
     updated_at: datetime | None = None
 
 
 def max_pr_updated(heads: list[RemoteHead]) -> datetime | None:
-    """Newest PR update time seen; the next reconcile's watermark."""
+    """Newest PR update time seen. The next reconcile's watermark."""
     times = [h.updated_at for h in heads if h.updated_at is not None]
     return max(times) if times else None
 
@@ -103,7 +103,7 @@ async def github_heads(
             commit_sha=pull["head"]["sha"],
             pr_number=pull["number"],
             pr_author=f"github:{pull['user']['login']}",
-            # base.sha is frozen at PR creation; merge into the current
+            # base.sha is frozen at PR creation. Merge into the current
             # base branch tip instead (see webhooks._parse_pr_event).
             base_sha=f"refs/heads/{pull['base']['ref']}",
             updated_at=datetime.fromisoformat(pull["updated_at"]),
@@ -172,7 +172,7 @@ async def gitlab_heads(
     mr_url = f"{repo_url}/merge_requests?state=opened&per_page=100"
     if updated_since is not None:
         # updated_after is exclusive, but the watermark equals a seen
-        # MR's updated_at; back off one second to keep the boundary
+        # MR's updated_at. Back off one second to keep the boundary
         # inclusive like the other forges (is_built dedupes overlap).
         cutoff = (updated_since - timedelta(seconds=1)).isoformat()
         mr_url += f"&updated_after={quote(cutoff, safe='')}"
@@ -183,7 +183,7 @@ async def gitlab_heads(
             commit_sha=pull["sha"],
             pr_number=pull["iid"],
             pr_author=f"gitlab:{pull['author']['username']}",
-            # The MR API exposes no base sha; merge against the
+            # The MR API exposes no base sha. Merge against the
             # target branch ref instead.
             base_sha=f"refs/heads/{pull['target_branch']}",
             updated_at=datetime.fromisoformat(pull["updated_at"]),

--- a/nixbot/nixbot/recovery.py
+++ b/nixbot/nixbot/recovery.py
@@ -2,7 +2,7 @@
 
 Recovery resumes rather than restarts: attributes already terminal in
 the database are skipped (attribute completion is one transactional
-write, so the database is trustworthy); pending attributes are first
+write, so the database is trustworthy). Pending attributes are first
 re-checked against the nix store by reading its sqlite database
 directly (see check_store_paths) — already-valid out paths complete
 without a rebuild — and only the rest re-run.
@@ -11,11 +11,11 @@ automatically.
 
 DB outage policy: when the database is unreachable the affected
 operation raises and the service restarts via systemd. Webhook
-fail-fast lives in ingestion; the health check backs the
+fail-fast lives in ingestion. The health check backs the
 HTTP health endpoint.
 
 Retention: builds older than the configured horizon are deleted along
-with their log files; stale workdirs are swept via RepoManager.cleanup.
+with their log files. Stale workdirs are swept via RepoManager.cleanup.
 """
 
 from __future__ import annotations
@@ -95,7 +95,7 @@ async def find_unfinished_builds(
         pending_jobs = []
         for attr in attrs:
             # 'building' rows are attributes that were running when the
-            # service died; they must resume like pending ones.
+            # service died. They must resume like pending ones.
             if attr.status not in ("pending", "building"):
                 continue  # terminal in DB: never redone
             if not attr.drv_path:
@@ -186,7 +186,7 @@ async def settle_already_built(
     path_checker: Callable[[list[str]], Awaitable[set[str]]] = check_store_paths,
 ) -> tuple[list[NixEvalJobSuccess], list[tuple[str, str]]]:
     """Complete pending attributes whose out paths already exist in the
-    store; return (jobs that still need building, settled (attr,
+    store. Return (jobs that still need building, settled (attr,
     out_path) pairs for gcroots/outputs post-processing)."""
     valid = await path_checker(
         [p for job in build.pending_jobs if (p := job.outputs.get("out"))]

--- a/nixbot/nixbot/redact.py
+++ b/nixbot/nixbot/redact.py
@@ -4,7 +4,7 @@ served in the web UI, or posted to a forge.
 We only redact secrets we control (deploy secret values, git and task
 tokens): matching them literally catches any forge's token by value and
 never touches unrelated output. Token-shape patterns are deliberately
-avoided; they cannot cover Gitea's prefix-less tokens and risk masking
+avoided. They cannot cover Gitea's prefix-less tokens and risk masking
 commit SHAs and other legitimate text.
 """
 
@@ -23,7 +23,7 @@ _MIN_LITERAL_LEN = 6
 
 def secret_literals(*values: str | None) -> list[bytes]:
     """Literal secrets to redact, including the leaf string values of
-    any JSON secret payload; too-short values are dropped."""
+    any JSON secret payload. Too-short values are dropped."""
     found: set[str] = set()
     for value in values:
         if value is None:

--- a/nixbot/nixbot/repo_config.py
+++ b/nixbot/nixbot/repo_config.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-# Preference order; the legacy buildbot-nix name keeps repositories
+# Preference order. The legacy buildbot-nix name keeps repositories
 # migrating from buildbot-nix working without a rename.
 CONFIG_FILENAMES = ("nixbot.toml", "buildbot-nix.toml")
 
@@ -50,7 +50,7 @@ class BranchConfig(BaseModel):
     @classmethod
     def load(cls, repo_root: Path) -> Self:
         """Read `nixbot.toml` (or the legacy `buildbot-nix.toml`)
-        from a checkout; defaults on absence or invalid content
+        from a checkout. Defaults on absence or invalid content
         (matching the buildbot-era behavior)."""
         for filename in CONFIG_FILENAMES:
             try:

--- a/nixbot/nixbot/repos.py
+++ b/nixbot/nixbot/repos.py
@@ -1,8 +1,8 @@
 """Project store: DB-backed enablement keyed by stable forge repo ID.
 
-Discovery (forge/) feeds repos in; rows are upserted on
+Discovery (forge/) feeds repos in. Rows are upserted on
 (forge, forge_repo_id) so renames/transfers keep history and the
-enablement flag. Enablement is toggled by admins in the web UI; the
+enablement flag. Enablement is toggled by admins in the web UI. The
 legacy topic filter is imported once, on the first startup with an
 empty projects table.
 """
@@ -91,7 +91,7 @@ class RepoStore:
         """Upsert pull-based repositories as (name, url, default_branch).
 
         Listing a repository in the static config is the enablement
-        decision, so new rows start enabled; the admin toggle is
+        decision, so new rows start enabled. The admin toggle is
         preserved on conflict."""
         if not repos:
             return
@@ -111,7 +111,7 @@ class RepoStore:
         self, forge: str, forge_repo_ids: Sequence[str]
     ) -> None:
         """Delete disabled repos of `forge` that discovery no longer
-        returned; enabled projects keep their build history."""
+        returned. Enabled projects keep their build history."""
         await q.prune_missing_disabled_projects(
             self.pool, forge=forge, forge_repo_ids=list(forge_repo_ids)
         )

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -39,7 +39,7 @@ async def rerun_worktree(
     credentials: FetchCredentials | None,
 ) -> AsyncIterator[tuple[ChangeEvent, Path]]:
     """Event reconstruction plus a fresh worktree at the recorded
-    commit; shared by the rerun paths."""
+    commit. Shared by the rerun paths."""
     event = event_for_build(info, build)
     # PR head commits are only reachable via the PR refs.
     refspecs = ["+refs/heads/*:refs/heads/*"]
@@ -69,10 +69,10 @@ async def rerun_pending_attributes(
     the stored eval results — no re-evaluation (attribute restarts
     and crash recovery)."""
     if build.id in o.cancel_events:
-        # Already running; a concurrent rerun would double-write
+        # Already running. A concurrent rerun would double-write
         # attribute completions.
         return
-    # Claim the slot before the first await; concurrent reruns
+    # Claim the slot before the first await. Concurrent reruns
     # must not pass the guard together.
     cancel_event = o.cancel_events[build.id] = asyncio.Event()
     try:
@@ -95,7 +95,7 @@ async def rerun_pending_attributes(
             pending_jobs = [
                 job for job in pending_jobs if job.system in o.config.build_systems
             ]
-        # No re-eval happens on this path; go straight to building.
+        # No re-eval happens on this path. Go straight to building.
         await db.set_build_status(o.pool, build.id, BuildStatus.BUILDING)
         # Register so supersede/PR-close cancellation also covers
         # recovered and restarted builds.
@@ -124,7 +124,7 @@ async def rerun_pending_attributes(
                 cache_failures=False,
             )
             if status == BuildStatus.SUCCEEDED:
-                # Crash recovery before effects started; the
+                # Crash recovery before effects started. The
                 # started-flag keeps already-deployed builds from
                 # re-deploying.
                 await o.maybe_run_effects(event, build, worktree_path, credentials)

--- a/nixbot/nixbot/restart_dispatch.py
+++ b/nixbot/nixbot/restart_dispatch.py
@@ -1,7 +1,7 @@
 """Build rerun paths driven from the work queue: resuming pending
 attributes from stored eval results, falling back to re-evaluation,
 and effects-only restarts. State resets happen synchronously in the
-service; this module only re-executes.
+service. This module only re-executes.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Pause before handing a rerun of a still-unwinding build back to
-# the work queue; bounds the retry cadence without holding the
+# the work queue. Bounds the retry cadence without holding the
 # dedup key indefinitely.
 UNWIND_RETRY_SECONDS = 0.5
 
@@ -134,7 +134,7 @@ async def _reeval(
             worktree_path,
         ):
             # Stale rows (e.g. failed_eval with NULL drv_path) would
-            # wedge the aggregate; the re-eval rewrites them. Finished
+            # wedge the aggregate. The re-eval rewrites them. Finished
             # rows with a drv_path are kept: their results are valid
             # and the re-eval skips already-built attributes.
             # The flag must drop before the rows: a concurrent build
@@ -161,7 +161,7 @@ async def change_event_for(
 
 
 async def _report_interrupted(s: CIService, resumable: ResumableBuild) -> None:
-    """Post the failure to the forge; otherwise the commit status
+    """Post the failure to the forge. Otherwise the commit status
     stays pending forever after an interrupted evaluation."""
     build = await builds_q.get_build(s.orchestrator.pool, id_=resumable.build_id)
     event = await change_event_for(s, resumable)

--- a/nixbot/nixbot/schedule_runner.py
+++ b/nixbot/nixbot/schedule_runner.py
@@ -105,13 +105,13 @@ async def run_scheduled(
     store = ScheduledEffectsStore(s.pool)
     project = await s.repo_store.by_id(due.project_id)
     if project is None or not project.enabled:
-        # Manual runs pass a pre-created row; close it instead of
+        # Manual runs pass a pre-created row. Close it instead of
         # leaving it stuck running.
         if run_id is not None:
             await store.finish_run(run_id, success=False, error="project disabled")
         return
     info = repo_info(project)
-    # Manual runs pre-create the row; the sweep loop does not.
+    # Manual runs pre-create the row. The sweep loop does not.
     if run_id is None:
         run_id = await store.start_run(due)
     try:

--- a/nixbot/nixbot/schedules.py
+++ b/nixbot/nixbot/schedules.py
@@ -2,10 +2,10 @@
 
 Ported from nix_eval.py:ScheduledEffectsEvaluateCommand:
 on each successful default-branch build the orchestrator discovers
-schedules via `nixbot-effects list-schedules` and persists them; a
+schedules via `nixbot-effects list-schedules` and persists them. A
 periodic loop runs due effects via `nixbot-effects run-scheduled`.
 
-Cron-like `when` specs; defaults resolve in
+Cron-like `when` specs. Defaults resolve in
 config.ScheduleWhen.resolved. All times are UTC.
 """
 
@@ -247,7 +247,7 @@ class ScheduledEffectsStore:
                 when = ScheduleWhen.model_validate(json.loads(row.when_spec))
                 occurrence = due_occurrence(when, row.schedule_name, now)
             except Exception:
-                # when-specs are repo-controlled; one malformed spec
+                # when-specs are repo-controlled. One malformed spec
                 # must not abort the sweep for all other projects.
                 logger.exception(
                     "invalid schedule spec, skipping",

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 
 _STATIC_CREDENTIALS = StaticCredentialsProvider()
 
-# Repo metadata rarely changes; the UI refresh button covers the
+# Repo metadata rarely changes. The UI refresh button covers the
 # "I just created a repo" case without waiting for the next tick.
 DISCOVERY_INTERVAL = 60 * 60
 REFRESH_COOLDOWN = 60
@@ -98,7 +98,7 @@ MAX_REPORT_DELAY_SECONDS = 3600
 
 def _report_payload(build_id: int, attempt: int, error: Exception) -> dict[str, Any]:
     payload: dict[str, Any] = {"build_id": build_id, "attempt": attempt}
-    # Forges send Retry-After on rate limits; honoring it is required
+    # Forges send Retry-After on rate limits. Honoring it is required
     # (e.g. GitHub secondary limits escalate when ignored).
     retry_after = getattr(error, "retry_after", None)
     if retry_after is not None:
@@ -200,7 +200,7 @@ class CIService:
     # garbage-collected mid-flight.
     _tasks: set[asyncio.Task] = field(default_factory=set)
     # Discovery must not run concurrently (upserts, webhook
-    # registration); the timestamp debounces the UI refresh button,
+    # registration). The timestamp debounces the UI refresh button,
     # which any logged-in user can press.
     _discovery_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _last_discovery: float = 0.0
@@ -260,7 +260,7 @@ class CIService:
 
     async def _submit_rerequest(self, event: CheckRerequested) -> None:
         """GitHub "Re-run" button → existing restart paths. Per-attr
-        runs restart that attr only; summary runs and check_suite
+        runs restart that attr only. Summary runs and check_suite
         restart the whole build."""
         project = await self.repo_store.by_forge_id(event.forge, event.forge_repo_id)
         if project is None:
@@ -269,7 +269,7 @@ class CIService:
         if build_id is not None:
             build = await builds_q.get_build(self.pool, id_=build_id)
             # external_id is attacker-influenced (set by whichever app
-            # created the run); never restart another project's build.
+            # created the run). Never restart another project's build.
             if build is None or build.project_id != project.id:
                 build_id = None
         if build_id is None:
@@ -288,7 +288,7 @@ class CIService:
         await self.restart_build(build_id)
 
     async def _submit_change(self, change: ChangeRequest) -> None:
-        """Enqueue only; the dispatcher runs _process_change. The key
+        """Enqueue only. The dispatcher runs _process_change. The key
         serializes deliveries of one commit, not of one branch:
         supersede needs newer commits to run concurrently."""
         await self.enqueue_work(
@@ -346,12 +346,12 @@ class CIService:
 
     async def _restart(self, build_id: int, *, attr: str | None) -> None:
         # Reset synchronously so the build row is the source of truth
-        # for the UI/recovery; the queue item is only a wake-up. Drop
+        # for the UI/recovery. The queue item is only a wake-up. Drop
         # the previous run's logs here too, so the pending row does not
         # show stale output until the rebuild starts.
         await q.reset_build_for_restart(self.pool, build_id=build_id, attr=attr)
         self.orchestrator.reset_build_logs(build_id, attr)
-        # Flip the forge checks to pending now; the async rerun only
+        # Flip the forge checks to pending now. The async rerun only
         # posts the terminal status, possibly much later.
         build = await builds_q.get_build(self.pool, id_=build_id)
         project = (
@@ -441,7 +441,7 @@ class CIService:
         elif item.kind == "rerun":
             # Resume pending attributes (restart and crash recovery).
             if await restart_dispatch.rerun(self, payload["build_id"]):
-                # Previous run still unwinding; retry, don't drop.
+                # Previous run still unwinding. Retry, don't drop.
                 await self.enqueue_work("rerun", item.dedup_key, payload)
         elif item.kind == "effects":
             await restart_dispatch.restart_effects(self, payload["build_id"])
@@ -494,7 +494,7 @@ class CIService:
             # competing attempt-1 item on failure.
             reporter = reporter.inner
         try:
-            # Empty results: only the summary is re-posted; per-attribute
+            # Empty results: only the summary is re-posted. Per-attribute
             # statuses were already posted (or cached) inline.
             await reporter.build_finished(
                 event,
@@ -600,7 +600,7 @@ class CIService:
         cancelled = await q.cancel_attribute(self.pool, build_id=build_id, attr=attr)
         if cancelled != 1:
             return
-        # No running pipeline re-aggregates for us; without this the
+        # No running pipeline re-aggregates for us. Without this the
         # build stays non-terminal forever once all rows are settled.
         status, generation = await db.aggregate_build(self.pool, build_id)
         if status in BuildStatus.TERMINAL:
@@ -623,7 +623,7 @@ class CIService:
         self, build_id: int, status: str, generation: int
     ) -> None:
         """Post the terminal forge status for a build settled outside a
-        running pipeline; otherwise the commit status stays pending
+        running pipeline. Otherwise the commit status stays pending
         forever."""
         build = await builds_q.get_build(self.orchestrator.pool, id_=build_id)
         if build is None:
@@ -648,7 +648,7 @@ class CIService:
                 if not reconciled:
                     # Startup reconciliation needs discovery first
                     # (GitHub installation tokens are learned during
-                    # discovery); retried until one pass succeeds so a
+                    # discovery). Retried until one pass succeeds so a
                     # forge outage at startup does not skip it.
                     await self.reconcile_once()
                     reconciled = True

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -6,7 +6,7 @@ commit-status *contexts* share the required-checks namespace, so
 branch protection rules are unaffected.
 
 Combined per-phase contexts are `nixbot/nix-eval` (warning count
-appended to the description) and `nixbot/nix-build`; the prefix is
+appended to the description) and `nixbot/nix-build`. The prefix is
 configurable via status_context_prefix, e.g. "buildbot" to keep
 branch protection rules from a buildbot-nix deployment working.
 Per-attribute failure statuses (`nixbot/nix-build
@@ -57,7 +57,7 @@ CHECK_RUN_TEXT_LIMIT = 60_000
 
 logger = logging.getLogger(__name__)
 
-# Cap on remembered (build id -> posted generation) entries; one entry
+# Cap on remembered (build id -> posted generation) entries. One entry
 # per build forever would be a slow leak in a long-lived process.
 POSTED_GENERATIONS_MAX = 1024
 
@@ -80,7 +80,7 @@ class StatusState(StrEnum):
 
 
 class StatusPostError(Exception):
-    """HTTP-level status post failure; retry_after carries the forge's
+    """HTTP-level status post failure. retry_after carries the forge's
     Retry-After / rate-limit-reset hint in seconds, if any."""
 
     def __init__(self, message: str, retry_after: float | None = None) -> None:
@@ -89,7 +89,7 @@ class StatusPostError(Exception):
 
 
 class CheckPermissionError(ForgeError):
-    """The GitHub App lacks Checks: write; latched so we stop
+    """The GitHub App lacks Checks: write. Latched so we stop
     hammering the API until the operator fixes the permission."""
 
 
@@ -127,7 +127,7 @@ class CheckRunIds(Protocol):
 
 
 class CheckRunStore:
-    """(project, sha, name) → GitHub check-run id; lets the poster
+    """(project, sha, name) → GitHub check-run id. Lets the poster
     PATCH the existing run instead of stacking duplicates on a SHA."""
 
     def __init__(self, pool: asyncpg.Pool) -> None:
@@ -163,7 +163,7 @@ _CHECK_RUN_FIELDS: dict[StatusState, tuple[str, str | None]] = {
 
 
 def _check_run_output(context: str, summary: str, text: str | None) -> dict[str, str]:
-    # The full context repeats the repo path; keep the title short.
+    # The full context repeats the repo path. Keep the title short.
     output = {"title": context.split(" ", 1)[0], "summary": summary}
     if text:
         if len(text) > CHECK_RUN_TEXT_LIMIT:
@@ -235,7 +235,7 @@ class GitHubCheckRunPoster:
             response = await self.client.http.patch(
                 f"{base}/{run_id}", headers=headers, json=body
             )
-            # The DB row can outlive the GitHub run; recreate instead
+            # The DB row can outlive the GitHub run. Recreate instead
             # of retrying the terminal summary forever.
             if response.status_code not in (httpx.codes.NOT_FOUND, httpx.codes.GONE):
                 _raise_for_check_run(response, f"{owner}/{repo}")
@@ -277,7 +277,7 @@ class GiteaStatusPoster:
 
 
 class GitlabStatusPoster:
-    # GitLab has no "error" state; both map to failed.
+    # GitLab has no "error" state. Both map to failed.
     _STATES: ClassVar[dict[StatusState, str]] = {
         StatusState.pending: "pending",
         StatusState.success: "success",
@@ -438,7 +438,7 @@ class ForgeStatusReporter:
                 context,
                 state,
                 # Descriptions may carry failure excerpts with raw ANSI
-                # colors (kept for the web UI); forges show them verbatim.
+                # colors (kept for the web UI). Forges show them verbatim.
                 strip_ansi(description),
                 self.build_url(event, build),
                 project_id=event.repo.id,
@@ -477,7 +477,7 @@ class ForgeStatusReporter:
     async def eval_finished(
         self, event: ChangeEvent, build: BuildRecord, report: EvalReport
     ) -> None:
-        # Failed evals show the error tail; successful ones the warnings.
+        # Failed evals show the error tail. Successful ones the warnings.
         if not report.success and report.error:
             text: str | None = _fence(report.error)
         elif report.warnings:
@@ -507,7 +507,7 @@ class ForgeStatusReporter:
             )
 
     async def eval_cancelled(self, event: ChangeEvent, build: BuildRecord) -> None:
-        """Resolve the pending eval context; see the orchestrator's
+        """Resolve the pending eval context. See the orchestrator's
         cancel path."""
         await self._post(
             event,
@@ -617,7 +617,7 @@ class ForgeStatusReporter:
         self, event: ChangeEvent, build: BuildRecord, attr: str | None
     ) -> None:
         """Flip the restarted checks to pending before the async rebuild
-        starts; force_new so GitHub renders them as re-running."""
+        starts. force_new so GitHub renders them as re-running."""
         if attr is None:
             await self._post(
                 event,
@@ -659,7 +659,7 @@ class ForgeStatusReporter:
         results: list[AttributeResult],
         attr_prefix: str,
     ) -> dict[str, int]:
-        """Per-attribute failure statuses and success flips; returns
+        """Per-attribute failure statuses and success flips. Returns
         failed/succeeded counts over `results`."""
         revision = event.commit_sha
         previously_failed = await self.failed_statuses.get_failed(revision)
@@ -727,7 +727,7 @@ class ForgeStatusReporter:
             description = f"{counts['succeeded']} attributes built"
         elif status == "cancelled":
             state = StatusState.error
-            # Attribute-level cancels aggregate like failures; only a
+            # Attribute-level cancels aggregate like failures. Only a
             # build-level cancel (no attribute info at all) was
             # superseded by a newer build.
             parts = [
@@ -758,7 +758,7 @@ def _fence(text: str) -> str:
     return f"```\n{strip_ansi(text)}\n```"
 
 
-# Flat/effect excerpts prefix lines with "name> "; structured failures
+# Flat/effect excerpts prefix lines with "name> ". Structured failures
 # skip this path entirely (they carry a BuildFailure).
 _DRV_PREFIX = re.compile(r"^[^\s>]+> +")
 
@@ -826,7 +826,7 @@ def _build_plan(
         header = f"Building {len(attrs)} attribute(s):"
         head, sep, trunc = "| attribute | raw |", "| --- | --- |", "| [all]({0}) |"
     else:
-        # Locally-skipped attributes were not built here; drop them.
+        # Locally-skipped attributes were not built here. Drop them.
         attrs = [a for a in attrs if statuses.get(a) != "skipped_local"]
         # Group by status (see _STATUS_ORDER), then alphabetically within
         # each status.
@@ -841,7 +841,7 @@ def _build_plan(
     if not attrs:
         return None
     lines = [header, "", head, sep]
-    # +1 per line for the newline join() inserts; undercounting lets the
+    # +1 per line for the newline join() inserts. Undercounting lets the
     # joined text exceed the budget, and _check_run_output then chops it
     # mid-row into invalid markdown.
     used = sum(len(line) + 1 for line in lines)

--- a/nixbot/nixbot/tests/e2e/support.py
+++ b/nixbot/nixbot/tests/e2e/support.py
@@ -51,7 +51,7 @@ def _seed_container(*, failed: bool) -> bytes:
 
 
 # A realistic multi-line nix eval trace (with ANSI colors) for the
-# failed_eval attribute; exercises the viewer/raw eval-error fallback.
+# failed_eval attribute. Exercises the viewer/raw eval-error fallback.
 _EVAL_ERROR = """\
 \x1b[31;1merror:\x1b[0m attribute 'x86_64-linux.evalfail' failed to evaluate
 

--- a/nixbot/nixbot/tests/e2e/test_browse.py
+++ b/nixbot/nixbot/tests/e2e/test_browse.py
@@ -26,7 +26,7 @@ def test_navigate_sidebar_to_failed_build(page: Page) -> None:
 
     page.locator('a[href$="/builds/2"]').first.click()
     page.wait_for_url("**/builds/2")
-    # Content semantics live in the httpx test_build_page; expanding
+    # Content semantics live in the httpx test_build_page. Expanding
     # the collapsed succeeded group lazy-loads its rows.
     assert "x86_64-linux.ok" not in page.content()
     page.get_by_text("2 succeeded").click()
@@ -43,7 +43,7 @@ def test_build_prev_next_navigation(page: Page) -> None:
 
 def test_structured_log_viewer(page: Page) -> None:
     page.goto("/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad")
-    # Failing derivation card is open with inline phase dividers; log rows
+    # Failing derivation card is open with inline phase dividers. Log rows
     # load lazily from /drv/{idx}.
     card = page.locator('.log-card[data-idx="0"]')
     card.get_by_text("hello-2.12").wait_for()
@@ -65,7 +65,7 @@ def test_structured_log_viewer(page: Page) -> None:
     assert down > 0
     seps.nth(1).locator(".phase-prev").click()
     assert lines.evaluate("el => el.scrollTop") < down
-    # Past the last phase falls through to the bottom; before the first
+    # Past the last phase falls through to the bottom. Before the first
     # falls through to the top.
     lines.evaluate("el => el.scrollTop = 0")
     seps.nth(1).locator(".phase-next").click()
@@ -199,7 +199,7 @@ def test_attribute_search_filters_groups(page: Page) -> None:
 
 
 def test_groups_keep_identity_when_one_appears(page: Page, server: TestServer) -> None:
-    """A new group shifts the list; positional morphing used to merge
+    """A new group shifts the list. Positional morphing used to merge
     one group's rows into another."""
 
     async def seed() -> None:

--- a/nixbot/nixbot/tests/e2e/test_live.py
+++ b/nixbot/nixbot/tests/e2e/test_live.py
@@ -1,7 +1,7 @@
 """Live behavior: SSE-driven attribute refresh and log streaming.
 
 These exercise the JavaScript in base.html/log.html against a real
-browser; the httpx web tests can only assert the markers exist.
+browser. The httpx web tests can only assert the markers exist.
 """
 
 from __future__ import annotations
@@ -27,7 +27,7 @@ def test_attribute_table_refreshes_while_building(
     page: Page, server: TestServer
 ) -> None:
     page.goto("/repos/github/acme/widget/builds/3")
-    # Succeeded attributes are collapsed; expand to lazy-load the rows.
+    # Succeeded attributes are collapsed. Expand to lazy-load the rows.
     page.get_by_text("succeeded", exact=False).first.click()
     row = page.locator('tr[data-attr="aarch64-linux.other"]')
     row.locator(".status-icon.succeeded").wait_for()
@@ -44,7 +44,7 @@ def test_attribute_table_refreshes_while_building(
         )
 
     server.run(fail_attribute())
-    # The status event refreshes the page; the failed attribute moves
+    # The status event refreshes the page. The failed attribute moves
     # into the inline failure table.
     row.locator(".status-icon.failed").wait_for(timeout=15_000)
     assert "flipped by e2e test" in page.content()
@@ -98,7 +98,7 @@ def test_log_page_streams_live_output(page: Page, server: TestServer) -> None:
         server.run(emit("second line arrives later"))
         lines.get_by_text("second line arrives later").wait_for(timeout=15_000)
 
-        # close() ends the SSE stream; streamed content stays visible.
+        # close() ends the SSE stream. Streamed content stays visible.
         server.run(finish())
         card = page.locator(".log-card", has_text="hello-2.12")
         assert "hello from the build" in card.inner_text()

--- a/nixbot/nixbot/tests/support.py
+++ b/nixbot/nixbot/tests/support.py
@@ -299,7 +299,7 @@ async def insert_project(  # noqa: PLR0913
     url: str = "u",
     private: bool = False,
 ) -> int:
-    """An enabled projects row; idempotent on (forge, forge_repo_id)."""
+    """An enabled projects row. Idempotent on (forge, forge_repo_id)."""
     return await pool.fetchval(
         """
         INSERT INTO projects (forge, forge_repo_id, owner, name,

--- a/nixbot/nixbot/tests/test_auth.py
+++ b/nixbot/nixbot/tests/test_auth.py
@@ -147,7 +147,7 @@ def test_signing_key_file_permissions(tmp_path: Path) -> None:
     load_signing_keys(tmp_path)
     assert (tmp_path / "session-key").stat().st_mode & 0o777 == 0o600
     rotate_signing_key(tmp_path)
-    # The previous key still verifies sessions; must not be world-readable.
+    # The previous key still verifies sessions. Must not be world-readable.
     assert (tmp_path / "session-key.previous").stat().st_mode & 0o777 == 0o600
 
 
@@ -232,7 +232,7 @@ async def test_oauth_login_flow() -> None:
         assert session_user is not None
         assert session_user.qualified == ALICE.qualified
         assert session_user.avatar_url == "https://avatars.test/alice"
-        # The forge token lives server-side; the cookie only carries
+        # The forge token lives server-side. The cookie only carries
         # an opaque session id.
         payload = signer.verify(session)
         assert payload is not None
@@ -272,7 +272,7 @@ async def test_oauth_login_flow() -> None:
 
 async def test_forge_token_lifetime_capped_by_expires_in() -> None:
     """Gitea access tokens expire after ~1h while the session lives
-    30 days; the stored forge token must expire with the token, not
+    30 days. The stored forge token must expire with the token, not
     the session, so visibility falls back to public instead of
     re-firing failing forge calls."""
     provider = github_oauth("cid", "csecret")
@@ -313,7 +313,7 @@ async def test_forge_token_lifetime_capped_by_expires_in() -> None:
 
 
 async def test_callback_stores_refresh_token() -> None:
-    """Gitea returns a refresh token; it must be persisted with the
+    """Gitea returns a refresh token. It must be persisted with the
     provider name so the ~1h access token can be renewed later."""
     provider = gitea_oauth("https://gitea.test", "cid", "cs")
     vault = DictVault()
@@ -371,7 +371,7 @@ class ExpiringVault(DictVault):
 
 async def test_refresher_renews_expired_access_token() -> None:
     """Regression for #81: the Gitea access token dies after ~1h while
-    the session cookie lives 30 days; the refresher must renew it via
+    the session cookie lives 30 days. The refresher must renew it via
     the refresh token instead of degrading to public visibility."""
     provider = gitea_oauth("https://gitea.test", "cid", "cs")
     calls: list[dict[str, str]] = []
@@ -470,7 +470,7 @@ async def test_concurrent_logins_do_not_clobber_oauth_state() -> None:
 
 async def test_oauth_callback_handles_token_exchange_errors() -> None:
     """GitHub returns expired/reused-code errors as HTTP 200 with an
-    error body; the callback must answer 403, not crash with a 500."""
+    error body. The callback must answer 403, not crash with a 500."""
     provider = github_oauth("cid", "csecret")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -540,7 +540,7 @@ def test_github_oauth_scope_and_enterprise_urls() -> None:
     default = github_oauth("cid", "cs")
     assert default.scope.split() == ["read:user"]
     # Private-repo visibility needs "repo" (GitHub has no read-only
-    # repo scope); explicit opt-in.
+    # repo scope). Explicit opt-in.
     private = github_oauth("cid", "cs", private_repo_scope=True)
     assert private.scope.split() == ["read:user", "repo"]
     assert default.authorize_url == "https://github.com/login/oauth/authorize"
@@ -592,7 +592,7 @@ def test_gitea_oauth_urls() -> None:
 
 async def test_oidc_exchange_uses_basic_auth() -> None:
     """OIDC servers only have to support client_secret_basic (RFC
-    6749 section 2.3.1); authelia rejects body credentials with 401."""
+    6749 section 2.3.1). Authelia rejects body credentials with 401."""
     seen: dict[str, str] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -630,7 +630,7 @@ async def test_oidc_exchange_uses_basic_auth() -> None:
 
 async def test_oidc_provider_honors_advertised_auth_methods() -> None:
     """A provider that only offers client_secret_post (e.g. older
-    PocketID) gets body credentials; everyone else gets basic."""
+    PocketID) gets body credentials. Everyone else gets basic."""
 
     def discovery(methods: list[str] | None) -> httpx.MockTransport:
         doc: dict[str, object] = {
@@ -694,7 +694,7 @@ def test_can_view_private_per_repo_precedence() -> None:
 
 
 def test_relevant_groups_keeps_only_rule_groups() -> None:
-    """LDAP users can be in dozens of groups; a signed cookie past
+    """LDAP users can be in dozens of groups. A signed cookie past
     ~4KB hits header limits, so the session only carries groups that
     a viewer rule can actually match."""
     viewers = {

--- a/nixbot/nixbot/tests/test_bootstrap.py
+++ b/nixbot/nixbot/tests/test_bootstrap.py
@@ -119,7 +119,7 @@ def test_socket_activation_overrides_listeners(
 
 
 async def test_lifespan_runs_once_with_two_listeners(tmp_path: Path) -> None:
-    """Two uvicorn servers share one app; each running the ASGI
+    """Two uvicorn servers share one app. Each running the ASGI
     lifespan would start the app twice (duplicate LISTEN connection,
     double SSE event delivery)."""
     starts: list[str] = []
@@ -134,7 +134,7 @@ async def test_lifespan_runs_once_with_two_listeners(tmp_path: Path) -> None:
             stops.append("x")
 
     app = FastAPI(lifespan=lifespan)
-    # AF_UNIX paths cap at ~107 bytes; xdist's nested tmp_path easily
+    # AF_UNIX paths cap at ~107 bytes. Xdist's nested tmp_path easily
     # exceeds that, so bind under a short tempdir.
     sock_dir = Path(tempfile.mkdtemp(prefix="nb-"))
     sock = sock_dir / "web.sock"

--- a/nixbot/nixbot/tests/test_branch_config.py
+++ b/nixbot/nixbot/tests/test_branch_config.py
@@ -1,7 +1,7 @@
 """Branch config lookup with multiple matching globs.
 
 A branch may match several configured globs (e.g. "*" and
-"release-*"); merging their settings must not raise just because the
+"release-*"). Merging their settings must not raise just because the
 globs differ -- otherwise every webhook for such a branch 500s.
 """
 

--- a/nixbot/nixbot/tests/test_build_scheduler.py
+++ b/nixbot/nixbot/tests/test_build_scheduler.py
@@ -30,7 +30,7 @@ SYSTEM = "x86_64-linux"
 
 
 class FakeExecutor:
-    """Records build order; per-attr outcomes configurable."""
+    """Records build order. Per-attr outcomes configurable."""
 
     def __init__(self, outcomes: dict[str, BuildOutcome] | None = None) -> None:
         self.outcomes = outcomes or {}
@@ -238,7 +238,7 @@ async def test_mixed_eval_results_independent() -> None:
 
 
 async def test_skipped_local_frees_dependents_immediately() -> None:
-    # parent is already in the local store (skipped); its dependent must
+    # parent is already in the local store (skipped). Its dependent must
     # be dispatched right away, not only after the unrelated running
     # build finishes.
     parent = mk_job("parent", cache_status=CacheStatus.local)
@@ -358,7 +358,7 @@ async def test_streaming_builds_start_before_eval_finishes() -> None:
 
 async def test_streaming_dependency_across_batches() -> None:
     # A job arriving in a later batch can depend on one from an
-    # earlier batch that already finished; it must still build.
+    # earlier batch that already finished. It must still build.
     async def main() -> None:
         executor = FakeExecutor()
         scheduler = JobScheduler(executor, [SYSTEM])
@@ -448,7 +448,7 @@ async def test_streaming_batch_order_does_not_leak_failed_dependency() -> None:
         await queue.put([mk_job("f")])
         run_task = asyncio.create_task(scheduler.run_incremental(queue))
         await asyncio.wait_for(dep_failed.wait(), timeout=5)
-        # "top" precedes "mid" in the batch; only "mid" depends on the
+        # "top" precedes "mid" in the batch. Only "mid" depends on the
         # failed job directly.
         await queue.put([mk_job("top", deps=["mid"]), mk_job("mid", deps=["f"])])
         await queue.put(None)
@@ -495,7 +495,7 @@ async def test_streaming_pending_dependent_fails_when_late_dep_arrives_failed() 
         await queue.put([mk_job("top", deps=["r", "a"])])
         await queue.put([mk_job("a", deps=["f"])])
         await queue.put(None)
-        # "top" must settle while "r" still runs; only then release.
+        # "top" must settle while "r" still runs. Only then release.
         await asyncio.wait_for(a_settled.wait(), timeout=5)
         release_r.set()
         result = await asyncio.wait_for(run_task, timeout=5)

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -905,7 +905,7 @@ async def test_recovery_reports_interrupted_effects(
     postgres_dsn: str, tmp_path: Path
 ) -> None:
     """An effect left running by a crash is settled failed but never
-    re-runs; recovery must post that failure so the check run does not
+    re-runs. Recovery must post that failure so the check run does not
     stay pending forever (issue #58)."""
     config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
@@ -966,7 +966,7 @@ async def test_work_dispatch(postgres_dsn: str, tmp_path: Path) -> None:
     service, _app = await build_service(config)
     pool = service.pool
     try:
-        # Scheduled payload roundtrip; the unknown project makes
+        # Scheduled payload roundtrip. The unknown project makes
         # execution a no-op, but parsing must succeed.
         await service.enqueue_work(
             "scheduled",
@@ -1026,7 +1026,7 @@ async def test_restart_resets_effects(postgres_dsn: str, tmp_path: Path) -> None
         assert not await pool.fetchval(
             "SELECT effects_started FROM builds WHERE id = $1", build_id
         )
-        # Stale log cleared by the reset; the failed rerun
+        # Stale log cleared by the reset. The failed rerun
         # (unfetchable URL) settled the row.
         row = await pool.fetchrow(
             "SELECT status, error, log_size FROM build_effects WHERE build_id = $1",

--- a/nixbot/nixbot/tests/test_db.py
+++ b/nixbot/nixbot/tests/test_db.py
@@ -54,7 +54,7 @@ async def test_failed_migration_error_not_masked(
     postgres_dsn: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """When a migration kills the connection, the transaction rollback
-    and the advisory unlock fail too; the original error must still
+    and the advisory unlock fail too. The original error must still
     propagate."""
     bad = migrations_mod.Migration(
         version=9999,
@@ -69,7 +69,7 @@ async def test_failed_migration_error_not_masked(
 
 
 async def test_huge_attr_name_does_not_break_notify_trigger(pool: asyncpg.Pool) -> None:
-    """pg_notify payloads cap at ~8000 bytes; the notify trigger must
+    """pg_notify payloads cap at ~8000 bytes. The notify trigger must
     truncate the repo-controlled attr name or every insert/update of
     such a row fails."""
 
@@ -149,7 +149,7 @@ async def test_check_run_store_round_trip(pool: asyncpg.Pool) -> None:
 
 
 async def test_failed_status_store_component(pool: asyncpg.Pool) -> None:
-    """FailedStatusStore is the only consumer of failed_statuses; its
+    """FailedStatusStore is the only consumer of failed_statuses. Its
     mark/upsert/get/clear cycle covers the table semantics."""
 
     store = FailedStatusStore(pool)
@@ -206,7 +206,7 @@ async def test_get_or_create_build_concurrent_no_duplicates(postgres_dsn: str) -
 
 
 async def test_cancelled_build_not_reused(pool: asyncpg.Pool) -> None:
-    # A cancelled build carries no verdict; re-pushing the same tree
+    # A cancelled build carries no verdict. Re-pushing the same tree
     # must build again instead of re-reporting "cancelled".
     project_id = await insert_project(pool, "cancelled-reuse")
     first, created = await db.get_or_create_build(
@@ -222,7 +222,7 @@ async def test_cancelled_build_not_reused(pool: asyncpg.Pool) -> None:
 
 
 async def test_reuse_backfills_pr_fields(pool: asyncpg.Pool) -> None:
-    # Branch push creates the build first; the PR event for the same
+    # Branch push creates the build first. The PR event for the same
     # tree must backfill pr_number/pr_author so the PR author keeps
     # restart/cancel rights.
     project_id = await insert_project(pool, "pr-backfill")
@@ -252,7 +252,7 @@ async def test_reuse_backfills_pr_fields(pool: asyncpg.Pool) -> None:
 async def test_reuse_by_other_pr_clears_both_identity_fields(
     pool: asyncpg.Pool,
 ) -> None:
-    # Two PRs producing the same tree share a build; the second PR's
+    # Two PRs producing the same tree share a build. The second PR's
     # event must not leave a row mixing PR A's number with no author,
     # nor attach PR B's author to PR A's number.
     project_id = await insert_project(pool, "pr-cross")
@@ -316,7 +316,7 @@ async def test_branch_push_takes_over_reused_pr_build(pool: asyncpg.Pool) -> Non
 
 
 async def test_pr_does_not_capture_branch_push_build(pool: asyncpg.Pool) -> None:
-    # A default-branch push created the build; a PR for a different
+    # A default-branch push created the build. A PR for a different
     # branch sharing the tree hash must not gain pr_author authz
     # (restart/cancel control) over it.
     project_id = await insert_project(pool, "pr-capture")
@@ -340,7 +340,7 @@ async def test_pr_does_not_capture_branch_push_build(pool: asyncpg.Pool) -> None
 
 
 async def test_complete_attribute_preserves_eval_outputs(pool: asyncpg.Pool) -> None:
-    # Eval records the full outputs map (multi-output drvs); completion
+    # Eval records the full outputs map (multi-output drvs). Completion
     # must merge the freshly-known "out" path into it, not replace the
     # map, and must never NULL an existing map when no out path is
     # known (restarted/cancelled attributes).
@@ -442,7 +442,7 @@ async def test_complete_attribute_marks_substituted_as_cached(
 
 
 async def test_complete_attribute_replaces_log_metadata(pool: asyncpg.Pool) -> None:
-    # Attribute restarts rewrite the same log file; the inline size
+    # Attribute restarts rewrite the same log file. The inline size
     # metadata must reflect the latest run, not the first.
     project_id = await insert_project(pool, "log-dup")
     build, _ = await db.get_or_create_build(pool, project_id, "tree-l", "sha", "main")

--- a/nixbot/nixbot/tests/test_effects.py
+++ b/nixbot/nixbot/tests/test_effects.py
@@ -1,7 +1,7 @@
 """Tests for effects secret resolution, scope rules, and CLI driving
 (with a fake nixbot-effects on PATH)."""
 
-# ruff: noqa: ARG001, S106 (fixtures used for side effects; test secret names)
+# ruff: noqa: ARG001, S106 (fixtures used for side effects. Test secret names)
 
 from __future__ import annotations
 
@@ -105,7 +105,7 @@ def fake_effects(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 echo "$@" >> {tmp_path}/calls
 case "$1" in
   list)
-    # nix routinely logs to stderr while evaluating; must not corrupt JSON.
+    # nix routinely logs to stderr while evaluating. Must not corrupt JSON.
     echo 'warning: Git tree is dirty' >&2
     echo '["deploy", "notify"]'
     ;;
@@ -163,7 +163,7 @@ async def test_run_effect_with_secrets(
     ok = await run_effect(ctx, "deploy", log_write)
     assert ok
     output = b"".join(chunks).decode()
-    # The effect echoes the secrets file; the deploy secret must be
+    # The effect echoes the secrets file. The deploy secret must be
     # masked in the log even though the CLI received the real file.
     assert "s3-longsecret" not in output
     assert "***" in output
@@ -177,7 +177,7 @@ async def test_run_effect_with_secrets(
 async def test_run_effect_inherits_environment(
     tmp_path: Path, fake_effects: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Remote builders need $HOME for ~/.ssh; the service environment
+    # Remote builders need $HOME for ~/.ssh. The service environment
     # must be inherited by nixbot-effects.
     monkeypatch.setenv("HOME", "/var/lib/nixbot-test")
     chunks: list[bytes] = []

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -1,7 +1,7 @@
 """Tests for the attribute build executor: fair queue, log capture,
 build subprocess handling (with a fake `nix` on PATH)."""
 
-# ruff: noqa: PLR2004, ARG001 (test literals; fixtures used for side effects)
+# ruff: noqa: PLR2004, ARG001 (test literals. Fixtures used for side effects)
 
 from __future__ import annotations
 
@@ -343,7 +343,7 @@ async def test_executor_hard_cancel_kills_process_group(
     not leak the running nix process group.
 
     Group-kill semantics themselves are covered by
-    test_proc.test_reap_kills_whole_group; this checks the executor's
+    test_proc.test_reap_kills_whole_group. This checks the executor's
     hard-cancel wiring (the finally path that also stops the log pump).
     """
     fake_nix.write_text("hangpid")
@@ -610,7 +610,7 @@ async def test_structured_capture_live_stream() -> None:
     assert deltas[0] == {"t": "drv", "idx": 1, "name": "qtbase-5.0"}
     assert {"t": "phase", "idx": 1, "phase": "build", "line": 0} in deltas
     assert {"t": "line", "idx": 1, "from": 1, "text": "CC main.o"} in deltas
-    # stop marks built, finalize status overrides to failed; both stream.
+    # stop marks built, finalize status overrides to failed. Both stream.
     assert {"t": "status", "idx": 1, "status": "built"} in deltas
     assert {"t": "status", "idx": 1, "status": "failed"} in deltas
     assert deltas[-1] is None  # close signals done
@@ -631,7 +631,7 @@ async def test_structured_capture_stalled_subscriber_bounded() -> None:
 
 
 async def test_structured_capture_monotonic_line_from_past_cap() -> None:
-    # The container caps retained lines, so its line count plateaus; live
+    # The container caps retained lines, so its line count plateaus. Live
     # delta "from" must stay monotonic anyway or row ids would collide.
     cap = StructuredCapture(clock=lambda: 1.0, max_lines=4)
     q = cap.subscribe()
@@ -662,7 +662,7 @@ def test_structured_failure_excerpt_uses_failed_derivation() -> None:
         cap.log_line(1, line)
     cap.set_status("/nix/store/aaa-ghidra-cli-test.drv", "failed")
     excerpt = cap.failure_excerpt()
-    # The failing derivation's own tail under a single name header; no
+    # The failing derivation's own tail under a single name header. No
     # per-line prefix, no nix re-quote.
     assert excerpt.splitlines()[0] == "ghidra-cli-test:"
     assert excerpt.splitlines()[-1] == "Error: exit status 1"
@@ -714,8 +714,8 @@ def test_phase_echo_suppressed_and_marker_is_zero_based() -> None:
     cap.close()
 
     reader = LogContainerReader(cap.finalize())
-    # idx 0 is the setup bucket; the build is idx 1. The echo is not
-    # stored; the marker points at the first real line (0-based).
+    # idx 0 is the setup bucket. The build is idx 1. The echo is not
+    # stored. The marker points at the first real line (0-based).
     assert reader.lines(1) == ["boom"]
     assert reader.entry(1)["ph"] == [["buildPhase", 0]]
 
@@ -764,7 +764,7 @@ def test_structured_failure_excerpt_caps_many_failures() -> None:
         cap.log_line(i + 1, f"boom {i}")
         cap.set_status(drv, "failed")
     excerpt = cap.failure_excerpt(max_drvs=2)
-    # Only the last two failures are shown, each under its name; the
+    # Only the last two failures are shown, each under its name. The
     # rest are counted.
     assert "pkg-4:\nboom 4" in excerpt
     assert "pkg-3:\nboom 3" in excerpt
@@ -791,7 +791,7 @@ def test_scrapes_cannot_build_reason_wording() -> None:
     cap.setup_line(f"error: Cannot build '{top}'.\n       Reason: 1 dependency failed.")
     cap.mark_failed(top)
     state = {e["name"]: e["status"] for e in cap.state()}
-    # Leaf flagged with its output; no phantom top-level card, setup neutral.
+    # Leaf flagged with its output. No phantom top-level card, setup neutral.
     assert state["closure-info"] == "failed"
     assert "vm-test-run-nixbot-gitlab" not in state
     assert state["setup"] == "built"
@@ -824,7 +824,7 @@ async def test_structured_capture_state_snapshot() -> None:
 
 
 # As written by render_log_event: the builder's own lines arrive as
-# internal-json events and get a name> prefix; nix's prose error then
+# internal-json events and get a name> prefix. Nix's prose error then
 # re-quotes the same lines with a bare "> ".
 NIX_FAILURE_TAIL = """\
 building '/nix/store/mxpvhwgqn3q6sl1lykymcj77z7a1iifi-fail-1.drv'
@@ -848,7 +848,7 @@ def test_failure_excerpt_extracts_log_and_reason() -> None:
     excerpt = failure_excerpt(NIX_FAILURE_TAIL)
     lines = excerpt.splitlines()
     # The structured (name-prefixed) line wins over nix's prose
-    # re-quote of the same text; the failure reason follows.
+    # re-quote of the same text. The failure reason follows.
     assert lines[0] == "fail-1> this build is supposed to fail"
     assert lines[1] == "Reason: builder failed with exit code 1."
     assert len([x for x in lines if "supposed to fail" in x]) == 1
@@ -873,7 +873,7 @@ def test_failure_excerpt_truncates_overlong_lines() -> None:
     long = "x" * 2000
     excerpt = failure_excerpt(f"fail-1> {long}\nReason: nope.\n")
     log_line = excerpt.splitlines()[0]
-    # Visible length capped; ellipsis marks the cut.
+    # Visible length capped. Ellipsis marks the cut.
     assert log_line.endswith("…")
     assert len(strip_ansi(log_line)) <= 650
 
@@ -892,7 +892,7 @@ def test_failure_excerpt_keeps_ansi_when_truncating() -> None:
     log_line = excerpt.splitlines()[0]
     assert "\x1b[31m" in log_line
     assert len(strip_ansi(log_line)) <= 650
-    # Truncation drops the source line's own reset; a reset is
+    # Truncation drops the source line's own reset. A reset is
     # re-appended so red does not bleed into the following line.
     assert log_line.endswith("\x1b[0m")
 

--- a/nixbot/nixbot/tests/test_forge.py
+++ b/nixbot/nixbot/tests/test_forge.py
@@ -93,7 +93,7 @@ FILTER_REPOS = [
             id="union-of-allowlists",
         ),
         # The topic only drives the one-shot legacy enablement import
-        # (projects.py); it must not exclude repos from discovery.
+        # (projects.py). It must not exclude repos from discovery.
         pytest.param(
             RepoFilters(topic="build-with-buildbot"),
             [0, 1, 2],
@@ -272,7 +272,7 @@ async def test_github_fetch_credentials_repo_scoped(
 async def test_github_credentials_before_discovery(
     github_client: GitHubAppClient,
 ) -> None:
-    """Webhooks are served before the initial discovery finishes; an
+    """Webhooks are served before the initial discovery finishes. An
     unknown repo's installation must be looked up on demand instead of
     dropping credentials (private fetch and statuses would fail)."""
     base = github_transport()
@@ -327,7 +327,7 @@ async def test_gitea_discovery() -> None:
                 "permissions": None,
             },
             {
-                # No admin permission: still discovered; hook
+                # No admin permission: still discovered. Hook
                 # registration degrades to a manual-setup hint.
                 "id": 8,
                 "name": "readonly",
@@ -348,7 +348,7 @@ async def test_gitea_discovery() -> None:
 
 
 async def test_gitea_discovery_skips_topics_by_default() -> None:
-    """Topics are only the one-shot legacy import aid; the hourly sync
+    """Topics are only the one-shot legacy import aid. The hourly sync
     must not pay one extra request per repo for them."""
     forge = FakeGitea(
         [
@@ -369,7 +369,7 @@ async def test_gitea_discovery_skips_topics_by_default() -> None:
 
 
 async def test_gitea_discovery_null_topics() -> None:
-    """Gitea returns {"topics": null} for repos without topics; that
+    """Gitea returns {"topics": null} for repos without topics. That
     must not crash discovery."""
     forge = FakeGitea(
         [
@@ -429,7 +429,7 @@ async def test_project_store_sync_and_legacy_import(pool: asyncpg.Pool) -> None:
 
 
 async def test_legacy_import_runs_despite_pull_based_rows(pool: asyncpg.Pool) -> None:
-    """sync_pull_based fills the projects table before discovery; that
+    """sync_pull_based fills the projects table before discovery. That
     must not suppress the one-shot legacy topic import."""
 
     await pool.execute("TRUNCATE projects CASCADE")
@@ -468,7 +468,7 @@ async def test_legacy_import_scopes_topics_per_forge(pool: asyncpg.Pool) -> None
 
 
 async def test_prune_missing_disabled_projects(pool: asyncpg.Pool) -> None:
-    """Disabled repos missing from discovery are pruned; enabled and
+    """Disabled repos missing from discovery are pruned. Enabled and
     pull-based rows survive."""
 
     await pool.execute("TRUNCATE projects CASCADE")
@@ -586,7 +586,7 @@ async def test_gitea_hook_registration(pool: asyncpg.Pool) -> None:
 
 
 async def test_gitlab_heads_carry_target_branch_base(pool: asyncpg.Pool) -> None:
-    """GitLab's MR API has no base sha; reconciliation must still merge
+    """GitLab's MR API has no base sha. Reconciliation must still merge
     MR heads into the target branch."""
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -724,7 +724,7 @@ async def test_reconcile_unbuilt_heads(pool: asyncpg.Pool) -> None:
 
 
 async def test_gitea_watermark_stops_pagination(pool: asyncpg.Pool) -> None:
-    """PRs are fetched newest-update-first; pagination must stop at
+    """PRs are fetched newest-update-first. Pagination must stop at
     the first PR older than the watermark instead of walking the
     whole open-PR backlog (nixpkgs-scale repos)."""
     requested_pages: list[int] = []
@@ -846,7 +846,7 @@ async def test_reconcile_watermark_store(pool: asyncpg.Pool) -> None:
 @pytest.mark.skipif(shutil.which("openssl") is None, reason="openssl required")
 async def test_github_check_run_post(github_client: GitHubAppClient) -> None:
     """End-to-end through the real App client (JWT, installation
-    token, repo lookup); the upsert/PATCH details are covered in
+    token, repo lookup). The upsert/PATCH details are covered in
     test_status."""
     posted: list[dict] = []
     fallback = github_transport()
@@ -1069,7 +1069,7 @@ async def test_register_repo_hook_500_with_403_in_body_raises(
 async def test_gitlab_register_repo_hook_status_classification(
     pool: asyncpg.Pool, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """403 degrades to a manual-setup warning; a 500 whose body
+    """403 degrades to a manual-setup warning. A 500 whose body
     contains "403" propagates as ForgeError."""
     status = 403
 
@@ -1121,7 +1121,7 @@ async def test_gitea_legacy_hook_delete_failure_warns(
     pool: asyncpg.Pool, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A failed legacy-hook DELETE silently leaves the old hook
-    delivering forever; it must at least be logged."""
+    delivering forever. It must at least be logged."""
     forge = FakeGitea(
         hooks=[
             {"id": 1, "config": {"url": "https://ci.example.com/change_hook/gitea"}},

--- a/nixbot/nixbot/tests/test_gitrepo.py
+++ b/nixbot/nixbot/tests/test_gitrepo.py
@@ -116,7 +116,7 @@ async def test_merge_conflict_raises(manager: RepoManager, upstream: Path) -> No
 async def test_reclone_on_corruption(manager: RepoManager, upstream: Path) -> None:
     await fetch(manager, upstream)
     clone = manager.clone_path(KEY)
-    # Destroy the object store; next fetch must transparently re-clone.
+    # Destroy the object store. Next fetch must transparently re-clone.
     shutil.rmtree(clone / "objects")
     await fetch(manager, upstream)
     sha = git(upstream, "rev-parse", "HEAD")
@@ -141,7 +141,7 @@ async def test_transient_fetch_error_keeps_clone(
 
 
 async def test_cleanup_resolves_symlinked_paths(tmp_path: Path, upstream: Path) -> None:
-    # git reports symlink-resolved worktree paths; cleanup must compare
+    # git reports symlink-resolved worktree paths. Cleanup must compare
     # resolved paths or it deletes live worktrees.
     real_state = tmp_path / "real-state"
     real_state.mkdir()
@@ -157,7 +157,7 @@ async def test_cleanup_resolves_symlinked_paths(tmp_path: Path, upstream: Path) 
 
 @pytest.fixture
 def submodule(upstream: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Add a file:// submodule to upstream; allows the file protocol
+    """Add a file:// submodule to upstream. Allows the file protocol
     (blocked by default since CVE-2022-39253) via environment-based
     git config passed through by run_git."""
     monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
@@ -264,7 +264,7 @@ async def test_cleanup_removes_stale_orphan_files(
     manager: RepoManager, upstream: Path
 ) -> None:
     """Crash-leaked side-files next to worktrees (e.g. effects secrets)
-    must be swept once old enough; fresh files stay."""
+    must be swept once old enough. Fresh files stay."""
     await fetch(manager, upstream)
     stale = manager.worktrees_dir / "stale-secret"
     stale.write_text("s3cret")

--- a/nixbot/nixbot/tests/test_logstore.py
+++ b/nixbot/nixbot/tests/test_logstore.py
@@ -85,7 +85,7 @@ def test_lines_with_phases_reinjects_markers() -> None:
     w.phase("pkg", "installPhase")
     w.line("pkg", "installing")
     r = LogContainerReader(w.finalize())
-    # Markers reconstructed from `ph`; plain lines() stays unchanged.
+    # Markers reconstructed from `ph`. Plain lines() stays unchanged.
     assert r.lines(0) == ["compiling", "installing"]
     assert r.lines_with_phases(0) == [
         "Running phase: buildPhase",
@@ -106,7 +106,7 @@ def test_phase_dedup() -> None:
 
 
 def test_grouping_shares_frame() -> None:
-    # Small drvs group into one frame; a big one forces a new frame.
+    # Small drvs group into one frame. A big one forces a new frame.
     w = LogContainerWriter(group_bytes=64)
     w.line("a", "x" * 10)
     w.line("b", "y" * 10)
@@ -155,7 +155,7 @@ def test_search_per_drv_cap() -> None:
 
 
 def test_search_across_grouped_frame() -> None:
-    # Two drvs in one frame; matches must attribute to the right drv/line.
+    # Two drvs in one frame. Matches must attribute to the right drv/line.
     w = LogContainerWriter(group_bytes=1 << 20)
     w.line("a", "alpha")
     w.line("a", "target here")

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -84,7 +84,7 @@ def test_sandbox_command_mounts(tmp_path: Path) -> None:
 
 
 def test_sandbox_skips_missing_daemon_socket(tmp_path: Path) -> None:
-    # Single-user nix installs have no daemon socket; the sandbox must
+    # Single-user nix installs have no daemon socket. The sandbox must
     # not hard-bind it (bwrap aborts on missing source paths) and the
     # evaluator must not be forced through the absent daemon.
     settings = EvalSettings(
@@ -198,7 +198,7 @@ async def test_eval_runner_integration(tmp_path: Path) -> None:
 async def test_stderr_noise_filtered_and_warnings_reach_callback(
     tmp_path: Path,
 ) -> None:
-    """Noise stays out of both the tail and the callback; warning and
+    """Noise stays out of both the tail and the callback. Warning and
     error lines reach the callback ANSI-stripped, progress output does
     not."""
     script = tmp_path / "warn.sh"
@@ -285,7 +285,7 @@ def test_cgroup_limiter_create_handles_missing_delegation(
 
 async def test_cgroup_limiter_eval_cgroup_lifecycle(tmp_path: Path) -> None:
     # Filesystem-level behavior with a plain directory standing in for the
-    # delegated subtree; cgroup.kill writes fail and are tolerated.
+    # delegated subtree. cgroup.kill writes fail and are tolerated.
     limiter = nix_eval.CgroupLimiter(tmp_path)
     path = limiter.new_eval_cgroup(123)
     assert (path / "memory.max").read_text() == str(123 * 1024 * 1024)
@@ -310,7 +310,7 @@ async def test_eval_runner_handles_long_json_lines(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # nix-eval-jobs emits one JSON object per line including the full
-    # neededBuilds closure; such lines easily exceed asyncio's 64 KiB
+    # neededBuilds closure. Such lines easily exceed asyncio's 64 KiB
     # default StreamReader limit and must not crash the evaluation.
     job = {
         "attr": "big",
@@ -383,7 +383,7 @@ async def test_eval_runner_flushes_partial_batch_on_timeout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # A slow eval that trickles jobs must not sit on a partial batch
-    # until the size threshold; the flush interval bounds the latency.
+    # until the size threshold. The flush interval bounds the latency.
     job = json.dumps(
         {
             "attr": "first",
@@ -484,7 +484,7 @@ async def test_eval_fails_cleanly_on_line_over_stream_limit(
 ) -> None:
     # A JSON line over the StreamReader limit used to raise ValueError
     # out of the reader, leaking a running nix-eval-jobs blocked on the
-    # full pipe; it must surface as a clean EvalError instead.
+    # full pipe. It must surface as a clean EvalError instead.
     monkeypatch.setattr(nix_eval, "STREAM_LIMIT", 64 * 1024)
     fake_nix_eval_jobs(
         tmp_path, monkeypatch, "head -c 200000 /dev/zero | tr '\\0' 'x'\necho\n"

--- a/nixbot/nixbot/tests/test_nix_eval_job.py
+++ b/nixbot/nixbot/tests/test_nix_eval_job.py
@@ -29,5 +29,5 @@ def test_impure_job_with_null_out_parses() -> None:
 
     assert isinstance(job, NixEvalJobSuccess)
     assert job.outputs == {"out": None}
-    # Downstream code does `job.outputs["out"] or None`; ensure that still works.
+    # Downstream code does `job.outputs["out"] or None`. Ensure that still works.
     assert (job.outputs["out"] or None) is None

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -1,7 +1,7 @@
 """Orchestrator/state-machine tests: ephemeral Postgres,
 real git repos, fake eval and executor."""
 
-# ruff: noqa: PLR2004, ARG001, ARG002 (test literals; protocol fakes ignore args)
+# ruff: noqa: PLR2004, ARG001, ARG002 (test literals. Protocol fakes ignore args)
 
 from __future__ import annotations
 
@@ -306,7 +306,7 @@ def run_effect_build(
     upstream: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> EffectBuildRunner:
-    """One default-branch build with a fake "deploy" effect; returns
+    """One default-branch build with a fake "deploy" effect. Returns
     the recorded effect runs for further assertions."""
 
     async def run() -> tuple[BuildRecord | None, Orchestrator, RepoInfo, list[str]]:
@@ -409,7 +409,7 @@ async def test_tree_hash_reuse(run_event: EventRunner, upstream: Path) -> None:
     executor = FakeExecutor()
     build1, _ = await run_event(eval_runner, executor)
     # Same tree content from another context: no second build, no
-    # second eval; existing result re-reported.
+    # second eval. Existing result re-reported.
     build2, reporter2 = await run_event(eval_runner, executor)
     assert build1 is not None
     assert build2 is not None
@@ -775,7 +775,7 @@ async def test_eval_warnings_null_when_empty(
 async def test_rerun_flips_stale_red_eval_status(
     pool: asyncpg.Pool, make_env: EnvFactory, upstream: Path
 ) -> None:
-    """Resuming from stored eval results skips eval; the eval status
+    """Resuming from stored eval results skips eval. The eval status
     must still be re-posted green over a stale red one."""
     sha = add_commit(upstream, "eval-flip")
     # Failing attribute: keeps the effects path out of this test.
@@ -1028,7 +1028,7 @@ async def test_eval_netrc_withheld_from_pr_with_instance_wide_creds(
     make_env: EnvFactory, tmp_path: Path, upstream: Path
 ) -> None:
     """PR-controlled eval fetches arbitrary flake inputs with the
-    netrc; an instance-wide Gitea/GitLab token must not reach it.
+    netrc. An instance-wide Gitea/GitLab token must not reach it.
     Repo-scoped GitHub tokens may."""
 
     git(upstream, "checkout", "-b", "prsrc")
@@ -1188,7 +1188,7 @@ async def test_recovery_rerun_runs_effects(
 async def test_unsupported_system_attr_does_not_block_aggregation(
     pool: asyncpg.Pool, run_event: EventRunner, upstream: Path
 ) -> None:
-    """The scheduler drops unsupported systems; a pending row for them
+    """The scheduler drops unsupported systems. A pending row for them
     would keep the build non-terminal forever."""
 
     add_commit(upstream, "sys")
@@ -1303,7 +1303,7 @@ async def test_effect_items_resume_only_pending(
     build, orchestrator, project, ran = await run_effect_build()
     assert build is not None
     assert ran == ["deploy"]
-    # Crash mid-run: the sweep settles the row; the requeued
+    # Crash mid-run: the sweep settles the row. The requeued
     # item must skip it.
     await pool.execute(
         "UPDATE build_effects SET status = 'running' WHERE build_id = $1",
@@ -1365,7 +1365,7 @@ async def test_failed_effect_reports_failure_status(
     upstream: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A failed effect must post a failure commit status; otherwise a
+    """A failed effect must post a failure commit status. Otherwise a
     failed deploy leaves the commit green (issue #30)."""
 
     async def failing_run(ctx: object, name: str, log_write: object = None) -> bool:
@@ -1431,7 +1431,7 @@ async def test_post_process_error_does_not_wedge_build(
     finished = [e for e in reporter.events if e[0] == "finished"]
     assert finished
     assert finished[-1][2] == BuildStatus.FAILED
-    # The eval succeeded; only the build may turn red.
+    # The eval succeeded. Only the build may turn red.
     assert ("eval", build.id, False, ()) not in reporter.events
 
 
@@ -1603,7 +1603,7 @@ async def test_reuse_replays_effect_statuses_to_new_commit(
     assert first is not None
     await drain_effect_items(orchestrator, project, pool)
 
-    # A second commit with an identical tree reuses the build; its
+    # A second commit with an identical tree reuses the build. Its
     # effects do not re-run, so the statuses must be replayed.
     git(upstream, "commit", "--allow-empty", "-m", "reuse-replay-empty")
     sha2 = git(upstream, "rev-parse", "HEAD")
@@ -1729,7 +1729,7 @@ async def test_post_process_paths_are_forge_scoped(
     make_env: EnvFactory, tmp_path: Path, upstream: Path
 ) -> None:
     """Gcroots and outputs for the same owner/repo on two forges must
-    not collide; the forge belongs in both path schemes."""
+    not collide. The forge belongs in both path schemes."""
 
     add_commit(upstream, "forge-scope")
     orchestrator, _, project = await make_env(

--- a/nixbot/nixbot/tests/test_polling.py
+++ b/nixbot/nixbot/tests/test_polling.py
@@ -62,7 +62,7 @@ async def test_polling_detects_changes(upstream: Path) -> None:
 
 
 async def test_poll_loop_survives_sink_errors(upstream: Path) -> None:
-    """A sink failure must not kill the loop; the head is retried."""
+    """A sink failure must not kill the loop. The head is retried."""
 
     @dataclass
     class FlakySink(RecordingSink):

--- a/nixbot/nixbot/tests/test_post_build.py
+++ b/nixbot/nixbot/tests/test_post_build.py
@@ -140,7 +140,7 @@ async def test_run_steps_hard_failure_continues(tmp_path: Path) -> None:
 async def test_run_steps_inherit_service_environment(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Tools like cachix need HOME/XDG_*; the service environment must
+    # Tools like cachix need HOME/XDG_*. The service environment must
     # be inherited, with step.environment overlaid.
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("INHERITED_VAR", "from-service")

--- a/nixbot/nixbot/tests/test_proc.py
+++ b/nixbot/nixbot/tests/test_proc.py
@@ -1,7 +1,7 @@
 """Direct tests for the shared ProcessGroup subprocess helper.
 
 These cover the kill semantics (whole group, including grandchildren;
-no zombie; idempotent when the child already exited) that the
+no zombie. Idempotent when the child already exited) that the
 executor, post-build and effects modules rely on.
 """
 

--- a/nixbot/nixbot/tests/test_races.py
+++ b/nixbot/nixbot/tests/test_races.py
@@ -37,7 +37,7 @@ async def test_cancel_during_retry_window(tmp_path: Path) -> None:
         nonlocal attempts
         attempts += 1
         if attempts == 1:
-            # Transient failure; cancel lands while the retry is
+            # Transient failure. Cancel lands while the retry is
             # being considered.
             cancel_event.set()
             return BuildOutcome.failure, True

--- a/nixbot/nixbot/tests/test_recovery.py
+++ b/nixbot/nixbot/tests/test_recovery.py
@@ -114,7 +114,7 @@ async def test_retention_cleanup(pool: asyncpg.Pool, tmp_path: Path) -> None:
 
 
 class _FakePool:
-    """Returns the given build ids; optionally runs a callback first."""
+    """Returns the given build ids. Optionally runs a callback first."""
 
     def __init__(
         self, ids: set[int], on_fetch: Callable[[], None] | None = None
@@ -181,7 +181,7 @@ async def test_retention_skips_restarted_builds(
     pool: asyncpg.Pool, tmp_path: Path
 ) -> None:
     # A restarted build briefly keeps its old finished_at while its
-    # status is 'building' again; the hourly sweep must not delete it
+    # status is 'building' again. The hourly sweep must not delete it
     # mid-rerun.
     build_id = await make_build(pool, "restarted-old")
     await pool.execute(

--- a/nixbot/nixbot/tests/test_redact.py
+++ b/nixbot/nixbot/tests/test_redact.py
@@ -7,7 +7,7 @@ from nixbot.redact import Redactor, secret_literals
 
 def test_secret_literals_extracts_json_values_over_threshold() -> None:
     literals = secret_literals('{"token": "supersecret", "n": 1, "x": "ab"}')
-    # Full payload plus the long leaf value; short "ab" and non-strings
+    # Full payload plus the long leaf value. Short "ab" and non-strings
     # are dropped.
     assert b"supersecret" in literals
     assert b"ab" not in literals

--- a/nixbot/nixbot/tests/test_repo_config.py
+++ b/nixbot/nixbot/tests/test_repo_config.py
@@ -1,7 +1,7 @@
 """Per-repository config file loading.
 
 Repositories migrating from buildbot-nix still carry a
-`buildbot-nix.toml`; it must keep working until renamed.
+`buildbot-nix.toml`. It must keep working until renamed.
 """
 
 from __future__ import annotations

--- a/nixbot/nixbot/tests/test_schedules.py
+++ b/nixbot/nixbot/tests/test_schedules.py
@@ -1,6 +1,6 @@
 """Tests for scheduled effects: parsing, cron matching, persistence."""
 
-# ruff: noqa: PLR2004, S106 (test literals; secret_name is a credential id)
+# ruff: noqa: PLR2004, S106 (test literals, secret_name is a credential id)
 from __future__ import annotations
 
 import os
@@ -131,7 +131,7 @@ async def test_replace_schedules_preserves_last_run_for_unchanged_spec(
 async def test_replace_schedules_tolerates_duplicate_effect_names(
     pool: asyncpg.Pool,
 ) -> None:
-    """Effect lists are repo-controlled; a duplicate name must not crash
+    """Effect lists are repo-controlled. A duplicate name must not crash
     the update and permanently block schedule refreshes."""
 
     project_id = await insert_project(pool, forge_repo_id="sched-dupe")
@@ -187,7 +187,7 @@ async def test_store_roundtrip_and_due(pool: asyncpg.Pool) -> None:
 
 
 def test_due_occurrence_window() -> None:
-    # The sweep loop drifts past minute boundaries; occurrences within
+    # The sweep loop drifts past minute boundaries. Occurrences within
     # the window must still be found.
     when = ScheduleWhen(minute=30, hour=2)
     occ = due_occurrence(when, "s", datetime(2026, 6, 5, 2, 33, 10, tzinfo=UTC))

--- a/nixbot/nixbot/tests/test_service.py
+++ b/nixbot/nixbot/tests/test_service.py
@@ -236,7 +236,7 @@ async def test_restart_gitlab_mr_build_fetches_mr_refs(
             forge_repo_id=f"svc-{time.monotonic_ns()}",
             url=f"file://{repo}",
         )
-        # file:// forces the full transfer protocol; clone before
+        # file:// forces the full transfer protocol. Clone before
         # the MR ref exists so only the fetch refspec can bring it
         # in (see test_orchestrator.make_gitlab_mr_env).
         await service.orchestrator.repos.fetch(
@@ -274,7 +274,7 @@ async def test_restart_eval_failed_build_reevaluates(
     service: CIService, git_repo: tuple[Path, str]
 ) -> None:
     """A build that failed before eval produced attributes has nothing
-    to resume; restarting it must re-evaluate instead of aggregating an
+    to resume. Restarting it must re-evaluate instead of aggregating an
     empty attribute set to 'succeeded'."""
     repo, sha = git_repo
 
@@ -375,7 +375,7 @@ async def test_restart_unknown_attribute_is_a_noop(
 async def test_restart_failed_eval_attribute_reevaluates(
     service: CIService, git_repo: tuple[Path, str]
 ) -> None:
-    """failed_eval attributes have no drv_path; resetting them to
+    """failed_eval attributes have no drv_path. Resetting them to
     pending must trigger a re-eval, not wedge the build in 'building'."""
     repo, sha = git_repo
 
@@ -491,7 +491,7 @@ async def test_restart_while_unwinding_waits_then_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Restart clicked while the old run is still unwinding (e.g.
-    right after a cancel) resets state immediately; the rerun must
+    right after a cancel) resets state immediately. The rerun must
     requeue until the slot clears, not be dropped silently."""
     repo, sha = git_repo
     monkeypatch.setattr("nixbot.restart_dispatch.UNWIND_RETRY_SECONDS", 0.0)
@@ -524,7 +524,7 @@ async def test_restart_while_unwinding_waits_then_runs(
     # Simulate the cancelled run still unwinding.
     service.orchestrator.cancel_events[build_id] = asyncio.Event()
     await service.restart_build(build_id)
-    # Reset already applied; the UI sees pending without a worker.
+    # Reset already applied. The UI sees pending without a worker.
     assert (
         await pool.fetchval("SELECT status FROM builds WHERE id = $1", build_id)
         == "pending"
@@ -541,7 +541,7 @@ async def test_restart_while_unwinding_waits_then_runs(
     )
     assert pending == 1  # the intent survived
 
-    # Old run finished; the queued rerun now goes through.
+    # Old run finished. The queued rerun now goes through.
     del service.orchestrator.cancel_events[build_id]
     await service.drain_work()
     await asyncio.gather(*service._tasks)  # noqa: SLF001
@@ -615,7 +615,7 @@ async def test_check_rerequested_dispatch(service: CIService) -> None:
     await service.submit(
         CheckRerequested(**base, build_id=build_id, name="nixbot/nix-build")
     )
-    # check_suite: no build_id, no name; resolved via LatestBuildForSha.
+    # check_suite: no build_id, no name. Resolved via LatestBuildForSha.
     await service.submit(CheckRerequested(**base))
     # external_id from another project's app must not be honoured.
     await service.submit(CheckRerequested(**base, build_id=99999999))
@@ -659,7 +659,7 @@ async def test_cancel_not_running_settles_attribute_rows(service: CIService) -> 
 async def test_cancel_attribute_not_running_reaggregates_build(
     service: CIService,
 ) -> None:
-    """Direct attribute cancel must re-aggregate the build; otherwise
+    """Direct attribute cancel must re-aggregate the build. Otherwise
     the build stays 'building' forever with all rows terminal."""
 
     pool = service.pool
@@ -755,7 +755,7 @@ class StubGitHub:
 async def test_topic_does_not_hard_filter_discovery(
     make_service: ServiceFactory, tmp_path: Path
 ) -> None:
-    """The topic is a one-shot legacy import aid; repos without it must
+    """The topic is a one-shot legacy import aid. Repos without it must
     still be discovered (disabled) so admins can enable them in the UI."""
 
     secret = tmp_path / "gh.pem"
@@ -818,7 +818,7 @@ async def test_startup_reevaluates_interrupted_eval(
 async def test_rerun_of_interrupted_eval_reevaluates(
     service: CIService, git_repo: tuple[Path, str]
 ) -> None:
-    """A crash mid-evaluation leaves a partial attribute set; resuming
+    """A crash mid-evaluation leaves a partial attribute set. Resuming
     only those rows would report success for a build that never
     finished evaluating. It must re-evaluate."""
     repo, sha = git_repo
@@ -845,7 +845,7 @@ async def test_rerun_resumes_building_rows_and_keeps_finished(
     service: CIService, git_repo: tuple[Path, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A build that crashed with an attribute in 'building' resumes that
-    attribute; already-finished rows are kept, not re-evaluated away."""
+    attribute. Already-finished rows are kept, not re-evaluated away."""
     repo, sha = git_repo
 
     async def all_valid(paths: list[str]) -> set[str]:

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -154,7 +154,7 @@ def make_reporter(
 
 async def test_posted_generations_bounded() -> None:
     """One entry per build forever is a slow leak in a long-lived
-    process; the generation guard only matters short-term."""
+    process. The generation guard only matters short-term."""
 
     reporter, _poster, _store = make_reporter()
     for build_id in range(POSTED_GENERATIONS_MAX + 100):
@@ -282,10 +282,10 @@ async def test_eval_finished_build_plan_in_nix_build_body() -> None:
     )
     text = poster.extras[build_post]["text"]
     assert "Building 2 attribute(s):" in text
-    # Sorted, so `a` precedes `b`; pending plan omits the status column.
+    # Sorted, so `a` precedes `b`. Pending plan omits the status column.
     assert text.index("checks.x86_64-linux.a") < text.index("checks.x86_64-linux.b")
     assert "status" not in text
-    # attribute name links to the live viewer; raw log is a separate link.
+    # attribute name links to the live viewer. Raw log is a separate link.
     assert (
         "[`checks.x86_64-linux.a`](https://ci.test/repos/github/acme/widget/builds/42/logs/checks.x86_64-linux.a)"
         in text
@@ -521,7 +521,7 @@ async def test_build_level_cancel_keeps_supersede_wording() -> None:
 
 
 async def test_attribute_descriptions_are_ansi_stripped() -> None:
-    """failure_excerpt keeps ANSI colors for the web UI; forge statuses
+    """failure_excerpt keeps ANSI colors for the web UI. Forge statuses
     must not carry raw escape codes."""
     reporter, poster, _ = make_reporter()
     await reporter.build_finished(
@@ -577,7 +577,7 @@ async def test_previously_failed_reposts_do_not_consume_budget() -> None:
 
 
 async def test_summary_counts_use_all_attribute_statuses() -> None:
-    """Reruns pass only the re-run subset as results; the summary
+    """Reruns pass only the re-run subset as results. The summary
     description must still cover the whole build."""
     reporter, poster, _ = make_reporter()
     all_statuses = {f"ok{i}": "succeeded" for i in range(99)} | {"flaky": "succeeded"}
@@ -596,7 +596,7 @@ async def test_summary_counts_use_all_attribute_statuses() -> None:
 
 
 async def test_failed_effect_posts_failure_status() -> None:
-    """A failed effect must flip the commit status to failure; a green
+    """A failed effect must flip the commit status to failure. A green
     status on a failed deploy hides the breakage (issue #30)."""
     reporter, poster, _ = make_reporter()
 
@@ -649,7 +649,7 @@ async def test_attr_prefix_follows_repo_configuration() -> None:
 
 async def test_poster_network_errors_do_not_propagate() -> None:
     """Transport failures on non-terminal posts must not wedge the
-    pipeline; the terminal summary propagates to drive the queued
+    pipeline. The terminal summary propagates to drive the queued
     retry (RetryingReporter catches it)."""
 
     class ExplodingPoster:
@@ -667,7 +667,7 @@ async def test_poster_network_errors_do_not_propagate() -> None:
 
 async def test_reporter_forwards_attr_and_text() -> None:
     """Per-attr posts carry the attr (so the check-run store records
-    it for rerequested) and the full error as markdown text; the eval
+    it for rerequested) and the full error as markdown text. The eval
     run carries the warnings."""
     reporter, poster, _ = make_reporter()
 
@@ -716,7 +716,7 @@ async def test_check_permission_error_does_not_disable_forge() -> None:
     )
     await reporter.build_started(EVENT, BUILD)
     await reporter.build_finished(EVENT, BUILD, BuildResult("succeeded", 1, []))
-    # Both phases still attempt to post; the forge is never latched off.
+    # Both phases still attempt to post. The forge is never latched off.
     assert calls == 2
 
 
@@ -729,7 +729,7 @@ def test_check_run_output_title_and_truncate() -> None:
 
 
 def test_build_plan_truncation_stays_within_check_run_budget() -> None:
-    """A huge attribute table must fit the check-run budget itself; if it
+    """A huge attribute table must fit the check-run budget itself. If it
     overshoots, _check_run_output chops it mid-row into invalid markdown."""
     attrs = [f"a{i:05d}" for i in range(20000)]
     statuses = dict.fromkeys(attrs, "succeeded")
@@ -830,7 +830,7 @@ async def test_github_check_run_poster_upsert() -> None:
 
 
 async def test_github_check_run_patch_404_recreates() -> None:
-    """The DB row outlives the GitHub run; without the fallback the
+    """The DB row outlives the GitHub run. Without the fallback the
     terminal summary would retry forever via the report work item."""
     methods: list[str] = []
 

--- a/nixbot/nixbot/tests/test_visibility.py
+++ b/nixbot/nixbot/tests/test_visibility.py
@@ -359,7 +359,7 @@ def test_api_token_inherits_login_groups(harness: WebHarness) -> None:
 
 
 def test_access_cache_prunes_expired_on_get() -> None:
-    """Expired entries must not accumulate forever; get() prunes them."""
+    """Expired entries must not accumulate forever. get() prunes them."""
     cache = AccessCache(ttl=0)
     cache.set("github:alice", RepoAccess(frozenset(), frozenset()))
     cache.set("github:bob", RepoAccess(frozenset(), frozenset()))
@@ -470,5 +470,5 @@ async def test_github_repo_access_fetcher_enterprise_api_url() -> None:
     access = await fetcher.repo_access(user, "tok")
     assert access.accessible == frozenset({"github:5", "github:6", "github:7"})
     assert access.admin == frozenset({"github:5"})
-    # write/maintain/admin all set the push flag; read-only does not.
+    # write/maintain/admin all set the push flag. Read-only does not.
     assert access.writable == frozenset({"github:5", "github:6"})

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -119,7 +119,7 @@ def test_project_page_with_filters(client: WebHarness) -> None:
     assert "#3" in by_branch.text
     assert ">#2<" not in by_branch.text
 
-    # A numeric ref means a PR; build 3 is PR #5.
+    # A numeric ref means a PR. Build 3 is PR #5.
     by_pr = client.get("/repos/github/acme/widget?ref=%235")
     assert "#3" in by_pr.text
     assert ">#2<" not in by_pr.text
@@ -159,7 +159,7 @@ def test_build_page(client: WebHarness) -> None:
     response = client.get("/repos/github/acme/widget/builds/2")
     assert response.status_code == 200
     text = response.text
-    # Failures render eagerly in an open group; the succeeded bulk is
+    # Failures render eagerly in an open group. The succeeded bulk is
     # collapsed to a count.
     assert "x86_64-linux.bad" in text
     failed_group = re.search(r'<details[^>]*data-group="failed"[^>]*>', text)
@@ -228,7 +228,7 @@ def test_build_page_shows_eval_warning_groups(client: WebHarness) -> None:
 
 
 def test_build_page_renders_ansi_in_error(client: WebHarness) -> None:
-    """Eval failures carry nix's colored output; raw escape codes must
+    """Eval failures carry nix's colored output. Raw escape codes must
     not reach the HTML (the API already strips them)."""
 
     async def seed() -> None:
@@ -611,7 +611,7 @@ def test_ansi_sgr_is_stateful() -> None:
     assert ansi_to_html("\x1b[38;5;31mx") == "x"
     assert ansi_to_html("\x1b[38;2;1;2;3mx") == "x"
     # systemd uses ITU colon syntax: arguments ride along inside one
-    # parameter; the sequence must not leak into the output.
+    # parameter. The sequence must not leak into the output.
     out = ansi_to_html("\x1b[0;1;38:5:185meth1")
     assert out == '<span class="ansi-bold">eth1</span>'
     assert strip_ansi("\x1b[0;1;38:5:185meth1") == "eth1"
@@ -622,7 +622,7 @@ def test_osc8_hyperlinks() -> None:
     assert ansi_to_html(raw) == (
         '<a href="https://example.com" rel="nofollow">click</a> plain'
     )
-    # Colored link text nests; the link survives an SGR reset.
+    # Colored link text nests. The link survives an SGR reset.
     raw = "\x1b]8;;https://e.x\x07\x1b[31mred\x1b[0mplain\x1b]8;;\x07"
     assert ansi_to_html(raw) == (
         '<a href="https://e.x" rel="nofollow"><span class="ansi-red">red</span></a>'
@@ -651,7 +651,7 @@ def test_non_sgr_sequences_are_stripped() -> None:
 
 
 def test_render_log_lines_carries_color_across_lines() -> None:
-    # nix error blocks are colored over several lines; the reset
+    # nix error blocks are colored over several lines. The reset
     # arrives lines later.
     out = render_log_lines("\x1b[31mone\ntwo\x1b[0m\nthree")
     assert '<span class="ansi-red">one</span>' in out
@@ -955,7 +955,7 @@ def test_log_viewer_waits_for_queued_attribute(client: WebHarness) -> None:
 
 
 def test_log_viewer_unavailable_for_logless_status(client: WebHarness) -> None:
-    # failed_eval / skipped_local never produce a log; the viewer shows
+    # failed_eval / skipped_local never produce a log. The viewer shows
     # a placeholder instead of a 404 so build-page links resolve.
     async def make_failed_eval() -> None:
         await client.ctx.pool.execute(
@@ -987,7 +987,7 @@ def test_log_viewer_unavailable_for_logless_status(client: WebHarness) -> None:
 
 
 def test_eval_error_served_like_build_log(client: WebHarness) -> None:
-    """failed_eval attributes have no build log; the viewer and raw
+    """failed_eval attributes have no build log. The viewer and raw
     routes serve the stored eval trace with the same UI as build logs."""
     build_page = client.get("/repos/github/acme/widget/builds/2")
     assert "/builds/2/logs/x86_64-linux.evalfail" in build_page.text
@@ -1097,7 +1097,7 @@ def test_queue_sorts_active_before_pending(client: WebHarness) -> None:
         finally:
             await ctx.pool.execute("DELETE FROM builds WHERE number IN (90, 91)")
 
-    # Build 3 is evaluating; both active builds come before the
+    # Build 3 is evaluating. Both active builds come before the
     # earlier-submitted pending one.
     assert client.loop.run_until_complete(run()) == [3, 91, 90]
 
@@ -1224,7 +1224,7 @@ def test_log_sse_stream_caps_history_backlog(
     client: WebHarness, tmp_path: Path
 ) -> None:
     """Subscribing late to a huge log must not render the entire
-    history through the ANSI pipeline; only a bounded tail replays."""
+    history through the ANSI pipeline. Only a bounded tail replays."""
     ctx = client.ctx
     ctx.state_dir = tmp_path
     registry = client.app.state.log_registry
@@ -1502,7 +1502,7 @@ def test_attribute_search(client: WebHarness) -> None:
 
 
 def test_css_covers_every_status() -> None:
-    """Status values double as CSS classes; a missing rule silently
+    """Status values double as CSS classes. A missing rule silently
     renders a grey icon."""
     css = (Path(__file__).parent.parent / "web" / "static" / "style.css").read_text()
     statuses = (
@@ -1568,7 +1568,7 @@ def test_effect_log_raw_text(client: WebHarness, tmp_path: Path) -> None:
 
 
 def test_effect_changes_notify_build_events(client: WebHarness) -> None:
-    """The page's SSE refresh rides on build_events; without a trigger
+    """The page's SSE refresh rides on build_events. Without a trigger
     on build_effects the Effects section never updates live."""
 
     async def run() -> list[str]:
@@ -1672,7 +1672,7 @@ def test_logout_revokes_session_cookie(postgres_dsn: str) -> None:
 
 
 def test_gitlab_nested_group_routes(client: WebHarness) -> None:
-    """GitLab nested-group projects have "/" in the owner; the web and
+    """GitLab nested-group projects have "/" in the owner. The web and
     API routes must still resolve them."""
 
     async def setup() -> None:
@@ -1840,7 +1840,7 @@ def test_scheduled_run_history_lists_runs(client: WebHarness) -> None:
 
 def test_scheduled_run_history_special_chars(client: WebHarness) -> None:
     """schedule/effect names are repo-controlled and may contain
-    slashes; query params route them safely."""
+    slashes. Query params route them safely."""
     ctx = client.ctx
 
     async def setup() -> int:
@@ -1898,7 +1898,7 @@ def test_scheduled_run_stream_replays_history(
 
 def test_scheduled_run_notify_build_events(client: WebHarness) -> None:
     """Run INSERT (running) and terminal UPDATE both NOTIFY on
-    build_events; an unchanged status does not."""
+    build_events. An unchanged status does not."""
 
     async def run() -> list[dict]:
         ctx = client.ctx

--- a/nixbot/nixbot/visibility.py
+++ b/nixbot/nixbot/visibility.py
@@ -81,10 +81,10 @@ class RepoAccessFetcher(Protocol):
     async def repo_access(self, user: User, token: str) -> RepoAccess: ...
 
 
-# GitLab access_level for Maintainer; the lowest level allowed to
+# GitLab access_level for Maintainer. The lowest level allowed to
 # manage CI settings, mapped to our per-repo "admin" permission.
 _GITLAB_MAINTAINER = 40
-# GitLab Developer; the lowest level that can push, mapped to our
+# GitLab Developer. The lowest level that can push, mapped to our
 # per-repo "writable" permission (restart/cancel builds).
 _GITLAB_DEVELOPER = 30
 
@@ -260,14 +260,14 @@ class VisibilityService:
         self, user: User | None, token: str | None = None
     ) -> list[int] | None:
         """Projects the requester may enable/disable. None = all
-        (instance admins); forge-side repo admins get their own."""
+        (instance admins). Forge-side repo admins get their own."""
         return await self._repo_ids_for(user, token, lambda a: a.admin)
 
     async def controllable_repo_ids(
         self, user: User | None, token: str | None = None
     ) -> list[int] | None:
         """Projects whose builds the requester may restart/cancel. None =
-        all (instance admins); forge-side repo writers get their own."""
+        all (instance admins). Forge-side repo writers get their own."""
         return await self._repo_ids_for(user, token, lambda a: a.writable)
 
     async def _repo_ids_for(

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -4,8 +4,8 @@ Server-rendered Jinja2, classless CSS with system-preference dark
 mode. Live updates are pushed: Postgres triggers NOTIFY on status
 changes, /events fans them out over SSE, and a few lines of inline
 JS refetch fragments or patch rows. Per-project sequential build
-numbers in URLs; prev/next navigation between builds and
-per-attribute history; attributes grouped by system with
+numbers in URLs. Prev/next navigation between builds and
+per-attribute history. Attributes grouped by system with
 failed-first ordering and inline error excerpts.
 
 Visibility filtering hooks (`visible_repo_ids`) are wired by task
@@ -86,7 +86,7 @@ INLINE_GROUPS = ("failed", "building")
 
 
 class WebContext:
-    """Shared state for the routes; auth (5.3) extends this."""
+    """Shared state for the routes. Auth (5.3) extends this."""
 
     def __init__(
         self,
@@ -103,11 +103,11 @@ class WebContext:
         self.visibility = visibility
         # Wired by bootstrap; None hides control buttons (authz unknown).
         self.authz: AuthzConfig | None = None
-        # Wired by bootstrap; admins see Gitea webhook setup with it.
+        # Wired by bootstrap. Admins see Gitea webhook setup with it.
         self.webhook_base_url: str | None = None
         self.token_store: ApiTokenStore | None = None
         self.forge_tokens: TokenVault | None = None
-        # Wired by bootstrap; renews expired forge access tokens.
+        # Wired by bootstrap. Renews expired forge access tokens.
         self.token_refresher: ForgeTokenRefresher | None = None
         # Logout denylist: stateless cookies stay verifiable until
         # expiry, so revoked session ids are checked server-side.
@@ -280,7 +280,7 @@ class _PageRoutes:
         ctx = self.ctx
         visible = await ctx.visible_repo_ids(request)
         # Discovery inserts repos disabled. Admins see the disabled repos
-        # they may toggle so a fresh instance is not a blank page; the
+        # they may toggle so a fresh instance is not a blank page. The
         # search box filters the list. Non-admins have an empty
         # toggleable set and see nothing here.
         toggleable = await ctx.toggleable_repo_ids(request)
@@ -346,7 +346,7 @@ class _PageRoutes:
         )
 
     async def _can_cancel_queue(self, request: Request) -> bool:
-        """UX only; the cancel-all route re-checks server-side."""
+        """UX only. The cancel-all route re-checks server-side."""
         ctx = self.ctx
         return ctx.authz is not None and is_admin(
             await ctx.request_user(request), ctx.authz
@@ -386,7 +386,7 @@ class _PageRoutes:
         )
 
     async def _can_run_schedules(self, request: Request, project_id: int) -> bool:
-        """UX only; the run-schedule route re-checks server-side."""
+        """UX only. The run-schedule route re-checks server-side."""
         ctx = self.ctx
         if ctx.authz is None:
             return False
@@ -400,7 +400,7 @@ class _PageRoutes:
     ) -> str | None:
         """Gitea webhook target for admins: manual setup when the
         buildbot user cannot manage hooks itself. The secret is not
-        included; it is rotated and shown once via the control route."""
+        included. It is rotated and shown once via the control route."""
         ctx = self.ctx
         if (
             project["forge"] not in ("gitea", "gitlab")
@@ -541,7 +541,7 @@ class _PageRoutes:
         build: dict[str, Any],
         q: str | None,
     ) -> HTMLResponse:
-        """The grouped attribute fragment; a query filters every group
+        """The grouped attribute fragment. A query filters every group
         and renders all of them eagerly opened."""
         group_counts, inline = await self._grouped_attributes(build["id"], q)
         return await self.ctx.render(

--- a/nixbot/nixbot/web/auth_routes.py
+++ b/nixbot/nixbot/web/auth_routes.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 SESSION_COOKIE = "nixbot_session"
 STATE_COOKIE = "nixbot_oauth_state"
-# Server-generated states are token_urlsafe; the callback echoes the
+# Server-generated states are token_urlsafe. The callback echoes the
 # state into a cookie name, so reject anything else outright.
 _STATE_RE = re.compile(r"[A-Za-z0-9_-]{1,128}")
 

--- a/nixbot/nixbot/web/control_routes.py
+++ b/nixbot/nixbot/web/control_routes.py
@@ -6,7 +6,7 @@ allowUnauthenticatedControl) and CSRF same-origin checks. Admin-only
 project enable/disable toggle.
 
 The actual restart/cancel work happens behind the ControlBackend
-protocol, implemented by the service service composition
+protocol, implemented by the service composition
 where the orchestrator lives.
 """
 

--- a/nixbot/nixbot/web/control_routes.py
+++ b/nixbot/nixbot/web/control_routes.py
@@ -128,7 +128,7 @@ class _ControlRoutes:
         )
         if known is None:
             raise HTTPException(status_code=404, detail="unknown attribute")
-        # Reuses the stored eval results (drv_path); no re-eval.
+        # Reuses the stored eval results (drv_path). No re-eval.
         await self.backend.restart_attribute(build["id"], attr)
         return _back_to_attr(forge, owner, name, number, attr)
 
@@ -248,7 +248,7 @@ class _ControlRoutes:
         schedule: Annotated[str, Form()],
         effect: Annotated[str, Form()],
     ) -> RedirectResponse:
-        """Trigger an onSchedule effect on demand. Repo admins only; the
+        """Trigger an onSchedule effect on demand. Repo admins only. The
         schedule must already exist so form input cannot run arbitrary
         effects."""
         project = await self.ctx.repo_or_404(forge, owner, name, request)
@@ -272,7 +272,7 @@ class _ControlRoutes:
     async def regenerate_webhook_secret(
         self, request: Request, project_id: int
     ) -> HTMLResponse:
-        """Rotate and show the webhook secret once; it is never
+        """Rotate and show the webhook secret once. It is never
         readable afterwards."""
         await self._require_repo_admin(request, project_id)
         secret = await WebhookSecrets(self.ctx.pool).rotate(project_id)
@@ -314,7 +314,7 @@ def create_control_api_router(
     authz: AuthzConfig,
     own_url: str,
 ) -> APIRouter:
-    """JSON control endpoints; part of the documented /api surface.
+    """JSON control endpoints. Part of the documented /api surface.
     API tokens authenticate via Authorization: Bearer."""
     router = APIRouter(prefix="/api", tags=["api"])
     routes = _ControlRoutes(ctx, backend, authz, own_url)

--- a/nixbot/nixbot/web/events.py
+++ b/nixbot/nixbot/web/events.py
@@ -1,7 +1,7 @@
 """Live status events for the web frontend.
 
 Postgres triggers (migration 0005) NOTIFY on every build/attribute
-status change; the broker holds one LISTEN connection and fans the
+status change. The broker holds one LISTEN connection and fans the
 payloads out to SSE subscribers. Pages refetch fragments or patch
 rows when an event arrives instead of polling on a timer.
 """
@@ -31,13 +31,13 @@ logger = logging.getLogger(__name__)
 CHANNEL = "build_events"
 KEEPALIVE_SECONDS = 30.0
 RECONNECT_SECONDS = 5.0
-# A burst of status changes is one "refetch" cue to a subscriber; emit
+# A burst of status changes is one "refetch" cue to a subscriber. Emit
 # at most one SSE write per this interval.
 COALESCE_SECONDS = 0.25
 # Long-lived streams must not keep a revoked viewer's visibility
-# snapshot forever; re-resolve it periodically.
+# snapshot forever. Re-resolve it periodically.
 VISIBILITY_REFRESH_SECONDS = 300.0
-# A slow client just loses events; each one only triggers a refetch
+# A slow client just loses events. Each one only triggers a refetch
 # of current state.
 QUEUE_SIZE = 64
 
@@ -72,7 +72,7 @@ class EventBroker:
         self._conn = await self.pool.acquire()
         await self._conn.add_listener(CHANNEL, self._on_notify)
         # A killed connection (postgres restart) would silence events
-        # forever; reconnect in the background.
+        # forever. Reconnect in the background.
         self._conn.add_termination_listener(self._on_termination)
 
     async def stop(self) -> None:
@@ -164,7 +164,7 @@ async def event_stream(
             if payload is None:
                 yield ": keepalive\n\n"
                 continue
-            # Drop the rest of the burst; one refetch covers them all.
+            # Drop the rest of the burst. One refetch covers them all.
             while not sub.queue.empty():
                 sub.queue.get_nowait()
             yield f"data: {payload}\n\n"

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -49,7 +49,7 @@ class LogRegistry:
 
     def __init__(self) -> None:
         self._writers: dict[tuple[int, str], LogWriter] = {}
-        # Scheduled-effect runs have no build_id; key them by run id in
+        # Scheduled-effect runs have no build_id. Key them by run id in
         # a separate map so the namespaces cannot collide.
         self._scheduled: dict[int, LogWriter] = {}
 
@@ -92,7 +92,7 @@ _RESET = _Style()
 def _apply_sgr(params: str, style: _Style) -> _Style:
     """SGR is stateful: codes modify the current style, they don't
     replace it. Unknown codes are ignored, which also covers colon
-    syntax (38:5:185 stays one unknown code); semicolon-separated
+    syntax (38:5:185 stays one unknown code). Semicolon-separated
     extended colors consume their arguments so e.g. 38;5;31 is not
     read as red."""
     fg, bold = style.fg, style.bold
@@ -119,7 +119,7 @@ def _apply_sgr(params: str, style: _Style) -> _Style:
 
 
 def _apply_osc(payload: str, style: _Style) -> _Style:
-    """OSC 8 opens/closes a hyperlink; every other OSC (window title
+    """OSC 8 opens/closes a hyperlink. Every other OSC (window title
     etc.) is dropped without touching the style."""
     if not payload.startswith("8;"):
         return style
@@ -146,7 +146,7 @@ def _render_segment(segment: str, style: _Style) -> str:
 
 
 def _ansi_convert(text: str, style: _Style) -> tuple[str, _Style]:
-    """Convert SGR colors to spans and OSC 8 to links; strip every
+    """Convert SGR colors to spans and OSC 8 to links. Strip every
     other sequence. `style` carries in from the previous chunk/line;
     the style left open at the end is returned for the next one."""
     out: list[str] = []
@@ -166,7 +166,7 @@ def ansi_to_html(text: str) -> str:
     return _ansi_convert(text, _RESET)[0]
 
 
-# Real escape sequences are tiny; a held-back "partial" larger than
+# Real escape sequences are tiny. A held-back "partial" larger than
 # this is an unterminated OSC that would buffer the live stream
 # forever.
 _TAIL_MAX = 4096
@@ -207,7 +207,7 @@ def render_log_lines(text: str) -> str:
             f'<span class="logline" id="L{i}">'
             f'<a class="lineno" href="#L{i}">{i}</a>{rendered}</span>'
         )
-    # .logline is display:block; a joining "\n" inside <pre> would
+    # .logline is display:block. A joining "\n" inside <pre> would
     # render as an extra blank line.
     return "".join(lines)
 
@@ -226,7 +226,7 @@ def phase_sep(name: str) -> str:
 
 
 def _phase_at(ph: list) -> dict[int, str]:
-    """0-based line -> phase name; empty phases collapse into the next."""
+    """0-based line -> phase name. Empty phases collapse into the next."""
     return {line: name for name, line in ph}
 
 
@@ -255,7 +255,7 @@ def render_rows(
 
 
 # A single huge derivation would insert tens of thousands of DOM nodes in
-# one swap and hang the tab. Render only a head+tail window; the elided
+# one swap and hang the tab. Render only a head+tail window. The elided
 # middle auto-loads as the reader scrolls, one bounded chunk at a time.
 _RENDER_HEAD = 2000
 _RENDER_TAIL = 3000
@@ -265,7 +265,7 @@ _RENDER_CHUNK = 2000
 
 def _chunk_marker(idx: int, base: str, start: int, end: int) -> str:
     """A marker that auto-loads lines [start, end) (0-based) once scrolled
-    into view, one bounded chunk at a time; htmx swaps the fetched rows
+    into view, one bounded chunk at a time. htmx swaps the fetched rows
     (and the next marker, if any) over it."""
     nxt = min(start + _RENDER_CHUNK, end)
     return (
@@ -285,12 +285,12 @@ def render_drv_window(
 ) -> str:
     """A derivation's log as anchored rows. The initial view (no range)
     is capped to a head+tail window with a load-more marker spanning the
-    gap; a range request renders lines [start, end) plus another marker
+    gap. A range request renders lines [start, end) plus another marker
     if more of the gap remains before the tail."""
     lines = reader.lines(idx)
     ph = _phase_at(reader.entry(idx)["ph"])
     n = len(lines)
-    gap_end = n - _RENDER_TAIL  # tail starts here; never render past it
+    gap_end = n - _RENDER_TAIL  # tail starts here. Never render past it
     if start is None:
         if n <= _RENDER_CAP:
             return render_rows(idx, 1, lines, phases=ph)[0]
@@ -377,7 +377,7 @@ async def _failure_summary(
     }
 
 
-# SSE history replay bound (lines); full logs stay available as raw
+# SSE history replay bound (lines). Full logs stay available as raw
 # downloads and in the static viewer.
 HISTORY_MAX_LINES = 2000
 
@@ -525,7 +525,7 @@ class _LogRoutes:
                 content = await asyncio.to_thread(render_log_lines, text)
             elif run.status == "running":
                 # Started but the writer is not registered yet (fetch /
-                # checkout runs before the first log byte); poll until it
+                # checkout runs before the first log byte). Poll until it
                 # appears instead of claiming the log is gone.
                 waiting = True
             else:
@@ -654,10 +654,10 @@ class _LogRoutes:
         idx: int,
     ) -> HTMLResponse:
         """Standalone, shareable page for one derivation's log. The
-        embedded card view caps its height; this page shows the same
+        embedded card view caps its height. This page shows the same
         rows full-width with working line permalinks. While the attribute
         is still running the rows come from the live capture (the client
-        follows the structured stream); once finished, from the container.
+        follows the structured stream). Once finished, from the container.
         Capture and container assign indices in the same registration
         order, so a link shared during the build stays valid after it."""
         project, build, path = await self._resolve(
@@ -720,7 +720,7 @@ class _LogRoutes:
         number: int,
         q: str = "",
     ) -> HTMLResponse:
-        """Search every attribute's container; per-derivation hit groups
+        """Search every attribute's container. Per-derivation hit groups
         (attr, name, line numbers), failures first. No container -> skipped.
         Returns rendered HTML the client swaps into #search-results."""
         _, build = await self._build_or_404(request, forge, owner, name, number)
@@ -789,7 +789,7 @@ class _LogRoutes:
             reader = await _load_container(path)
             if reader is not None:
                 # Structured viewer: per-derivation cards render lazily
-                # from /drv/{idx}; no flat body needed.
+                # from /drv/{idx}. No flat body needed.
                 toc = _toc_entries(reader)
             elif path is not None and path.exists():
                 data = await asyncio.to_thread(read_log, path)
@@ -798,7 +798,7 @@ class _LogRoutes:
                 )
             elif attr_status in ("pending", "building"):
                 # The build page links queued attributes before any
-                # log exists; show a waiting page instead of a 404.
+                # log exists. Show a waiting page instead of a 404.
                 waiting = True
             elif attr_status in NO_LOG_STATUSES:
                 # No build log, but eval failures carry a trace: show it
@@ -889,7 +889,7 @@ async def _stream_events(
 ) -> AsyncGenerator[str, None]:
     """History first, then live chunks (if a writer is running);
     everything rendered to HTML server-side so the client just
-    appends; the replayed history is tail-limited so a late
+    appends. The replayed history is tail-limited so a late
     subscriber to a huge log does not push megabytes through the
     ANSI renderer."""
     ansi = AnsiHtmlStream()

--- a/nixbot/nixbot/web/queries.py
+++ b/nixbot/nixbot/web/queries.py
@@ -73,7 +73,7 @@ class WebQueries:
         return dataclasses.asdict(row) if row else None
 
     async def repo_candidates(self, owner: str, name: str) -> list[dict[str, Any]]:
-        """All forges' rows for an unqualified owner/name; used by the
+        """All forges' rows for an unqualified owner/name. Used by the
         legacy-URL redirect to pick a target."""
         return _dicts(await gen.web_repo_candidates(self.pool, owner=owner, name=name))
 
@@ -97,7 +97,7 @@ class WebQueries:
         project_ids: list[int] | None = None,
         before: int | None = None,
     ) -> list[dict[str, Any]]:
-        """Activity feed; cursor on build id for infinite scroll."""
+        """Activity feed. Cursor on build id for infinite scroll."""
         return _dicts(
             await gen.web_recent_builds(
                 self.pool, project_ids=project_ids, before=before, limit_=limit

--- a/nixbot/nixbot/web/routing.py
+++ b/nixbot/nixbot/web/routing.py
@@ -3,12 +3,12 @@
 GitLab nested groups put "/" into the owner (e.g. "group/sub"), which
 plain `{owner}` parameters cannot match. The `owner` convertor accepts
 one or more path segments, but never segments that start a fixed route
-suffix (builds/rows/attrs/schedules); otherwise a multi-segment owner
+suffix (builds/rows/attrs/schedules). Otherwise a multi-segment owner
 would swallow `/builds/{number}` and misroute deeper URLs to the repo
 page. The `segment` convertor is the single-segment variant for the
 project name: without it, `/repos/f/a/b/rows` would parse as
 owner="a/b", name="rows" on the repo route. Repos literally named
-after a reserved word are not routable; the forges reserve these names
+after a reserved word are not routable. The forges reserve these names
 themselves (GitLab) or they are vanishingly unlikely.
 """
 
@@ -36,7 +36,7 @@ class SegmentConvertor(OwnerConvertor):
 
 
 def register_owner_convertor() -> None:
-    """Idempotent; must run before any route using `{owner:owner}` or
+    """Idempotent. Must run before any route using `{owner:owner}` or
     `{name:segment}`."""
     register_url_convertor("owner", OwnerConvertor())
     register_url_convertor("segment", SegmentConvertor())

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Structured per-derivation log viewer. Cards are server-rendered; htmx
+// Structured per-derivation log viewer. Cards are server-rendered. htmx
 // fetches each card's rows (/drv/{idx}) lazily on first open. Phase
 // dividers are inline sticky elements the server splices in (see
 // phase_sep in logs.py); CSS pins them, so there is no scroll math here.
@@ -105,7 +105,7 @@
     else pending = { card, idx, line }; // afterSwap completes the jump
   }
 
-  // Search results are server-rendered; the client only jumps into a
+  // Search results are server-rendered. The client only jumps into a
   // card, waiting for htmx to load its rows when they aren't yet present.
   must("search-results").addEventListener("click", (e) => {
     const a = /** @type {HTMLElement} */ (e.target).closest("a[data-idx]");
@@ -269,7 +269,7 @@
     });
     src.addEventListener("delta", (ev) => apply(JSON.parse(ev.data)));
     src.addEventListener("done", () => src.close());
-    // EventSource reconnects ~every 1s; if the server stays gone (engine
+    // EventSource reconnects ~every 1s. If the server stays gone (engine
     // restart) give up and reload so the finished log renders server-side.
     src.onerror = () => {
       if (++errors >= 5) {

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -300,7 +300,7 @@ h2 .status-icon {
 	opacity: 0.6;
 }
 
-/* Pill chrome on the build lists; headings keep plain text. No color
+/* Pill chrome on the build lists. Headings keep plain text. No color
    here: it would outweigh the .status.<state> variants below (higher
    specificity). currentColor keeps the border in sync with the state
    color. */
@@ -530,7 +530,7 @@ details.menu .menu-label {
 	}
 }
 @media (prefers-reduced-motion: reduce) {
-	/* A frozen ring reads as a rendering glitch; slow, small rotation
+	/* A frozen ring reads as a rendering glitch. Slow, small rotation
 	   is acceptable under reduced motion. */
 	.spinner {
 		animation-duration: 3s;
@@ -759,7 +759,7 @@ pre.log {
 .pipeline-meta {
 	font-size: 0.85rem;
 }
-/* Last ten builds, oldest to newest; bar height tracks duration. */
+/* Last ten builds, oldest to newest. Bar height tracks duration. */
 .pipeline-spark {
 	display: flex;
 	align-items: flex-end;
@@ -860,7 +860,7 @@ table td.empty-state {
 	align-self: center;
 }
 
-/* Wide tables scroll sideways inside a wrapper; display: block on
+/* Wide tables scroll sideways inside a wrapper. Display: block on
    the table itself would strip its screen-reader role. */
 .table-scroll {
 	overflow-x: auto;
@@ -910,7 +910,7 @@ details.webhook-setup summary {
 
 /* ======================================================================
    Structured log viewer (log.html + _macros.html drv_card).
-   Native <details> disclosure; only the summary chrome is styled.
+   Native <details> disclosure. Only the summary chrome is styled.
    Sections below: Cards, Log body, Phase bar, Search, Succeeded panel.
    ====================================================================== */
 
@@ -989,7 +989,7 @@ details.webhook-setup summary {
 	text-decoration: underline;
 }
 /* Log body: the scrolling line list htmx fetches into .log-lines.
-   Grow to fit, cap then scroll; smaller cap on phones. */
+   Grow to fit, cap then scroll. Smaller cap on phones. */
 .log-lines {
 	max-height: 21rem;
 	overflow: auto;
@@ -1048,7 +1048,7 @@ details.webhook-setup summary {
 	border-block: 1px dashed var(--border);
 	text-align: center;
 }
-/* Phase divider: inline separator the server splices in; sticky pins it
+/* Phase divider: inline separator the server splices in. Sticky pins it
    as the current-phase header. prev/next scroll siblings (see the JS). */
 .phase-sep {
 	position: sticky;

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -1012,15 +1012,15 @@ details.webhook-setup summary {
 	border: 1px solid var(--border);
 	border-radius: 8px;
 }
-/* Whole log stays in the DOM (Ctrl-F, anchors, selection, a11y);
-   content-visibility skips off-screen layout/paint. Fixed 20px row +
-   matching contain-intrinsic-size keeps the scrollbar honest and lets
-   the phase bar map scrollTop -> line by ROW_H (see structured-logs.js). */
+/* Whole log stays in the DOM (Ctrl-F, anchors, selection, a11y).
+   content-visibility skips off-screen layout/paint.
+   contain-intrinsic-size is only a layout estimate for unrendered rows. */
 .log-lines .logline {
 	display: flex;
-	height: 20px;
+	min-height: 20px;
 	line-height: 20px;
-	white-space: pre;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
 	content-visibility: auto;
 	contain-intrinsic-size: auto 20px;
 	scroll-margin-top: 2rem;

--- a/nixbot/nixbot/web/templates/_attributes.html
+++ b/nixbot/nixbot/web/templates/_attributes.html
@@ -6,8 +6,8 @@
   {% if count %}
     {% set eager = group in inline %}
     {# Eager groups (failures, building, any match under a search)
-       start open; the bulk stays collapsed and lazy. #}
-    {# id: idiomorph matches by it; positional matching mixes one
+       start open. The bulk stays collapsed and lazy. #}
+    {# id: idiomorph matches by it. Positional matching mixes one
        group's rows into another when a new group appears. #}
     <details class="attr-group"
              id="attrs-{{ group }}"

--- a/nixbot/nixbot/web/templates/_macros.html
+++ b/nixbot/nixbot/web/templates/_macros.html
@@ -8,7 +8,7 @@
   {%- endif -%}
 {%- endmacro %}
 {# The *_url helpers return "" for pull_based projects with non-http
-   clone URLs; render plain text instead of a broken href then. #}
+   clone URLs. Render plain text instead of a broken href then. #}
 {% macro maybe_link(url) -%}
   {%- if url -%}
     <a href="{{ url }}" rel="nofollow">{{ caller() }}</a>
@@ -59,10 +59,10 @@
               data-copy="{{ value }}"
               aria-label="copy {{ label }}">copy</button>
     {%- endmacro %}
-    {# Phase-bar widget; scroll position drives it client-side. #}
+    {# Phase-bar widget. Scroll position drives it client-side. #}
     {# Structured log card, shared by the finished page and the live SSE.
        On the finished page htmx fetches the rows into .log-lines on first
-       open (or immediately for the open card); live cards omit htmx and
+       open (or immediately for the open card). Live cards omit htmx and
        stream rows in over the SSE. Metadata rides on data-*. #}
     {% macro drv_card(d, base, open=false, live=false) -%}
       {%- set failed = d.status == "failed" -%}
@@ -79,7 +79,7 @@
           <span class="status-icon {{ state }}" aria-hidden="true"></span>
           <span class="card-text">
             <span class="card-name">{{ d.name }}</span>
-            {# .meta-status is what the live JS rewrites; the links stay. #}
+            {# .meta-status is what the live JS rewrites. The links stay. #}
             <span class="meta"><span class="meta-status">{{ meta }}</span>
             {% if live or d.n > 0 %}
               · <a href="{{ base }}/drv/{{ d.idx }}/view"

--- a/nixbot/nixbot/web/templates/_queue.html
+++ b/nixbot/nixbot/web/templates/_queue.html
@@ -2,7 +2,7 @@
 {% if queue %}
   <div class="section-row">
     <h2 class="section">Queue</h2>
-    {# UX only; the route enforces admin server-side. #}
+    {# UX only. The route enforces admin server-side. #}
     {% if can_cancel_queue %}
       <form method="post" action="/builds/cancel-all">
         <button>cancel all</button>

--- a/nixbot/nixbot/web/templates/_search_results.html
+++ b/nixbot/nixbot/web/templates/_search_results.html
@@ -1,4 +1,4 @@
-{# Grouped log-search hits (failures first); each line jumps into the
+{# Grouped log-search hits (failures first). Each line jumps into the
    owning card. Rendered server-side and swapped into #search-results. #}
 {% if not groups %}
   <p class="search-count">no matches</p>

--- a/nixbot/nixbot/web/templates/base.html
+++ b/nixbot/nixbot/web/templates/base.html
@@ -110,11 +110,11 @@
           const saved = groupState.get(g.dataset.group);
           if (saved !== undefined) g.open = saved;
           /* idiomorph swaps in the lazy placeholder without htmx
-             processing; without this the intersect trigger never
+             processing. Without this the intersect trigger never
              arms and the group stays on "loading". */
           htmx.process(g);
         }
-        /* SSE morphs render the unfiltered groups; refire an active
+        /* SSE morphs render the unfiltered groups. Refire an active
            search. Guarded on #main so the search swap can't loop. */
         const filter = document.querySelector("#attr-filter");
         if (e.detail.target.id === "main" && filter?.value) {

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -8,7 +8,7 @@
   hx-ext="sse, morph" sse-connect="/events?build={{ build.id }}"
 {% endblock bodyattrs %}
 {% block body %}
-  {# sseOpen re-checks state rendered before the stream connected; a
+  {# sseOpen re-checks state rendered before the stream connected. A
      status change in that gap (eval start, attr restart) would
      otherwise be lost. #}
   {# throttle, not delay: delay debounces, so a busy build's event
@@ -58,7 +58,7 @@
           </p>
         </div>
         <div class="controls">
-          {# UX only; the control routes enforce authz server-side. #}
+          {# UX only. The control routes enforce authz server-side. #}
           {% if can_control and build.status in RUNNING_STATUSES %}
             <form method="post" action="{{ build_path(project, build.number) }}/cancel">
               <button>cancel</button>

--- a/nixbot/nixbot/web/templates/drv.html
+++ b/nixbot/nixbot/web/templates/drv.html
@@ -28,7 +28,7 @@
   </main>
   {% if live %}
     {# Follow the running derivation over the attribute's structured
-       stream, filtered to this idx; a terminal status reloads into the
+       stream, filtered to this idx. A terminal status reloads into the
        finished (container-backed) page. #}
     {% set stream_url = build_path(project, build.number) ~ "/logs/" ~ (attr | urlencode) ~ "/stream?format=structured" %}
     <script>

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -60,7 +60,7 @@
         <div id="drv-list"
              {% if live_structured %}data-stream="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}/stream?format=structured"{% endif %}>
           {% if live_structured %}
-            {# Status groups matching the finished page; the JS moves
+            {# Status groups matching the finished page. The JS moves
                cards between them on status deltas. #}
             <div class="live-group" id="group-failed" hidden>
               <h2 class="section">
@@ -127,7 +127,7 @@
     const LIVE = {{ live | tojson }};
     const RUNNING = {{ (attr_status in ("pending", "building")) | tojson }};
     const log = document.getElementById("log");
-    /* Failures sit at the end; start there unless a line is linked. */
+    /* Failures sit at the end. Start there unless a line is linked. */
     if (log && !location.hash) log.scrollTop = log.scrollHeight;
     /* Queued or just (re)started with no stream yet: reload until it
        exists. Polling, not events: a status event sent before the

--- a/nixbot/nixbot/web/templates/repo.html
+++ b/nixbot/nixbot/web/templates/repo.html
@@ -128,7 +128,7 @@
                 {% endif %}
               </td>
               <td class="attr-status">
-                {# UX only; the run route enforces authz server-side. #}
+                {# UX only. The run route enforces authz server-side. #}
                 {% if can_run_schedules %}
                   <form method="post" action="{{ repo_path(project) }}/schedules/run">
                     <input type="hidden" name="schedule" value="{{ s.schedule }}">

--- a/nixbot/nixbot/web/templates/scheduled_log.html
+++ b/nixbot/nixbot/web/templates/scheduled_log.html
@@ -47,7 +47,7 @@
        running->running INSERT raised no further event to react to. */
     if (WAITING) setTimeout(() => location.reload(), 2000);
     /* Status changes for this run (INSERT running / terminal UPDATE)
-       arrive on the shared events channel; reload to re-render the
+       arrive on the shared events channel. Reload to re-render the
        header dot and, once finished, the server-side static log. */
     const events = new EventSource("/events?project={{ project.id }}");
     events.onmessage = (ev) => {

--- a/nixbot/nixbot/web/templating.py
+++ b/nixbot/nixbot/web/templating.py
@@ -36,7 +36,7 @@ class CachedStaticFiles(StaticFiles):
 
 
 def _static_version() -> str:
-    """Content hash over the static assets; bound into asset URLs so
+    """Content hash over the static assets. Bound into asset URLs so
     browser caches roll over on deploy."""
     digest = hashlib.sha256()
     for f in sorted(STATIC_DIR.rglob("*")):
@@ -105,7 +105,7 @@ def commit_url(project: dict[str, Any], sha: str) -> str:
 
 
 def repo_path(project: dict[str, Any]) -> str:
-    """Internal page path; accepts project rows and build rows joined
+    """Internal page path. Accepts project rows and build rows joined
     with the project (which carry the name as project_name)."""
     name = project.get("name") or project["project_name"]
     return f"/repos/{project['forge']}/{project['owner']}/{name}"
@@ -169,6 +169,6 @@ def make_env() -> Environment:
     env.globals["repo_path"] = repo_path
     env.globals["build_path"] = build_path
     env.globals["RUNNING_STATUSES"] = RUNNING_STATUSES
-    # Header login links; the service composition fills this in.
+    # Header login links. The service composition fills this in.
     env.globals["login_providers"] = []
     return env

--- a/nixbot/nixbot/webhooks.py
+++ b/nixbot/nixbot/webhooks.py
@@ -1,7 +1,7 @@
 """Webhook ingestion.
 
 Endpoints `/webhooks/{github,gitea,gitlab}` plus the legacy buildbot
-alias `/change_hook/github` (identical validation; the GitHub App
+alias `/change_hook/github` (identical validation. The GitHub App
 webhook secret is deployment-wide, so legacy hooks still verify).
 GitHub
 payloads are verified against the App-level webhook secret
@@ -13,7 +13,7 @@ fast with 500 so the GitHub App redelivers (Gitea and GitLab are
 backstopped by startup reconciliation).
 
 All pull requests build (no trust gating — the Nix sandbox is the
-trust boundary); merge-queue branches always build.
+trust boundary). Merge-queue branches always build.
 """
 
 from __future__ import annotations
@@ -53,7 +53,7 @@ def should_build_branch(
     branches: BranchConfigDict, default_branch: str, branch: str
 ) -> bool:
     """Default branch, configured extra branches, and merge-queue
-    branches build; everything else is ignored (PRs always build and
+    branches build. Everything else is ignored (PRs always build and
     are decided separately)."""
     return is_merge_queue_branch(branch) or branches.do_run(default_branch, branch)
 
@@ -63,7 +63,7 @@ def should_build_branch(
 
 def _constant_time_eq(a: str, b: str) -> bool:
     """hmac.compare_digest with str args raises TypeError on non-ASCII
-    input; forge headers are attacker-controlled, so compare bytes."""
+    input. Forge headers are attacker-controlled, so compare bytes."""
     return hmac.compare_digest(a.encode("utf-8", "replace"), b.encode())
 
 
@@ -135,7 +135,7 @@ class PrClosed:
 @dataclass(frozen=True)
 class CheckRerequested:
     """GitHub "Re-run" button. build_id round-trips via the check
-    run's external_id (set by GitHubCheckRunPoster); name resolves the
+    run's external_id (set by GitHubCheckRunPoster). Name resolves the
     per-attr restart. check_suite carries neither — head_sha is the
     fallback."""
 
@@ -189,7 +189,7 @@ def _parse_pr_event(
         pr_number=number,
         pr_author=f"{forge}:{(pr.get('user') or {}).get('login', '')}",
         # base.sha is frozen at PR creation while the base branch moves
-        # on; merge into the branch tip (fetched alongside) so the PR is
+        # on. Merge into the branch tip (fetched alongside) so the PR is
         # tested against the current base.
         base_sha=f"refs/heads/{base_ref}" if base_ref else base.get("sha"),
     )
@@ -228,7 +228,7 @@ def _parse_github_check_event(
     event_type: str, repo_id: str, payload: dict[str, Any]
 ) -> CheckRerequested | None:
     # "requested" fires on every push (push hook already covers that)
-    # and "created"/"completed" are echoes of our own posts; only the
+    # and "created"/"completed" are echoes of our own posts. Only the
     # explicit Re-run button matters.
     if payload.get("action") != "rerequested":
         return None
@@ -261,7 +261,7 @@ def parse_gitea_event(event_type: str, payload: dict[str, Any]) -> WebhookEvent 
         head = payload.get("after", "")
         if not head or set(head) == {"0"}:
             return None
-        # Gitea lists `commits` oldest-first; the pushed head is
+        # Gitea lists `commits` oldest-first. The pushed head is
         # `head_commit` (fall back to the commit matching `after`).
         head_commit: dict[str, Any] = payload.get("head_commit") or next(
             (
@@ -324,14 +324,14 @@ def parse_gitlab_event(  # noqa: PLR0911
         action = attrs.get("action", "")
         if action == "close":
             return PrClosed(forge="gitlab", forge_repo_id=repo_id, pr_number=number)
-        # No cancel on merge; see parse_github_event.
+        # No cancel on merge. See parse_github_event.
         if action not in ("open", "update", "reopen"):
             return None
         # Metadata-only updates (labels, title, milestone) carry no
-        # oldrev; only head-moving updates trigger a build.
+        # oldrev. Only head-moving updates trigger a build.
         if action == "update" and not attrs.get("oldrev"):
             return None
-        # No commit_message; see parse_github_event.
+        # No commit_message. See parse_github_event.
         target_branch = attrs.get("target_branch", "")
         # payload["user"] is the event actor, not the MR author (only
         # the author's numeric id is in the payload). pr_author grants
@@ -349,7 +349,7 @@ def parse_gitlab_event(  # noqa: PLR0911
             commit_sha=(attrs.get("last_commit") or {}).get("id", ""),
             pr_number=number,
             pr_author=pr_author,
-            # The payload has no base sha; the target branch head was
+            # The payload has no base sha. The target branch head was
             # fetched alongside, so merge against its ref.
             base_sha=f"refs/heads/{target_branch}" if target_branch else None,
         )
@@ -357,7 +357,7 @@ def parse_gitlab_event(  # noqa: PLR0911
 
 
 def parse_webhook_body(request: Request, body: bytes) -> dict[str, Any]:
-    """Decode the webhook payload; malformed input is a client error
+    """Decode the webhook payload. Malformed input is a client error
     (400), never a 500 that would trigger pointless redeliveries."""
     content_type = request.headers.get("Content-Type", "")
     try:
@@ -390,7 +390,7 @@ async def read_body(request: Request) -> bytes:
 
 
 class ChangeSink(Protocol):
-    """Receives parsed webhook events; the orchestrator side implements
+    """Receives parsed webhook events. The orchestrator side implements
     this. Must raise on database outage (translated to 500)."""
 
     async def submit(self, event: WebhookEvent) -> None: ...


### PR DESCRIPTION

Long lines ran off-screen: embedded cards needed horizontal scrolling
and the drv page widened the whole document, worse on mobile. Wrap so
the end of long store paths and compiler errors stays visible.

The fixed 20px row height was only needed by the ROW_H phase bar
removed in d9d0ba9244. Drop the stale comment referencing it.
