### PR TITLE
nbo: command line client for nixbot

### DIFF
--- a/devShells/default.nix
+++ b/devShells/default.nix
@@ -27,6 +27,8 @@ in
       # from sqlc.yaml.
       sqlc
       devProcessCompose
+      # nbo, the CLI client
+      self.packages.${system}.nixbot-cli
       (pkgs.python3.withPackages (
         ps:
         [

--- a/devShells/default.nix
+++ b/devShells/default.nix
@@ -38,6 +38,7 @@ in
           ps.pytest-xdist
           ps.pytest-benchmark
           ps.playwright
+          ps.pyte
         ]
         ++ self.packages.${system}.nixbot.dependencies
       ))

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,88 @@
+# Command-line client (nbo)
+
+`nbo` lets you inspect and control builds on a nixbot instance from the
+terminal: list builds, watch them finish, read failure logs, and restart or
+cancel builds.
+
+Run it directly:
+
+```console
+nix run github:nix-community/nixbot#nixbot-cli -- --help
+```
+
+or add the `nixbot-cli` package to your profile or dev shell to get the `nbo`
+command.
+
+## Connecting to a server
+
+Point `nbo` at your instance with the `NIXBOT_URL` environment variable or a
+config file:
+
+```console
+export NIXBOT_URL=https://ci.example.org
+```
+
+```toml
+# ~/.config/nixbot/hosts.toml
+["https://ci.example.org"]
+token = "bnix_..."
+```
+
+Read-only commands work without a token on public instances.
+
+### API tokens
+
+Restarting or cancelling builds and enabling repositories require an API token.
+Log in to the web UI of your instance and create one under **Settings**
+(`https://ci.example.org/settings`), then either put it in `hosts.toml` as shown
+above or export it:
+
+```console
+export NIXBOT_TOKEN=bnix_...
+```
+
+`nbo auth status` shows which server and token are in use and whether the server
+is reachable.
+
+## Repositories and builds
+
+Inside a checkout the repository is inferred from the `origin` remote and the
+build number from the `HEAD` commit; both can be given explicitly
+(`-R [forge/]owner/name`, a build number as first argument).
+
+```console
+nbo repo list
+nbo repo enable github/acme/widget      # admin token required
+nbo build list --branch main
+nbo build view 412                      # status, attribute summary, failed attributes
+nbo build watch 412                     # follow until it finishes, exit 1 on failure
+nbo build restart 412 --attr checks.x86_64-linux.treefmt
+nbo build restart 412 --effects
+nbo build cancel 412
+```
+
+`--json [fields]` on list/view/log commands prints machine-readable output,
+optionally projected to a comma-separated field list.
+
+## Logs
+
+```console
+nbo log 412                                         # failure summary with log tails
+nbo log 412 checks.x86_64-linux.nixos-test --tail 200
+nbo log 412 /nix/store/...-zfs-2.2.4.drv            # one derivation of the attribute
+nbo log 412 checks.x86_64-linux.nixos-test --follow # stream while it runs
+```
+
+Attribute arguments accept unambiguous substrings.
+
+## Exit codes
+
+| code | meaning                              |
+| ---- | ------------------------------------ |
+| 0    | success                              |
+| 1    | the build or attribute failed        |
+| 2    | usage error / not found              |
+| 4    | authentication or permission failure |
+
+Scripts and agents can also use the underlying HTTP API directly: every instance
+documents it under `/llms.txt` and `/api/openapi.json`.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -41,6 +41,16 @@ above or export it:
 export NIXBOT_TOKEN=bnix_...
 ```
 
+Instead of storing the token in plain text you can have `nbo` fetch it from a
+password manager such as `pass` or `rbw` on every run:
+
+```toml
+# ~/.config/nixbot/hosts.toml
+["https://ci.example.org"]
+token_command = "pass show ci.example.org/nixbot"
+# or: token_command = "rbw get nixbot-ci"
+```
+
 `nbo auth status` shows which server and token are in use and whether the server
 is reachable.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -66,7 +66,8 @@ nbo repo enable github/acme/widget      # admin token required
 nbo build list --branch main
 nbo build view 412                      # status, attribute summary, failed attributes
 nbo build watch 412                     # follow until it finishes, exit 1 on failure
-nbo build restart 412 --attr checks.x86_64-linux.treefmt
+nbo build watch 412 --attr treefmt --attr nixos-eve   # wait only for these attributes
+nbo build restart 412 --attr x86_64-linux.treefmt     # a substring like "treefmt" works too
 nbo build restart 412 --effects
 nbo build cancel 412
 ```

--- a/formatter/treefmt.nix
+++ b/formatter/treefmt.nix
@@ -79,6 +79,7 @@
         pkgs.python3.pkgs.zstandard
         pkgs.python3.pkgs.python-multipart
         pkgs.python3.pkgs.playwright
+        pkgs.python3.pkgs.pyte
       ];
     };
   };

--- a/formatter/treefmt.nix
+++ b/formatter/treefmt.nix
@@ -89,6 +89,7 @@
   settings.formatter."mypy-" = lib.mkIf pkgs.stdenv.buildPlatform.isLinux {
     includes = [
       "nixbot/**/*.py"
+      "nixbot_cli/**/*.py"
       "nixbot_effects/**/*.py"
     ];
   };

--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -29,6 +29,7 @@ __all__: collections.abc.Sequence[str] = (
     "web_attribute_neighbor_numbers",
     "web_attribute_page",
     "web_attributes",
+    "web_attributes_finished_after",
     "web_build_by_number",
     "web_builds_for_repo",
     "web_effects",
@@ -281,6 +282,15 @@ ORDER BY CASE
 END, a.attr
 """
 
+WEB_ATTRIBUTES_FINISHED_AFTER: typing.Final[str] = """-- name: WebAttributesFinishedAfter :many
+SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated FROM build_attributes a
+WHERE a.build_id = $1 AND a.finished_at IS NOT NULL
+  AND ($2::timestamptz IS NULL
+       OR (a.finished_at, a.id) > ($2::timestamptz,
+                                   $3::bigint))
+ORDER BY a.finished_at, a.id
+"""
+
 WEB_BUILD_BY_NUMBER: typing.Final[str] = """-- name: WebBuildByNumber :one
 SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds WHERE project_id = $1 AND number = $2
 """
@@ -519,6 +529,12 @@ def web_attributes(conn: ConnectionLike, *, build_id: int) -> QueryResults[model
     def _decode_hook(row: asyncpg.Record) -> models.BuildAttribute:
         return models.BuildAttribute(id=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], log_size=row[11], log_truncated=row[12])
     return QueryResults[models.BuildAttribute](conn, WEB_ATTRIBUTES, _decode_hook, build_id)
+
+
+def web_attributes_finished_after(conn: ConnectionLike, *, build_id: int, after: datetime.datetime | None, after_id: int) -> QueryResults[models.BuildAttribute]:
+    def _decode_hook(row: asyncpg.Record) -> models.BuildAttribute:
+        return models.BuildAttribute(id=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], log_size=row[11], log_truncated=row[12])
+    return QueryResults[models.BuildAttribute](conn, WEB_ATTRIBUTES_FINISHED_AFTER, _decode_hook, build_id, after, after_id)
 
 
 async def web_build_by_number(conn: ConnectionLike, *, project_id: int, number: int) -> models.Build | None:

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -548,8 +548,8 @@ class StructuredCapture:
         with contextlib.suppress(ValueError):
             self._subs.remove(q)
 
-    def state(self) -> list[dict]:
-        st = self._w.state()
+    def state(self, *, with_lines: bool = True) -> list[dict]:
+        st = self._w.state(with_lines=with_lines)
         for e in st:
             if e["idx"] in self._running_idx:
                 e["status"] = "running"

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -574,7 +574,9 @@ class StructuredCapture:
         if drv_path not in self._idx:
             self._idx[drv_path] = len(self._idx)
         self._running.add(drv_path)
-        self._emit({"t": "drv", "idx": self._idx[drv_path], "name": name})
+        self._emit(
+            {"t": "drv", "idx": self._idx[drv_path], "drv": drv_path, "name": name}
+        )
 
     def _bump(self, drv: str) -> int:
         self._seen[drv] = self._seen.get(drv, 0) + 1
@@ -647,7 +649,14 @@ class StructuredCapture:
             name = _drv_display_name(drv_path)
             self._w.register(drv_path, name)
             self._idx[drv_path] = len(self._idx)
-            self._emit({"t": "drv", "idx": self._idx[drv_path], "name": name})
+            self._emit(
+                {
+                    "t": "drv",
+                    "idx": self._idx[drv_path],
+                    "drv": drv_path,
+                    "name": name,
+                }
+            )
         self._w.status(drv_path, status)
         self._running.discard(drv_path)
         self._emit({"t": "status", "idx": self._idx[drv_path], "status": status})

--- a/nixbot/nixbot/logstore.py
+++ b/nixbot/nixbot/logstore.py
@@ -126,6 +126,7 @@ class LogContainerWriter:
         return [
             {
                 "idx": i,
+                "drv": drv,
                 "name": d.name,
                 "status": d.status,
                 "ph": d.phases,
@@ -134,7 +135,7 @@ class LogContainerWriter:
                 "t1": d.t1,
                 "n": d.count,
             }
-            for i, d in enumerate(self._drvs.values())
+            for i, (drv, d) in enumerate(self._drvs.items())
         ]
 
     def finalize(self) -> bytes:
@@ -157,10 +158,11 @@ class LogContainerWriter:
             off += len(fr)
             buf, members, bufbytes = [], [], 0
 
-        for d in self._drvs.values():
+        for drv, d in self._drvs.items():
             lines = d.lines
             txt = "".join(t + "\n" for t in lines).encode()
             e = {
+                "drv": drv,
                 "name": d.name,
                 "status": d.status,
                 "off": 0,

--- a/nixbot/nixbot/logstore.py
+++ b/nixbot/nixbot/logstore.py
@@ -120,9 +120,10 @@ class LogContainerWriter:
         """(name, lines) for derivations left in a failed status."""
         return [(d.name, d.lines) for d in self._drvs.values() if d.status == "failed"]
 
-    def state(self) -> list[dict]:
+    def state(self, *, with_lines: bool = True) -> list[dict]:
         """Current per-derivation state for a live snapshot burst. Mirrors
-        the finalized TOC plus the lines seen so far."""
+        the finalized TOC plus the lines seen so far. with_lines=False
+        (the JSON API) omits the line history and keeps only counts."""
         return [
             {
                 "idx": i,
@@ -130,7 +131,7 @@ class LogContainerWriter:
                 "name": d.name,
                 "status": d.status,
                 "ph": d.phases,
-                "lines": d.lines,
+                **({"lines": d.lines} if with_lines else {}),
                 "t0": d.t0,
                 "t1": d.t1,
                 "n": d.count,

--- a/nixbot/nixbot/migrations/0022_attr_finished_idx.sql
+++ b/nixbot/nixbot/migrations/0022_attr_finished_idx.sql
@@ -1,0 +1,3 @@
+-- Cursor queries for build watchers: attributes finished since (finished_at, id).
+CREATE INDEX build_attributes_build_finished_idx
+    ON build_attributes (build_id, finished_at);

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -106,6 +106,15 @@ ORDER BY CASE
     ELSE 4
 END, a.attr;
 
+-- name: WebAttributesFinishedAfter :many
+-- Cursor feed for build watchers: (after, after_id) is the last row already seen.
+SELECT a.* FROM build_attributes a
+WHERE a.build_id = $1 AND a.finished_at IS NOT NULL
+  AND (sqlc.narg(after)::timestamptz IS NULL
+       OR (a.finished_at, a.id) > (sqlc.narg(after)::timestamptz,
+                                   sqlc.arg(after_id)::bigint))
+ORDER BY a.finished_at, a.id;
+
 -- name: WebEffects :many
 SELECT * FROM build_effects WHERE build_id = $1 ORDER BY name;
 

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import httpx
 import pytest
 import zstandard
 from nixbot_cli import main as cli
@@ -259,3 +260,46 @@ def test_settings_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert Settings.load() == Settings("https://ci.example.org", "bnix_abc")
     monkeypatch.setenv("NIXBOT_TOKEN", "bnix_env")
     assert Settings.load().token == "bnix_env"  # noqa: S105 (test credential)
+
+
+def test_log_follow_finished_attr_falls_back_to_stored_log(
+    api: NixbotClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A finished attribute has no live stream. --follow prints the log."""
+    assert run_cli(api, "log", "1", "bad1", "--follow", "-R", "acme/widget") == 1
+    out = capsys.readouterr().out
+    assert "CC main.o" in out
+    assert "error: boom" in out
+
+
+def test_log_follow_renders_live_stream(capsys: pytest.CaptureFixture[str]) -> None:
+    """The structured SSE stream (as emitted by /logs/{attr}/stream)
+    becomes derivation headers, phase separators and raw lines."""
+    body = (
+        'event: state\ndata: [{"idx":0,"drv":"/nix/store/aaa-hello-1.0.drv",'
+        '"name":"hello-1.0","status":"running","n":3}]\n\n'
+        ": keepalive\n\n"
+        'event: drv\ndata: {"t":"drv","idx":1,"drv":"/nix/store/bbb-dep.drv","name":"dep-2.0"}\n\n'
+        'event: phase\ndata: {"t":"phase","idx":0,"phase":"buildPhase","line":3}\n\n'
+        'event: line\ndata: {"t":"line","idx":0,"from":4,"text":"CC main.o"}\n\n'
+        'event: drv-done\ndata: {"t":"status","idx":0,"status":"failed"}\n\n'
+        "event: done\ndata: {}\n\n"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/logs/broken/stream")
+        return httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+
+    client = NixbotClient(
+        http=httpx.Client(
+            base_url="http://test", transport=httpx.MockTransport(handler)
+        )
+    )
+    cli.follow_attr(client, REPO, 5, "broken", tail=None)
+    out = capsys.readouterr().out
+    assert "── dep-2.0 ──" in out
+    assert "── hello-1.0: buildPhase ──" in out
+    assert "CC main.o" in out
+    assert "hello-1.0: ✗ failed" in out

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -1,0 +1,261 @@
+"""nbo commands (nixbot_cli.main) against the real web app."""
+
+# ruff: noqa: PLR2004 (literal values in test assertions are fine)
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import zstandard
+from nixbot_cli import main as cli
+from nixbot_cli.api import NixbotClient, RepoRef
+from nixbot_cli.config import Settings
+
+from nixbot.api_tokens import ApiTokenStore
+from nixbot.auth import AuthzConfig, User
+from nixbot.executor import attribute_log_path, container_path
+from nixbot.logstore import LogContainerWriter
+from nixbot.web.control_routes import create_control_api_router
+
+from .support import (
+    WebHarness,
+    db_pool,
+    git,
+    init_upstream,
+    insert_build,
+    insert_project,
+    web_harness,
+)
+from .test_cli_api import make_client
+from .test_control import FakeBackend
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    import asyncpg
+    from fastapi import FastAPI
+
+REPO = RepoRef("github", "acme", "widget")
+ROOT = User(provider="github", username="root")
+COMMIT = "c0ffee1234c0ffee1234c0ffee1234c0ffee1234"
+BACKEND = FakeBackend()
+
+
+@pytest.fixture(scope="module")
+async def postgres_dsn(postgres_dsn: str) -> str:
+    async with db_pool(postgres_dsn) as pool:
+        project_id = await insert_project(pool, forge_repo_id="cli-cmd")
+        failed = await insert_build(
+            pool, project_id, number=1, status="failed", commit_sha=COMMIT
+        )
+        await insert_build(
+            pool, project_id, number=2, status="building", branch="pr", started=True
+        )
+        await pool.execute(
+            """
+            INSERT INTO build_attributes (build_id, attr, system, status, error, drv_path)
+            VALUES
+              ($1, 'good', 'x86_64-linux', 'succeeded', NULL, '/nix/store/aaa-good.drv'),
+              ($1, 'bad1', 'x86_64-linux', 'failed', 'builder failed',
+               '/nix/store/bbb-hello-1.0.drv')
+            """,
+            failed,
+        )
+    return postgres_dsn
+
+
+@pytest.fixture(scope="module")
+def harness(postgres_dsn: str) -> Iterator[WebHarness]:
+    def configure(app: FastAPI, pool: asyncpg.Pool) -> None:
+        ctx = app.state.web_context
+        ctx.authz = AuthzConfig(admins=["github:root"])
+        ctx.token_store = ApiTokenStore(pool)
+        app.include_router(
+            create_control_api_router(
+                ctx, BACKEND, AuthzConfig(admins=["github:root"]), "http://test"
+            )
+        )
+
+    with web_harness(postgres_dsn, configure=configure) as h:
+        yield h
+
+
+@pytest.fixture(scope="module")
+def api(harness: WebHarness) -> NixbotClient:
+    store = harness.ctx.token_store
+    assert store is not None
+    return make_client(harness, token=harness.run(store.create(ROOT, "cli")))
+
+
+def run_cli(client: NixbotClient, *argv: str) -> int:
+    """Parse argv like nbo and run the selected command."""
+    args = cli.build_parser().parse_args(argv)
+    return int(args.func(client, args))
+
+
+def test_repo_list_and_toggle(
+    api: NixbotClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert run_cli(api, "repo", "list") == 0
+    assert "github/acme/widget" in capsys.readouterr().out
+
+    assert run_cli(api, "repo", "disable", "acme/widget") == 0
+    assert "disabled" in capsys.readouterr().out
+    assert run_cli(api, "repo", "enable", "github/acme/widget") == 0
+    assert api.repo(REPO)["enabled"] is True
+    capsys.readouterr()
+
+
+def test_build_list_and_view(
+    api: NixbotClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert run_cli(api, "build", "list", "-R", "github/acme/widget") == 0
+    out = capsys.readouterr().out
+    assert "1" in out
+    assert "✗ failed" in out
+
+    assert (
+        run_cli(
+            api,
+            "build",
+            "list",
+            "-R",
+            "acme/widget",
+            "--status",
+            "building",
+            "--json",
+            "number,status",
+        )
+        == 0
+    )
+    assert '"number": 2' in capsys.readouterr().out
+
+    assert run_cli(api, "build", "view", "1", "-R", "acme/widget") == 0
+    out = capsys.readouterr().out
+    assert "build #1" in out
+    assert "1 failed" in out
+    assert "bad1" in out
+
+
+def test_build_restart_cancel(
+    api: NixbotClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    BACKEND.attr_restarts.clear()
+    assert (
+        run_cli(api, "build", "restart", "1", "-R", "acme/widget", "--attr", "bad1")
+        == 0
+    )
+    assert [a for _, a in BACKEND.attr_restarts] == ["bad1"]
+    assert run_cli(api, "build", "restart", "1", "-R", "acme/widget", "--effects") == 0
+    assert run_cli(api, "build", "cancel", "2", "-R", "acme/widget") == 0
+    assert "cancelling build #2" in capsys.readouterr().out
+    assert len(BACKEND.cancelled) == 1
+
+
+def test_log_summary_attr_and_drv(
+    harness: WebHarness,
+    api: NixbotClient,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    async def seed() -> None:
+        harness.ctx.state_dir = tmp_path
+        build_id = await harness.ctx.pool.fetchval(
+            "SELECT id FROM builds WHERE number = 1"
+        )
+        log_file = attribute_log_path(tmp_path, build_id, "bad1")
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        log_file.write_bytes(
+            zstandard.ZstdCompressor().compress(b"CC main.o\nerror: boom\n")
+        )
+        w = LogContainerWriter()
+        w.register("/nix/store/bbb-hello-1.0.drv", "hello-1.0")
+        w.line("/nix/store/bbb-hello-1.0.drv", "CC main.o")
+        w.line("/nix/store/bbb-hello-1.0.drv", "error: boom")
+        w.status("/nix/store/bbb-hello-1.0.drv", "failed")
+        container_path(log_file).write_bytes(w.finalize())
+
+    harness.run(seed())
+
+    # Whole build: failure summary, exit reflects the build result.
+    assert run_cli(api, "log", "1", "-R", "acme/widget") == 1
+    out = capsys.readouterr().out
+    assert "── bad1 ──" in out
+    assert "error: boom" in out
+
+    # Attribute substring with --tail limiting the output.
+    assert run_cli(api, "log", "1", "bad", "-R", "acme/widget", "--tail", "1") == 1
+    assert capsys.readouterr().out == "error: boom\n"
+
+    # A .drv store path scopes to that derivation.
+    assert (
+        run_cli(
+            api,
+            "log",
+            "1",
+            "/nix/store/bbb-hello-1.0.drv",
+            "-R",
+            "acme/widget",
+            "--tail",
+            "1",
+        )
+        == 1
+    )
+    assert capsys.readouterr().out == "error: boom\n"
+
+    with pytest.raises(cli.UsageError, match="no attribute"):
+        run_cli(api, "log", "1", "nope", "-R", "acme/widget")
+
+
+def test_repo_and_build_inference(
+    harness: WebHarness,
+    api: NixbotClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without -R and a number, the repo comes from the git remote and
+    the build from the HEAD commit."""
+    checkout = init_upstream(tmp_path / "repo")
+    git(checkout, "remote", "add", "origin", "git@github.com:acme/widget.git")
+    head = git(checkout, "rev-parse", "HEAD")
+    monkeypatch.chdir(checkout)
+
+    assert cli.resolve_repo(api, None) == REPO
+    with pytest.raises(cli.UsageError, match="no build for commit"):
+        cli.resolve_build(api, REPO, None)
+    harness.run(
+        harness.ctx.pool.execute(
+            "UPDATE builds SET commit_sha = $1 WHERE number = 2", head
+        )
+    )
+    assert cli.resolve_build(api, REPO, None) == 2
+
+
+def test_auth_status(
+    api: NixbotClient,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NIXBOT_URL", "http://test")
+    monkeypatch.setenv("NIXBOT_TOKEN", "bnix_secret")
+    assert run_cli(api, "auth", "status") == 0
+    out = capsys.readouterr().out
+    assert "server: http://test" in out
+    assert "bnix_sec" in out
+    assert "server is reachable" in out
+
+
+def test_settings_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NIXBOT_URL", raising=False)
+    monkeypatch.delenv("NIXBOT_TOKEN", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    with pytest.raises(ValueError, match="no server configured"):
+        Settings.load()
+    hosts = tmp_path / "nixbot" / "hosts.toml"
+    hosts.parent.mkdir(parents=True)
+    hosts.write_text('["https://ci.example.org"]\ntoken = "bnix_abc"\n')
+    assert Settings.load() == Settings("https://ci.example.org", "bnix_abc")
+    monkeypatch.setenv("NIXBOT_TOKEN", "bnix_env")
+    assert Settings.load().token == "bnix_env"  # noqa: S105 (test credential)

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -405,3 +405,71 @@ def test_sanitize_line_defuses_terminal_control_output() -> None:
 
     progress = "downloading   0%\rdownloading 100%"
     assert sanitize_line(progress) == "downloading 100%"
+
+
+def test_build_watch_attr_waits_for_selected_attributes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--attr waits only for the given attributes and mirrors their result
+    in the exit code, with a log tail and URL for the failed one."""
+    build = {"id": 9, "number": 5, "status": "building"}
+    attrs = [
+        {
+            "id": 1,
+            "attr": "quick",
+            "status": "succeeded",
+            "cached": True,
+            "finished_at": "2026-01-01T00:00:01Z",
+        },
+        {
+            "id": 2,
+            "attr": "slow",
+            "status": "building",
+            "cached": False,
+            "finished_at": None,
+        },
+        {
+            "id": 3,
+            "attr": "other",
+            "status": "building",
+            "cached": False,
+            "finished_at": None,
+        },
+    ]
+    hint = 'data: {"build_id":9,"attr":"slow","status":"failed"}\n\n'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/builds/5"):
+            return httpx.Response(200, json={"build": build, "attributes": attrs})
+        if path == "/api/events":
+            attrs[1] = {
+                "id": 2,
+                "attr": "slow",
+                "status": "failed",
+                "cached": False,
+                "error": "builder failed",
+                "finished_at": "2026-01-01T00:00:02Z",
+            }
+            return httpx.Response(
+                200, content=hint, headers={"content-type": "text/event-stream"}
+            )
+        if path.endswith("/builds/5/attrs"):
+            done = [a for a in attrs if a["finished_at"]]
+            return httpx.Response(200, json={"build": build, "items": done})
+        if path.endswith("/logs/slow/text"):
+            return httpx.Response(200, text="error: boom\n")
+        raise AssertionError(path)
+
+    client = NixbotClient(
+        http=httpx.Client(
+            base_url="http://test", transport=httpx.MockTransport(handler)
+        )
+    )
+    assert cli.watch_attrs(client, REPO, 5, ["quick", "slow"]) == 1
+    out = capsys.readouterr().out
+    assert "✓ cached quick" in out
+    assert "✗ failed slow" in out
+    assert "logs/raw/slow" in out
+    assert "error: boom" in out
+    assert "other" not in out

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -12,6 +12,7 @@ import zstandard
 from nixbot_cli import main as cli
 from nixbot_cli.api import NixbotClient, RepoRef
 from nixbot_cli.config import Settings
+from nixbot_cli.term import sanitize_line
 
 from nixbot.api_tokens import ApiTokenStore
 from nixbot.auth import AuthzConfig, User
@@ -391,3 +392,16 @@ def test_build_watch_reports_progress_and_failures(
     assert "✗ failed bad" in out
     assert "build #5: 2 finished, 1 failed" in out
     assert "error: boom" in out
+
+
+def test_sanitize_line_defuses_terminal_control_output() -> None:
+    """VM/BIOS boot logs (SeaBIOS etc.) emit clear-screen, cursor moves and
+    charset switches that must never reach our terminal, while colors stay."""
+    bios = "\x1b[2J\x1b[1;1H\x1b(B\x00SeaBIOS (version rel-1.17.0)\x07\tbooting"
+    assert sanitize_line(bios) == "SeaBIOS (version rel-1.17.0)    booting"
+
+    colored = "\x1b[31merror:\x1b[0m boom\x1b]0;title\x07"
+    assert sanitize_line(colored) == "\x1b[31merror:\x1b[0m boom\x1b[0m"
+
+    progress = "downloading   0%\rdownloading 100%"
+    assert sanitize_line(progress) == "downloading 100%"

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -372,7 +372,7 @@ def test_build_watch_reports_progress_and_failures(
     )
     assert cli.watch_build(client, REPO, 5) == 1
     out = capsys.readouterr().out
-    assert "✓ succeeded good (cached)" in out
+    assert "✓ cached good" in out
     assert "✗ failed bad" in out
     assert "build #5: 2 finished, 1 failed" in out
     assert "error: boom" in out

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -262,6 +262,24 @@ def test_settings_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert Settings.load().token == "bnix_env"  # noqa: S105 (test credential)
 
 
+def test_settings_token_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The token can come from a secret manager command (pass, rbw, ...)."""
+    monkeypatch.delenv("NIXBOT_TOKEN", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    hosts = tmp_path / "nixbot" / "hosts.toml"
+    hosts.parent.mkdir(parents=True)
+    hosts.write_text(
+        '["https://ci.example.org"]\ntoken_command = "echo bnix_from_pass"\n'
+    )
+    assert Settings.load().token == "bnix_from_pass"  # noqa: S105 (test credential)
+
+    hosts.write_text('["https://ci.example.org"]\ntoken_command = "false"\n')
+    with pytest.raises(ValueError, match="token_command"):
+        Settings.load()
+
+
 def test_log_follow_finished_attr_falls_back_to_stored_log(
     api: NixbotClient, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -329,20 +329,35 @@ def test_build_watch_reports_progress_and_failures(
     """watch prints one verdict per finished attribute as events arrive
     and ends with the failure summary once the build is terminal."""
     build = {"id": 9, "number": 5, "status": "building"}
-    attrs = [
-        {"attr": "good", "status": "succeeded", "cached": True},
-        {"attr": "bad", "status": "building", "cached": False},
+    finished = [
+        {
+            "id": 1,
+            "attr": "good",
+            "status": "succeeded",
+            "cached": True,
+            "finished_at": "2026-01-01T00:00:01Z",
+        },
     ]
     hint = 'data: {"build_id":9,"attr":"bad","status":"failed"}\n\n'
 
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
-        if path.endswith("/builds/5"):
-            return httpx.Response(200, json={"build": build, "attributes": attrs})
+        if path.endswith("/builds/5/attrs"):
+            after = request.url.params.get("finished_after")
+            items = [a for a in finished if not after or a["finished_at"] > after]
+            return httpx.Response(200, json={"build": dict(build), "items": items})
         if path == "/api/events":
             assert request.url.params["build"] == "9"
             # After the hint the build finishes with one failed attribute.
-            attrs[1] = {"attr": "bad", "status": "failed", "cached": False}
+            finished.append(
+                {
+                    "id": 2,
+                    "attr": "bad",
+                    "status": "failed",
+                    "cached": False,
+                    "finished_at": "2026-01-01T00:00:02Z",
+                }
+            )
             build["status"] = "failed"
             return httpx.Response(
                 200, content=hint, headers={"content-type": "text/event-stream"}

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -303,3 +303,58 @@ def test_log_follow_renders_live_stream(capsys: pytest.CaptureFixture[str]) -> N
     assert "── hello-1.0: buildPhase ──" in out
     assert "CC main.o" in out
     assert "hello-1.0: ✗ failed" in out
+
+
+def test_build_watch_reports_progress_and_failures(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """watch prints one verdict per finished attribute as events arrive
+    and ends with the failure summary once the build is terminal."""
+    build = {"id": 9, "number": 5, "status": "building"}
+    attrs = [
+        {"attr": "good", "status": "succeeded", "cached": True},
+        {"attr": "bad", "status": "building", "cached": False},
+    ]
+    hint = 'data: {"build_id":9,"attr":"bad","status":"failed"}\n\n'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/builds/5"):
+            return httpx.Response(200, json={"build": build, "attributes": attrs})
+        if path == "/api/events":
+            assert request.url.params["build"] == "9"
+            # After the hint the build finishes with one failed attribute.
+            attrs[1] = {"attr": "bad", "status": "failed", "cached": False}
+            build["status"] = "failed"
+            return httpx.Response(
+                200, content=hint, headers={"content-type": "text/event-stream"}
+            )
+        if path.endswith("/failures"):
+            return httpx.Response(
+                200,
+                json={
+                    "status": "failed",
+                    "error": None,
+                    "failures": [
+                        {
+                            "attr": "bad",
+                            "status": "failed",
+                            "error": "builder failed",
+                            "log_tail": "error: boom",
+                        }
+                    ],
+                },
+            )
+        raise AssertionError(path)
+
+    client = NixbotClient(
+        http=httpx.Client(
+            base_url="http://test", transport=httpx.MockTransport(handler)
+        )
+    )
+    assert cli.watch_build(client, REPO, 5) == 1
+    out = capsys.readouterr().out
+    assert "✓ succeeded good (cached)" in out
+    assert "✗ failed bad" in out
+    assert "build #5: 2 finished, 1 failed" in out
+    assert "error: boom" in out

--- a/nixbot/nixbot/tests/test_cli_api.py
+++ b/nixbot/nixbot/tests/test_cli_api.py
@@ -42,9 +42,11 @@ async def postgres_dsn(postgres_dsn: str) -> str:
         await insert_build(pool, project_id, number=2, status="building", started=True)
         await pool.execute(
             """
-            INSERT INTO build_attributes (build_id, attr, system, status, error) VALUES
-              ($1, 'good', 'x86_64-linux', 'succeeded', NULL),
-              ($1, 'bad1', 'x86_64-linux', 'failed', 'builder failed')
+            INSERT INTO build_attributes
+              (build_id, attr, system, status, error, finished_at) VALUES
+              ($1, 'good', 'x86_64-linux', 'succeeded', NULL, '2026-01-01T00:00:01Z'),
+              ($1, 'bad1', 'x86_64-linux', 'failed', 'builder failed',
+               '2026-01-01T00:00:02Z')
             """,
             failed,
         )
@@ -123,6 +125,18 @@ def test_repos_and_builds(api: NixbotClient) -> None:
     assert [f["attr"] for f in failures["failures"]] == ["bad1"]
     assert [e["build_number"] for e in api.attr_history(REPO, "bad1")] == [1]
     assert [b["number"] for b in api.queue()] == [2]
+
+
+def test_finished_attrs_cursor(api: NixbotClient) -> None:
+    delta = api.finished_attrs(REPO, 1)
+    assert delta["build"]["status"] == "failed"
+    assert [a["attr"] for a in delta["items"]] == ["good", "bad1"]
+
+    good = delta["items"][0]
+    rest = api.finished_attrs(
+        REPO, 1, finished_after=good["finished_at"], after_id=good["id"]
+    )
+    assert [a["attr"] for a in rest["items"]] == ["bad1"]
 
 
 def test_control_requires_token(harness: WebHarness, api: NixbotClient) -> None:

--- a/nixbot/nixbot/tests/test_cli_api.py
+++ b/nixbot/nixbot/tests/test_cli_api.py
@@ -1,0 +1,178 @@
+"""nixbot_cli.api against the real web app via the ASGI transport."""
+
+# ruff: noqa: PLR2004 (literal values in test assertions are fine)
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from nixbot_cli.api import ApiError, NixbotClient, RepoRef
+
+from nixbot.api_tokens import ApiTokenStore
+from nixbot.auth import AuthzConfig, User
+from nixbot.executor import attribute_log_path, container_path
+from nixbot.logstore import LogContainerWriter
+from nixbot.web.control_routes import create_control_api_router
+
+from .support import WebHarness, db_pool, insert_build, insert_project, web_harness
+from .test_control import FakeBackend
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    import asyncpg
+    from fastapi import FastAPI
+
+REPO = RepoRef("github", "acme", "widget")
+ROOT = User(provider="github", username="root")
+AUTHZ = AuthzConfig(admins=["github:root"])
+
+
+BACKEND = FakeBackend()
+
+
+@pytest.fixture(scope="module")
+async def postgres_dsn(postgres_dsn: str) -> str:
+    async with db_pool(postgres_dsn) as pool:
+        project_id = await insert_project(pool, forge_repo_id="cli-1")
+        failed = await insert_build(pool, project_id, number=1, status="failed")
+        await insert_build(pool, project_id, number=2, status="building", started=True)
+        await pool.execute(
+            """
+            INSERT INTO build_attributes (build_id, attr, system, status, error) VALUES
+              ($1, 'good', 'x86_64-linux', 'succeeded', NULL),
+              ($1, 'bad1', 'x86_64-linux', 'failed', 'builder failed')
+            """,
+            failed,
+        )
+    return postgres_dsn
+
+
+@pytest.fixture(scope="module")
+def harness(postgres_dsn: str) -> Iterator[WebHarness]:
+    def configure(app: FastAPI, pool: asyncpg.Pool) -> None:
+        ctx = app.state.web_context
+        ctx.authz = AUTHZ
+        ctx.token_store = ApiTokenStore(pool)
+        app.include_router(
+            create_control_api_router(ctx, BACKEND, AUTHZ, "http://test")
+        )
+
+    with web_harness(postgres_dsn, configure=configure) as h:
+        yield h
+
+
+class _SyncASGITransport(httpx.BaseTransport):
+    """Bridges the CLI's sync httpx.Client onto the in-process app."""
+
+    def __init__(self, harness: WebHarness) -> None:
+        self.harness = harness
+        self.asgi = httpx.ASGITransport(app=harness.app)
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        async def send() -> httpx.Response:
+            response = await self.asgi.handle_async_request(request)
+            await response.aread()
+            return response
+
+        response = self.harness.run(send())
+        return httpx.Response(
+            response.status_code, headers=response.headers, content=response.content
+        )
+
+
+def make_client(harness: WebHarness, token: str | None = None) -> NixbotClient:
+    http = httpx.Client(transport=_SyncASGITransport(harness), base_url="http://test")
+    return NixbotClient(token=token, http=http)
+
+
+@pytest.fixture(scope="module")
+def api(harness: WebHarness) -> NixbotClient:
+    """Client authenticated with an admin's personal API token."""
+    store = harness.ctx.token_store
+    assert store is not None
+    return make_client(harness, token=harness.run(store.create(ROOT, "cli")))
+
+
+def test_repo_ref_parse() -> None:
+    assert RepoRef.parse("github/acme/widget") == REPO
+    assert str(REPO) == "github/acme/widget"
+    with pytest.raises(ValueError, match="forge/owner/name"):
+        RepoRef.parse("acme/widget")
+
+
+def test_repos_and_builds(api: NixbotClient) -> None:
+    assert [(r["owner"], r["name"]) for r in api.repos()] == [("acme", "widget")]
+    assert api.repo(REPO)["enabled"] is True
+    with pytest.raises(ApiError) as err:
+        api.repo(RepoRef("github", "acme", "nope"))
+    assert err.value.status == 404
+
+    page = api.builds(REPO)
+    assert {b["number"] for b in page["items"]} == {1, 2}
+    assert [b["number"] for b in api.builds(REPO, status="failed")["items"]] == [1]
+
+    detail = api.build(REPO, 1)
+    assert detail["build"]["status"] == "failed"
+    assert {a["attr"] for a in detail["attributes"]} == {"good", "bad1"}
+
+    failures = api.failures(REPO, 1)
+    assert [f["attr"] for f in failures["failures"]] == ["bad1"]
+    assert [e["build_number"] for e in api.attr_history(REPO, "bad1")] == [1]
+    assert [b["number"] for b in api.queue()] == [2]
+
+
+def test_control_requires_token(harness: WebHarness, api: NixbotClient) -> None:
+    with pytest.raises(ApiError) as err:
+        make_client(harness).restart_build(REPO, 1)
+    assert err.value.status == 403
+
+    assert api.restart_build(REPO, 1)["action"] == "restart"
+    assert api.cancel_build(REPO, 1)["action"] == "cancel"
+    assert api.restart_attr(REPO, 1, "bad1")["attr"] == "bad1"
+    assert api.cancel_attr(REPO, 1, "bad1")["attr"] == "bad1"
+    assert api.restart_effects(REPO, 1)["action"] == "restart-effects"
+    assert len(BACKEND.restarted) == 1
+    assert [a for _, a in BACKEND.attr_restarts] == ["bad1"]
+    assert [a for _, a in BACKEND.attr_cancels] == ["bad1"]
+
+    with pytest.raises(ApiError) as err:
+        api.restart_attr(REPO, 1, "nope")
+    assert err.value.status == 404
+
+
+def test_enable_disable(api: NixbotClient) -> None:
+    assert api.set_enabled(REPO, enabled=False)["enabled"] is False
+    assert api.repo(REPO)["enabled"] is False
+    assert api.set_enabled(REPO, enabled=True)["enabled"] is True
+
+
+def test_log_toc_and_text(
+    harness: WebHarness, api: NixbotClient, tmp_path: Path
+) -> None:
+    async def seed() -> None:
+        harness.ctx.state_dir = tmp_path
+        build_id = await harness.ctx.pool.fetchval(
+            "SELECT id FROM builds WHERE number = 1"
+        )
+        log_file = attribute_log_path(tmp_path, build_id, "bad1")
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        w = LogContainerWriter()
+        w.register("/nix/store/aaa-hello-1.0.drv", "hello-1.0")
+        w.line("/nix/store/aaa-hello-1.0.drv", "CC main.o")
+        w.line("/nix/store/aaa-hello-1.0.drv", "error: boom")
+        w.status("/nix/store/aaa-hello-1.0.drv", "failed")
+        container_path(log_file).write_bytes(w.finalize())
+
+    harness.run(seed())
+    toc = api.log_toc(REPO, 1, "bad1")
+    assert [d["name"] for d in toc["derivations"]] == ["hello-1.0"]
+
+    text = api.log_text(REPO, 1, "bad1", drv="hello", tail=1)
+    assert text == "error: boom\n"
+    with pytest.raises(ApiError) as err:
+        api.log_text(REPO, 1, "bad1", drv="nope")
+    assert err.value.status == 404

--- a/nixbot/nixbot/tests/test_cli_tty.py
+++ b/nixbot/nixbot/tests/test_cli_tty.py
@@ -222,6 +222,43 @@ def test_tty_watch_shows_finished_and_running_attrs() -> None:
     assert not any("build #5" in line for line in lines)
 
 
+def test_resize_burst_never_erases_verdicts() -> None:
+    """While the terminal is being resized (a burst of size changes, one
+    per frame) nothing may be erased and the region stays hidden until
+    the size settles again."""
+    size = {"cols": WIDTH, "rows": HEIGHT}
+    out = io.StringIO()
+    display = Display(out, size=lambda: (size["cols"], size["rows"]), origin=1)
+    screen = pyte.HistoryScreen(WIDTH, HEIGHT, history=1000)
+    stream = pyte.Stream(screen)
+
+    def frame(batch: list[str], region: list[str]) -> None:
+        mark = out.tell()
+        display.frame(batch, region)
+        stream.feed(out.getvalue()[mark:])
+
+    frame(["verdict-0", "verdict-1"], ["HEADER", "running"])
+    resize_output_start = out.tell()
+    for i, rows in enumerate((11, 10, 9)):  # drag in progress
+        size.update(rows=rows)
+        screen.resize(rows, WIDTH)
+        frame([f"verdict-{2 + i}"], ["HEADER", "running"])
+    burst = out.getvalue()[resize_output_start:]
+    assert "HEADER" not in burst  # region not redrawn mid-resize
+    assert "\x1b[J" not in burst  # nothing erased
+    assert "\x1b[2J" not in burst
+
+    # Once the size settles the visible screen is rebuilt from the model:
+    # most recent verdicts on top, region below, no stale copies.
+    frame(["verdict-5"], ["HEADER", "running"])
+    frame(["verdict-6"], ["HEADER", "running"])
+    visible = [row.rstrip() for row in screen.display]
+    shown = [line for line in visible if line.startswith("verdict-")]
+    assert shown == [f"verdict-{i}" for i in range(7)]
+    assert visible.index("HEADER") == len(shown)
+    assert sum("HEADER" in line for line in visible) == 1
+
+
 def test_long_verdicts_wrap_without_corrupting_region() -> None:
     out = io.StringIO()
     display = make_display(out)

--- a/nixbot/nixbot/tests/test_cli_tty.py
+++ b/nixbot/nixbot/tests/test_cli_tty.py
@@ -1,0 +1,234 @@
+"""nbo build watch TTY renderer against a pyte terminal emulator."""
+
+# ruff: noqa: PLR2004 (literal values in test assertions are fine)
+from __future__ import annotations
+
+import io
+import time
+
+import httpx
+import pyte
+from nixbot_cli.api import NixbotClient, RepoRef
+from nixbot_cli.watch_tty import Display, TtyWatch
+
+WIDTH, HEIGHT = 60, 12
+
+
+def emulate(chunks: str) -> pyte.HistoryScreen:
+    screen = pyte.HistoryScreen(WIDTH, HEIGHT, history=1000)
+    pyte.Stream(screen).feed(chunks)
+    return screen
+
+
+def buffer_lines(screen: pyte.HistoryScreen) -> list[str]:
+    """Scrollback plus visible rows, as plain text."""
+    history = [
+        "".join(line[x].data for x in range(WIDTH)).rstrip()
+        for line in screen.history.top
+    ]
+    return history + [row.rstrip() for row in screen.display]
+
+
+def make_display(out: io.StringIO) -> Display:
+    return Display(out, size=lambda: (WIDTH, HEIGHT))
+
+
+def test_verdicts_scroll_and_region_stays_at_bottom() -> None:
+    """Verdicts land in scrollback exactly once and in order, while the
+    live region only ever exists as the last rows of the screen."""
+    out = io.StringIO()
+    display = make_display(out)
+    verdicts = []
+    for i in range(40):
+        batch = [f"verdict-{i}-a", f"verdict-{i}-b"]
+        verdicts += batch
+        region = ["HEADER", f"running-{i}", f"gist-{i}"]
+        display.frame(batch, region)
+    display.close()
+
+    lines = buffer_lines(emulate(out.getvalue()))
+    kept = [line for line in lines if line.startswith("verdict-")]
+    assert kept == verdicts
+    assert sum("HEADER" in line for line in lines) == 0  # cleared on close
+
+
+def test_region_visible_while_running() -> None:
+    out = io.StringIO()
+    display = make_display(out)
+    for i in range(20):
+        display.frame([f"verdict-{i}"], ["HEADER", f"running-{i}"])
+
+    screen = emulate(out.getvalue())
+    lines = buffer_lines(screen)
+    # The region exists exactly once, at the bottom of the visible screen.
+    assert sum("HEADER" in line for line in lines) == 1
+    visible = [row.rstrip() for row in screen.display]
+    assert "HEADER" in visible[-2]
+    assert visible[-1] == "running-19"
+    # No verdict was lost or duplicated by the region redraws.
+    kept = [line for line in lines if line.startswith("verdict-")]
+    assert kept == [f"verdict-{i}" for i in range(20)]
+
+
+def test_region_growth_does_not_eat_verdicts() -> None:
+    """Reserving more bottom rows must not overwrite existing verdicts."""
+    out = io.StringIO()
+    display = make_display(out)
+    display.frame(["verdict-0"], ["HEADER"])
+    display.frame(["verdict-1"], ["HEADER", "run-a", "run-b", "run-c"])
+    display.frame([], ["HEADER"])
+    display.close()
+
+    lines = buffer_lines(emulate(out.getvalue()))
+    kept = [line for line in lines if line.startswith("verdict-")]
+    assert kept == ["verdict-0", "verdict-1"]
+    assert sum("run-a" in line for line in lines) == 0
+
+
+def test_region_starts_at_the_prompt_row_without_a_gap() -> None:
+    """Output continues right below the shell prompt instead of jumping
+    to the bottom of the screen."""
+    out = io.StringIO()
+    display = Display(out, size=lambda: (WIDTH, HEIGHT), origin=4)
+    display.frame(["verdict-0", "verdict-1"], ["HEADER", "running"])
+
+    visible = [row.rstrip() for row in emulate(out.getvalue()).display]
+    assert visible[3:7] == ["verdict-0", "verdict-1", "HEADER", "running"]
+    assert all(not row for row in visible[7:])
+
+
+def test_resize_keeps_single_region() -> None:
+    """A SIGWINCH shows up as a changed size() result on the next frame.
+    The renderer must re-anchor the region without duplicating it."""
+    size = {"cols": WIDTH, "rows": HEIGHT}
+    out = io.StringIO()
+    display = Display(out, size=lambda: (size["cols"], size["rows"]))
+    screen = pyte.HistoryScreen(WIDTH, HEIGHT, history=1000)
+    stream = pyte.Stream(screen)
+
+    def frame(batch: list[str], region: list[str]) -> None:
+        mark = out.tell()
+        display.frame(batch, region)
+        stream.feed(out.getvalue()[mark:])
+
+    for i in range(10):
+        frame([f"verdict-{i}"], ["HEADER", f"running-{i}"])
+    # The terminal shrinks between two frames.
+    size.update(cols=40, rows=8)
+    screen.resize(8, 40)
+    for i in range(10, 16):
+        frame([f"verdict-{i}"], ["HEADER", f"running-{i}"])
+
+    lines = buffer_lines(screen)
+    assert sum("HEADER" in line for line in lines) == 1
+    visible = [row.rstrip() for row in screen.display]
+    assert "HEADER" in visible[-2]
+    assert visible[-1] == "running-15"
+    # Verdicts printed after the resize are neither lost nor duplicated.
+    post = [
+        line for line in lines if line.startswith("verdict-1") and line != "verdict-1"
+    ]
+    assert post == [f"verdict-{i}" for i in range(10, 16)]
+
+
+def test_tty_watch_shows_finished_and_running_attrs() -> None:
+    """End to end against a mocked API: verdicts of already-finished
+    attributes appear, running attributes show up in the live region and
+    the run ends with the build's final status."""
+    build = {"id": 9, "number": 5, "status": "building"}
+    finished = [
+        {
+            "id": 1,
+            "attr": "good",
+            "status": "succeeded",
+            "cached": True,
+            "started_at": "2026-01-01T00:00:00Z",
+            "finished_at": "2026-01-01T00:00:01Z",
+        },
+    ]
+    detail_attrs = [
+        *finished,
+        {
+            "id": 2,
+            "attr": "slowone",
+            "status": "building",
+            "cached": False,
+            "started_at": "2026-01-01T00:00:00Z",
+            "finished_at": None,
+        },
+    ]
+    hint = 'data: {"build_id":9,"attr":"slowone","status":"succeeded"}\n\n'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/builds/5"):
+            return httpx.Response(
+                200, json={"build": dict(build), "attributes": detail_attrs}
+            )
+        if path.endswith("/builds/5/attrs"):
+            after = request.url.params.get("finished_after")
+            items = [a for a in finished if not after or a["finished_at"] > after]
+            return httpx.Response(200, json={"build": dict(build), "items": items})
+        if path == "/api/events":
+            # Give the renderer time to draw a frame with the running attr.
+            time.sleep(0.6)
+            finished.append(
+                {
+                    "id": 2,
+                    "attr": "slowone",
+                    "status": "succeeded",
+                    "cached": False,
+                    "started_at": "2026-01-01T00:00:00Z",
+                    "finished_at": "2026-01-01T00:00:02Z",
+                }
+            )
+            build["status"] = "succeeded"
+            return httpx.Response(
+                200, content=hint, headers={"content-type": "text/event-stream"}
+            )
+        if path.endswith("/logs/slowone/stream"):
+            return httpx.Response(
+                200,
+                content='event: line\ndata: {"idx":0,"text":"compiling"}\n\n'
+                "event: done\ndata: {}\n\n",
+                headers={"content-type": "text/event-stream"},
+            )
+        raise AssertionError(path)
+
+    client = NixbotClient(
+        http=httpx.Client(
+            base_url="http://test", transport=httpx.MockTransport(handler)
+        )
+    )
+    out = io.StringIO()
+    watcher = TtyWatch(
+        client,
+        RepoRef("github", "acme", "widget"),
+        5,
+        out,
+        size=lambda: (WIDTH, HEIGHT),
+    )
+    status = watcher.run()
+
+    assert status == "succeeded"
+    assert watcher.finished == 2
+    lines = buffer_lines(emulate(out.getvalue()))
+    assert sum(line.startswith("✓ cached good") for line in lines) == 1
+    assert sum(line.startswith("✓ built slowone") for line in lines) == 1
+    # The live region showed the running attribute and its header at least once.
+    assert "slowone" in out.getvalue()
+    assert "build #5" in out.getvalue()
+    # The region is gone after the run.
+    assert not any("build #5" in line for line in lines)
+
+
+def test_long_verdicts_wrap_without_corrupting_region() -> None:
+    out = io.StringIO()
+    display = make_display(out)
+    long_line = "verdict-long " + "x" * (2 * WIDTH)
+    for _ in range(5):
+        display.frame([long_line], ["HEADER", "running"])
+
+    lines = buffer_lines(emulate(out.getvalue()))
+    assert sum("HEADER" in line for line in lines) == 1
+    assert sum(line.startswith("verdict-long") for line in lines) == 5

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -1096,3 +1096,33 @@ def test_webhook_panel_is_forge_aware(harness: WebHarness) -> None:
         assert "webhook setup" not in github_page
     finally:
         harness.ctx.webhook_base_url = None
+
+
+def test_api_attr_and_effects_control(harness: WebHarness) -> None:
+    BACKEND.attr_restarts.clear()
+    BACKEND.attr_cancels.clear()
+    BACKEND.effect_restarts.clear()
+    base = "/api/repos/github/acme/widget/builds/1"
+
+    # Anonymous rejected.
+    assert harness.post(f"{base}/attrs/bad1/restart").status_code == 403
+    assert BACKEND.attr_restarts == []
+
+    response = harness.post(f"{base}/attrs/bad1/restart", ROOT)
+    assert response.status_code == 200
+    assert response.json() == {"number": 1, "attr": "bad1", "action": "restart"}
+    assert [a for _, a in BACKEND.attr_restarts] == ["bad1"]
+    # Unknown attribute is a 404, not an enqueue.
+    assert harness.post(f"{base}/attrs/nope/restart", ROOT).status_code == 404
+    assert len(BACKEND.attr_restarts) == 1
+
+    response = harness.post(f"{base}/attrs/bad1/cancel", ROOT)
+    assert response.status_code == 200
+    assert response.json() == {"number": 1, "attr": "bad1", "action": "cancel"}
+    assert [a for _, a in BACKEND.attr_cancels] == ["bad1"]
+    assert harness.post(f"{base}/attrs/nope/cancel", ROOT).status_code == 404
+
+    response = harness.post(f"{base}/effects/restart", ROOT)
+    assert response.status_code == 200
+    assert response.json() == {"number": 1, "action": "restart-effects"}
+    assert len(BACKEND.effect_restarts) == 1

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -607,7 +607,12 @@ async def test_structured_capture_live_stream() -> None:
     while not q.empty():
         deltas.append(q.get_nowait())
 
-    assert deltas[0] == {"t": "drv", "idx": 1, "name": "qtbase-5.0"}
+    assert deltas[0] == {
+        "t": "drv",
+        "idx": 1,
+        "drv": "/nix/store/aaa-qtbase-5.0.drv",
+        "name": "qtbase-5.0",
+    }
     assert {"t": "phase", "idx": 1, "phase": "build", "line": 0} in deltas
     assert {"t": "line", "idx": 1, "from": 1, "text": "CC main.o"} in deltas
     # stop marks built, finalize status overrides to failed. Both stream.
@@ -649,10 +654,16 @@ async def test_structured_capture_status_without_start_build() -> None:
     q = cap.subscribe()
     cap.set_status("/nix/store/aaa-qtbase-5.0.drv", "built")
     deltas = [q.get_nowait() for _ in range(q.qsize())]
-    assert deltas[0] == {"t": "drv", "idx": 1, "name": "qtbase-5.0"}
+    assert deltas[0] == {
+        "t": "drv",
+        "idx": 1,
+        "drv": "/nix/store/aaa-qtbase-5.0.drv",
+        "name": "qtbase-5.0",
+    }
     assert deltas[1] == {"t": "status", "idx": 1, "status": "built"}
     entry = next(e for e in cap.state() if e["idx"] == 1)
     assert entry["name"] == "qtbase-5.0"
+    assert entry["drv"] == "/nix/store/aaa-qtbase-5.0.drv"
 
 
 def test_structured_failure_excerpt_uses_failed_derivation() -> None:

--- a/nixbot/nixbot/tests/test_logstore.py
+++ b/nixbot/nixbot/tests/test_logstore.py
@@ -44,6 +44,7 @@ def test_toc_metadata() -> None:
     w.status("pkg", "failed")
     r = LogContainerReader(w.finalize())
     e = r.entry(0)
+    assert e["drv"] == "pkg"  # the writer key: the full drv path in production
     assert e["name"] == "pkg"
     assert e["status"] == "failed"
     assert e["n"] == 4

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -1154,7 +1154,13 @@ def test_openapi_docs(client: WebHarness) -> None:
     # Responses are typed: every operation documents a response schema.
     for path, ops in spec["paths"].items():
         for method, op in ops.items():
-            schema = op["responses"]["200"]["content"]["application/json"]["schema"]
+            content = op["responses"]["200"]["content"]
+            if "application/json" not in content:
+                # Plain-text log and SSE endpoints document their own
+                # media type instead of a JSON schema.
+                assert "text/plain" in content or "text/event-stream" in content
+                continue
+            schema = content["application/json"]["schema"]
             assert schema not in ({}, None), f"{method} {path}"
     assert "Build" in spec["components"]["schemas"]
 
@@ -1931,3 +1937,134 @@ def test_scheduled_run_notify_build_events(client: WebHarness) -> None:
     assert [p["status"] for p in payloads] == ["running", "succeeded"]
     assert all(p["run_id"] == run_id for p in payloads)
     assert all("build_id" not in p for p in payloads)
+
+
+# --- JSON log API ------------------------------------------------------
+
+
+def seed_container(client: WebHarness, tmp_path: Path) -> None:
+    async def run() -> None:
+        ctx = client.ctx
+        ctx.state_dir = tmp_path
+        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
+        log_file = attribute_log_path(tmp_path, build_id, "x86_64-linux.bad")
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        # Production writes both the flat log and the container sidecar.
+        log_file.write_bytes(
+            zstandard.ZstdCompressor().compress(
+                b"\x1b[31mCC main.o\x1b[0m\nerror: boom undeclared\n"
+            )
+        )
+        w = LogContainerWriter()
+        w.register("/nix/store/aaa-qtbase-5.0.drv", "qtbase-5.0")
+        w.phase("/nix/store/aaa-qtbase-5.0.drv", "build")
+        w.line("/nix/store/aaa-qtbase-5.0.drv", "\x1b[31mCC main.o\x1b[0m")
+        w.line("/nix/store/aaa-qtbase-5.0.drv", "error: boom undeclared")
+        w.status("/nix/store/aaa-qtbase-5.0.drv", "failed")
+        w.register("/nix/store/bbb-zlib-1.3.drv", "zlib-1.3")
+        w.status("/nix/store/bbb-zlib-1.3.drv", "built")
+        container_path(log_file).write_bytes(w.finalize())
+
+    client.loop.run_until_complete(run())
+
+
+def test_api_log_toc_and_text(client: WebHarness, tmp_path: Path) -> None:
+    seed_container(client, tmp_path)
+    base = "/api/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad"
+
+    toc = client.get(base).json()
+    assert toc["attr"] == "x86_64-linux.bad"
+    assert [d["name"] for d in toc["derivations"]] == ["qtbase-5.0", "zlib-1.3"]
+    qt = toc["derivations"][0]
+    assert qt["drv"] == "/nix/store/aaa-qtbase-5.0.drv"
+    assert qt["status"] == "failed"
+    assert qt["n"] == 2
+    assert qt["ph"] == [["build", 0]]
+    assert client.get(f"{base}nope").status_code == 404
+
+    # Whole attribute, ANSI stripped by default.
+    text = client.get(f"{base}/text").text
+    assert "CC main.o" in text
+    assert "\x1b" not in text
+    # ?ansi=1 keeps SGR colors, ?tail keeps only the last lines.
+    assert "\x1b[31m" in client.get(f"{base}/text?ansi=1").text
+    assert client.get(f"{base}/text?tail=1").text == "error: boom undeclared\n"
+
+    # One derivation by store path or name substring.
+    by_path = client.get(f"{base}/text?drv=/nix/store/aaa-qtbase-5.0.drv").text
+    assert "error: boom undeclared" in by_path
+    assert "Running phase: build" in by_path
+    assert client.get(f"{base}/text?drv=qtbase").text == by_path
+    assert client.get(f"{base}/text?drv=nope").status_code == 404
+    ambiguous = client.get(f"{base}/text?drv=b")  # matches both names
+    assert ambiguous.status_code == 400
+    assert "qtbase-5.0" in ambiguous.json()["detail"]
+
+
+def test_api_log_toc_flat_log_fallback(client: WebHarness, tmp_path: Path) -> None:
+    """Logs without per-derivation structure appear as one synthetic
+    derivation; ?drv= is rejected."""
+    seed_log(client, tmp_path)  # flat .zst, no container
+    base = "/api/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad"
+    toc = client.get(base).json()
+    assert toc["derivations"] == [
+        {
+            "idx": 0,
+            "drv": None,
+            "name": "x86_64-linux.bad",
+            "status": toc["status"],
+            "n": 1,
+            "ph": [],
+            "t0": None,
+            "t1": None,
+        }
+    ]
+    assert client.get(f"{base}/text").text == "build exploded\n"
+    assert client.get(f"{base}/text?drv=x").status_code == 404
+
+
+def test_api_log_stream_json(client: WebHarness, tmp_path: Path) -> None:
+    """The /api stream sends a TOC-shaped snapshot (no line history) and
+    raw-text deltas; no HTML."""
+    ctx = client.ctx
+    ctx.state_dir = tmp_path
+    registry = client.app.state.log_registry
+
+    async def run() -> str:
+        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 3")
+        writer = LogWriter(path=tmp_path / "logs" / "live" / "x86_64-linux.ok.zst")
+        cap = StructuredCapture(clock=lambda: 1.0)
+        writer.capture = cap
+        cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")
+        cap.log_line(1, "CC main.o")  # history: must not appear in the stream
+        registry.register(build_id, "x86_64-linux.ok", writer)
+        try:
+            url = "/api/repos/github/acme/widget/builds/3/logs/x86_64-linux.ok/stream"
+            task = asyncio.ensure_future(client.http.get(url))
+            await asyncio.sleep(0.1)
+            cap.phase(1, "build")
+            cap.log_line(1, "\x1b[31mCC failed\x1b[0m")
+            cap.set_status("/nix/store/aaa-qtbase-5.0.drv", "failed")
+            cap.close()
+            return (await task).text
+        finally:
+            registry.unregister(build_id, "x86_64-linux.ok")
+
+    stream = client.loop.run_until_complete(run())
+    assert "event: state" in stream
+    assert '"drv":"/nix/store/aaa-qtbase-5.0.drv"' in stream
+    assert '"n":1' in stream  # snapshot carries counts...
+    assert "CC main.o" not in stream  # ...but no line history
+    assert "<span" not in stream  # no HTML anywhere
+    assert "event: phase" in stream
+    assert "event: line" in stream
+    assert '"text":"\\u001b[31mCC failed\\u001b[0m"' in stream  # raw ANSI text
+    assert "event: drv-done" in stream
+    assert '"status":"failed"' in stream
+    assert "event: done" in stream
+
+    # Finished/absent capture: just done, the client uses TOC + text.
+    finished = client.get(
+        "/api/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad/stream"
+    ).text
+    assert finished == "event: done\ndata: {}\n\n"

--- a/nixbot/nixbot/web/api_routes.py
+++ b/nixbot/nixbot/web/api_routes.py
@@ -100,6 +100,13 @@ class BuildDetail(BaseModel):
     attributes: list[Attribute]
 
 
+class AttributeDelta(BaseModel):
+    """Build status plus the attributes finished after a cursor."""
+
+    build: Build
+    items: list[Attribute]
+
+
 class AttributeHistoryEntry(Attribute):
     """Attribute result plus the build it belongs to."""
 
@@ -151,6 +158,16 @@ def clean_row(row: dict[str, Any]) -> dict[str, Any]:
         else:
             out[key] = value
     return out
+
+
+async def _build_or_404(  # noqa: PLR0913
+    ctx: WebContext, request: Request, forge: str, owner: str, name: str, number: int
+) -> dict[str, Any]:
+    project = await ctx.repo_or_404(forge, owner, name, request)
+    build = await ctx.queries.build_by_number(project["id"], number)
+    if build is None:
+        raise HTTPException(status_code=404)
+    return build
 
 
 def create_api_router(ctx: WebContext) -> APIRouter:
@@ -209,14 +226,37 @@ def create_api_router(ctx: WebContext) -> APIRouter:
         request: Request, forge: str, owner: str, name: str, number: int
     ) -> dict[str, Any]:
         """Build plus all of its attributes."""
-        project = await ctx.repo_or_404(forge, owner, name, request)
-        build = await ctx.queries.build_by_number(project["id"], number)
-        if build is None:
-            raise HTTPException(status_code=404)
+        build = await _build_or_404(ctx, request, forge, owner, name, number)
         attributes = await ctx.queries.attributes(build["id"])
         return {
             "build": clean_row(build),
             "attributes": [clean_row(a) for a in attributes],
+        }
+
+    @router.get(
+        "/repos/{forge}/{owner:owner}/{name:segment}/builds/{number}/attrs",
+        response_model=AttributeDelta,
+    )
+    async def get_finished_attributes(  # noqa: PLR0913
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        finished_after: datetime | None = None,
+        after_id: int = 0,
+    ) -> dict[str, Any]:
+        """Attributes finished after the (finished_after, after_id) cursor.
+
+        Ordered by cursor, so the last item is the cursor for the next request.
+        """
+        build = await _build_or_404(ctx, request, forge, owner, name, number)
+        attributes = await ctx.queries.attributes_finished_after(
+            build["id"], finished_after, after_id
+        )
+        return {
+            "build": clean_row(build),
+            "items": [clean_row(a) for a in attributes],
         }
 
     @router.get(

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -676,6 +676,12 @@ the instance restricts project visibility.
 - POST /api/repos/{forge}/{owner}/{name}/builds/{number}/effects/restart
 - POST /api/repos/{forge}/{owner}/{name}/enable (admin)
 - POST /api/repos/{forge}/{owner}/{name}/disable (admin)
+
+## Command line
+
+The `nbo` CLI (package `nixbot-cli`) wraps this API: repo/build
+listing, restart/cancel, failure summaries, log tails and live
+following. See docs/CLI.md in the nixbot repository.
 """
 
 

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -655,8 +655,15 @@ the instance restricts project visibility.
 - GET /api/repos/{forge}/{owner}/{name}/builds/{number} -> build + all attributes
 - GET /api/repos/{forge}/{owner}/{name}/attrs/{attr} -> per-attribute history
 - GET /api/queue -> global build queue
-- GET /repos/{forge}/{owner}/{name}/builds/{number}/logs/raw/{attr}?tail=N
-  -> plain-text log (full when tail is omitted)
+- GET /api/repos/{forge}/{owner}/{name}/builds/{number}/logs/{attr}
+  -> log table of contents: derivations with drv path, status, phases,
+     line counts and timings
+- GET /api/repos/{forge}/{owner}/{name}/builds/{number}/logs/{attr}/text?tail=N&drv=<path|name>&ansi=1
+  -> plain-text log (whole attribute, or one derivation via drv=)
+- GET /api/repos/{forge}/{owner}/{name}/builds/{number}/logs/{attr}/stream
+  -> SSE while the attribute runs: `state` snapshot (no history), then
+     drv/line/phase/drv-done deltas with raw text, `done` at the end
+- GET /api/events?build=N -> SSE build/attribute status-change cues
 - GET /repos/{forge}/{owner}/{name}/badge.svg?branch=B
   -> SVG build-status badge for a branch (default branch when branch is omitted)
 
@@ -664,6 +671,9 @@ the instance restricts project visibility.
 
 - POST /api/repos/{forge}/{owner}/{name}/builds/{number}/restart
 - POST /api/repos/{forge}/{owner}/{name}/builds/{number}/cancel
+- POST /api/repos/{forge}/{owner}/{name}/builds/{number}/attrs/{attr}/restart
+- POST /api/repos/{forge}/{owner}/{name}/builds/{number}/attrs/{attr}/cancel
+- POST /api/repos/{forge}/{owner}/{name}/builds/{number}/effects/restart
 - POST /api/repos/{forge}/{owner}/{name}/enable (admin)
 - POST /api/repos/{forge}/{owner}/{name}/disable (admin)
 """

--- a/nixbot/nixbot/web/control_routes.py
+++ b/nixbot/nixbot/web/control_routes.py
@@ -57,6 +57,12 @@ class ControlAction(BaseModel):
     action: str  # restart | cancel
 
 
+class AttrControlAction(ControlAction):
+    """Acknowledgement of a per-attribute restart/cancel request."""
+
+    attr: str
+
+
 class EnableResult(BaseModel):
     owner: str
     name: str
@@ -199,6 +205,55 @@ class _ControlRoutes:
         await self.backend.cancel_build(build["id"])
         return {"number": number, "action": "cancel"}
 
+    async def api_restart_attribute(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        attr: str,
+    ) -> dict:
+        """Re-run one attribute using its stored eval result (no re-eval).
+        Authz: admins, the PR author, or repo writers."""
+        build = await self._authorize(request, forge, owner, name, number)
+        known = await maint_gen.attribute_known(
+            self.ctx.pool, build_id=build["id"], attr=attr
+        )
+        if known is None:
+            raise HTTPException(status_code=404, detail="unknown attribute")
+        await self.backend.restart_attribute(build["id"], attr)
+        return {"number": number, "attr": attr, "action": "restart"}
+
+    async def api_cancel_attribute(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        attr: str,
+    ) -> dict:
+        """Cancel one pending/running attribute. Authz: admins, the PR
+        author, or repo writers."""
+        build = await self._authorize(request, forge, owner, name, number)
+        known = await maint_gen.attribute_known(
+            self.ctx.pool, build_id=build["id"], attr=attr
+        )
+        if known is None:
+            raise HTTPException(status_code=404, detail="unknown attribute")
+        await self.backend.cancel_attribute(build["id"], attr)
+        return {"number": number, "attr": attr, "action": "cancel"}
+
+    async def api_restart_effects(
+        self, request: Request, forge: str, owner: str, name: str, number: int
+    ) -> dict:
+        """Re-run the build's effects. Authz: admins, the PR author, or
+        repo writers."""
+        build = await self._authorize(request, forge, owner, name, number)
+        await self.backend.restart_effects(build["id"])
+        return {"number": number, "action": "restart-effects"}
+
     async def api_set_enabled(
         self, request: Request, forge: str, owner: str, name: str
     ) -> dict:
@@ -325,6 +380,18 @@ def create_control_api_router(
     router.post(f"{base}/builds/{{number}}/cancel", response_model=ControlAction)(
         routes.api_cancel
     )
+    # :path — attribute names may contain slashes.
+    router.post(
+        f"{base}/builds/{{number}}/attrs/{{attr:path}}/restart",
+        response_model=AttrControlAction,
+    )(routes.api_restart_attribute)
+    router.post(
+        f"{base}/builds/{{number}}/attrs/{{attr:path}}/cancel",
+        response_model=AttrControlAction,
+    )(routes.api_cancel_attribute)
+    router.post(
+        f"{base}/builds/{{number}}/effects/restart", response_model=ControlAction
+    )(routes.api_restart_effects)
     router.post(f"{base}/enable", response_model=EnableResult)(routes.api_set_enabled)
     router.post(f"{base}/disable", response_model=EnableResult)(routes.api_set_enabled)
     return router

--- a/nixbot/nixbot/web/events.py
+++ b/nixbot/nixbot/web/events.py
@@ -176,7 +176,10 @@ async def event_stream(
 def create_events_router(ctx: WebContext, broker: EventBroker) -> APIRouter:
     router = APIRouter()
 
+    # /api/events is the documented alias for API/CLI consumers; the
+    # bare /events route stays for the web UI's EventSource clients.
     @router.get("/events")
+    @router.get("/api/events")
     async def events(
         request: Request,
         build: int | None = None,

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -20,6 +20,7 @@ from fastapi.responses import (
     Response,
     StreamingResponse,
 )
+from pydantic import BaseModel
 
 from ..ansi import (  # noqa: TID252
     ANSI_PARTIAL_RE,
@@ -308,7 +309,12 @@ def render_drv_window(
 def _toc_entries(reader: LogContainerReader) -> list[dict]:
     fields = ("name", "status", "n", "ph", "t0", "t1")
     return [
-        {"idx": i, **{k: reader.entry(i)[k] for k in fields}}
+        # .get("drv"): containers written before the drv path was recorded.
+        {
+            "idx": i,
+            "drv": reader.entry(i).get("drv"),
+            **{k: reader.entry(i)[k] for k in fields},
+        }
         for i in range(len(reader))
     ]
 
@@ -344,6 +350,64 @@ def _strip_tail(text: str, tail: int) -> str:
     """ANSI-stripped last `tail` lines; CPU-bound on multi-MB logs, so
     callers run it via asyncio.to_thread."""
     return "\n".join(strip_ansi(text).splitlines()[-tail:])
+
+
+def _plain(text: str, tail: int | None, *, ansi: bool) -> str:
+    """Tail/ANSI post-processing for the plain-text API responses.
+    CPU-bound on multi-MB logs, so callers run it via asyncio.to_thread."""
+    if not ansi:
+        text = strip_ansi(text)
+    if tail:
+        text = "\n".join(text.splitlines()[-tail:])
+    return text if not text or text.endswith("\n") else text + "\n"
+
+
+class EventStreamResponse(StreamingResponse):
+    """Documents SSE routes as text/event-stream in the OpenAPI spec."""
+
+    media_type = "text/event-stream"
+
+
+class LogDerivation(BaseModel):
+    """One derivation inside an attribute's structured log."""
+
+    idx: int
+    drv: str | None  # full .drv store path; None for setup/legacy entries
+    name: str
+    status: str
+    n: int  # line count
+    ph: list[list]  # [phase name, first 0-based line]
+    t0: int | None  # ms epoch
+    t1: int | None
+
+
+class LogToc(BaseModel):
+    """Table of contents of one attribute's structured log."""
+
+    attr: str
+    status: str | None
+    derivations: list[LogDerivation]
+
+
+def _api_derivations(entries: list[dict]) -> list[dict]:
+    """Normalize capture/container entries for LogDerivation: only real
+    store paths count as drv (not the synthetic setup key)."""
+    return [
+        {**e, "drv": d if (d := e.get("drv")) and d.endswith(".drv") else None}
+        for e in entries
+    ]
+
+
+def _match_drv(entries: list[dict], selector: str) -> dict:
+    """Entry whose drv path equals or name contains `selector`.
+    404 on no match, 400 listing candidates when ambiguous."""
+    matches = [e for e in entries if e.get("drv") == selector or selector in e["name"]]
+    if not matches:
+        raise HTTPException(status_code=404, detail="unknown derivation")
+    if len(matches) > 1:
+        names = ", ".join(e["name"] for e in matches)
+        raise HTTPException(status_code=400, detail=f"ambiguous derivation: {names}")
+    return matches[0]
 
 
 async def _failure_summary(
@@ -423,22 +487,16 @@ class _LogRoutes:
         attr: str,
         tail: int | None = Query(None, ge=1),
     ) -> PlainTextResponse:
-        """Full log as plain text; ?tail=N returns only the last N lines."""
+        """Full log as plain text; ?tail=N returns only the last N lines.
+        Falls back to the stored eval error (e.g. failed_eval) so raw
+        links work for every failure status."""
         _, build, path = await self._resolve(request, forge, owner, name, number, attr)
-        text = await _log_text(self.registry, build, attr, path)
-        if text is None:
-            # No build log (e.g. failed_eval): fall back to the stored
-            # eval error so raw links work for every failure status.
-            text = await gen.attribute_error(
-                self.ctx.pool, build_id=build["id"], attr=attr
-            )
+        text = await self._attr_text(build, attr, path)
         if text is None:
             raise HTTPException(status_code=404)
-        if tail:
-            return PlainTextResponse(
-                await asyncio.to_thread(_strip_tail, text, tail) + "\n"
-            )
-        return PlainTextResponse(await asyncio.to_thread(strip_ansi, text))
+        return PlainTextResponse(
+            await asyncio.to_thread(_plain, text, tail, ansi=False)
+        )
 
     async def log_raw_text_legacy(  # noqa: PLR0913
         self,
@@ -619,6 +677,122 @@ class _LogRoutes:
         """
         _, build = await self._build_or_404(request, forge, owner, name, number)
         return await _failure_summary(self.ctx, self.registry, build, tail)
+
+    def _capture(self, build: dict, attr: str) -> StructuredCapture | None:
+        writer = self.registry.get(build["id"], attr)
+        return writer.capture if writer else None
+
+    async def _attr_text(self, build: dict, attr: str, path: Path | None) -> str | None:
+        """The attribute's log text, falling back to the stored eval error
+        (e.g. failed_eval) so every failure status has readable output."""
+        text = await _log_text(self.registry, build, attr, path)
+        if text is None:
+            text = await gen.attribute_error(
+                self.ctx.pool, build_id=build["id"], attr=attr
+            )
+        return text
+
+    async def api_log_toc(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        attr: str,
+    ) -> dict:
+        """Table of contents of one attribute's log: its derivations with
+        status, phases, line counts and timings. Running attributes are
+        served from the live capture; logs without per-derivation
+        structure appear as a single synthetic entry."""
+        _, build, path = await self._resolve(request, forge, owner, name, number, attr)
+        attr_status = await gen.attribute_status(
+            self.ctx.pool, build_id=build["id"], attr=attr
+        )
+        if attr_status is None:
+            raise HTTPException(status_code=404, detail="unknown attribute")
+        capture = self._capture(build, attr)
+        if capture is not None:
+            entries = capture.state(with_lines=False)
+        elif (reader := await _load_container(path)) is not None:
+            entries = _toc_entries(reader)
+        else:
+            # Flat log or eval error only: one synthetic derivation.
+            text = await self._attr_text(build, attr, path)
+            entries = (
+                []
+                if text is None
+                else [
+                    {
+                        "idx": 0,
+                        "drv": None,
+                        "name": attr,
+                        "status": attr_status,
+                        "n": len(text.splitlines()),
+                        "ph": [],
+                        "t0": None,
+                        "t1": None,
+                    }
+                ]
+            )
+        return {
+            "attr": attr,
+            "status": attr_status,
+            "derivations": _api_derivations(entries),
+        }
+
+    async def api_log_text(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        attr: str,
+        tail: int | None = Query(None, ge=1),
+        drv: str | None = None,
+        ansi: bool = Query(default=False),
+    ) -> PlainTextResponse:
+        """The attribute's log as plain text. ?tail=N keeps the last N
+        lines, ?drv=<store path or name substring> selects one derivation
+        of a structured log, ?ansi=1 keeps SGR color sequences."""
+        _, build, path = await self._resolve(request, forge, owner, name, number, attr)
+        text: str | None
+        if drv:
+            capture = self._capture(build, attr)
+            if capture is not None:
+                entry = _match_drv(capture.state(), drv)
+                text = "\n".join(entry["lines"])
+            elif (reader := await _load_container(path)) is not None:
+                entry = _match_drv(_toc_entries(reader), drv)
+                text = "\n".join(
+                    await asyncio.to_thread(reader.lines_with_phases, entry["idx"])
+                )
+            else:
+                raise HTTPException(
+                    status_code=404, detail="log has no per-derivation structure"
+                )
+        else:
+            text = await self._attr_text(build, attr, path)
+            if text is None:
+                raise HTTPException(status_code=404)
+        return PlainTextResponse(await asyncio.to_thread(_plain, text, tail, ansi=ansi))
+
+    async def api_log_stream(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        attr: str,
+    ) -> StreamingResponse:
+        """SSE stream of a running attribute: a `state` snapshot (the TOC,
+        no line history), then `drv`/`line`/`phase`/`drv-done` deltas with
+        raw text, and `done` when the attribute finishes. History comes
+        from the text endpoint."""
+        _, build, _ = await self._resolve(request, forge, owner, name, number, attr)
+        return EventStreamResponse(_structured_events_json(self._capture(build, attr)))
 
     async def log_drv_lines(  # noqa: PLR0913
         self,
@@ -874,14 +1048,54 @@ def create_log_router(ctx: WebContext, registry: LogRegistry) -> APIRouter:
 
 
 def create_log_api_router(ctx: WebContext, registry: LogRegistry) -> APIRouter:
-    """The failure summary belongs to the documented /api surface,
-    unlike the HTML/plain-text log routes."""
+    """JSON/plain-text log endpoints of the documented /api surface."""
     router = APIRouter(tags=["api"])
     routes = _LogRoutes(ctx, registry)
-    router.get(f"/api{_BASE}/failures", response_model=FailureSummary)(
-        routes.build_failures
+    base = f"/api{_BASE}"
+    router.get(f"{base}/failures", response_model=FailureSummary)(routes.build_failures)
+    # :path — attribute names may contain slashes; the /text and /stream
+    # suffixes are matched before the TOC catch-all.
+    router.get(f"{base}/logs/{{attr:path}}/text", response_class=PlainTextResponse)(
+        routes.api_log_text
     )
+    router.get(f"{base}/logs/{{attr:path}}/stream", response_class=EventStreamResponse)(
+        routes.api_log_stream
+    )
+    router.get(f"{base}/logs/{{attr:path}}", response_model=LogToc)(routes.api_log_toc)
     return router
+
+
+async def _structured_events_json(
+    capture: StructuredCapture | None,
+) -> AsyncGenerator[str, None]:
+    """JSON twin of _structured_events for the /api stream: no HTML, no
+    line history (the state snapshot is TOC-shaped), raw text in line
+    deltas. A finished/absent capture just signals done."""
+    if capture is None:
+        yield "event: done\ndata: {}\n\n"
+        return
+    queue = capture.subscribe()
+    # Atomic with subscribe (no await between): no delta lost or duplicated.
+    state = _api_derivations(capture.state(with_lines=False))
+    yield f"event: state\ndata: {json.dumps(state, separators=(',', ':'))}\n\n"
+    try:
+        while True:
+            try:
+                delta = await asyncio.wait_for(queue.get(), timeout=30)
+            except TimeoutError:
+                yield ": keepalive\n\n"
+                continue
+            if delta is None:
+                yield "event: done\ndata: {}\n\n"
+                return
+            # The capture's "status" delta is the derivation finishing.
+            event = "drv-done" if delta["t"] == "status" else delta["t"]
+            # json escapes any CR/LF in log text, so payloads cannot
+            # forge SSE fields.
+            payload = json.dumps(delta, separators=(",", ":"))
+            yield f"event: {event}\ndata: {payload}\n\n"
+    finally:
+        capture.unsubscribe(queue)
 
 
 async def _stream_events(

--- a/nixbot/nixbot/web/queries.py
+++ b/nixbot/nixbot/web/queries.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any
 from ..db_gen import web as gen  # noqa: TID252
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     import asyncpg
 
 PAGE_SIZE = 50
@@ -148,6 +150,16 @@ class WebQueries:
     async def attributes(self, build_id: int) -> list[dict[str, Any]]:
         """Attributes, failed first, then by name."""
         return _dicts(await gen.web_attributes(self.pool, build_id=build_id))
+
+    async def attributes_finished_after(
+        self, build_id: int, after: datetime | None, after_id: int
+    ) -> list[dict[str, Any]]:
+        """Attributes that finished after the (after, after_id) cursor."""
+        return _dicts(
+            await gen.web_attributes_finished_after(
+                self.pool, build_id=build_id, after=after, after_id=after_id
+            )
+        )
 
     async def effects(self, build_id: int) -> list[dict[str, Any]]:
         return _dicts(await gen.web_effects(self.pool, build_id=build_id))

--- a/nixbot/pyproject.toml
+++ b/nixbot/pyproject.toml
@@ -111,6 +111,8 @@ module = "asyncpg.*"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
+# the CLI package's tests run in this suite against the real app
+pythonpath = ["../nixbot_cli"]
 timeout = 60
 asyncio_mode = "auto"
 # Distribute by module: module-scoped fixtures (ephemeral Postgres,

--- a/nixbot_cli/nixbot_cli/__init__.py
+++ b/nixbot_cli/nixbot_cli/__init__.py
@@ -1,0 +1,1 @@
+"""nbo: command-line client for the nixbot HTTP API."""

--- a/nixbot_cli/nixbot_cli/api.py
+++ b/nixbot_cli/nixbot_cli/api.py
@@ -195,6 +195,23 @@ class NixbotClient:
                 raise ApiError(response.status_code, response.text)
             yield from _iter_sse(response)
 
+    def events(self, *, build: int | None = None) -> Iterator[dict]:
+        """Change hints from /api/events, filtered to one build (by DB id).
+        Keepalive comments are yielded as {} so callers can refresh
+        periodically. Only returns when the server closes the stream."""
+        params = {"build": build} if build is not None else {}
+        with self.http.stream(
+            "GET", "/api/events", params=params, timeout=None
+        ) as response:
+            if response.is_error:
+                response.read()
+                raise ApiError(response.status_code, response.text)
+            for line in response.iter_lines():
+                if line.startswith("data:"):
+                    yield json.loads(line.removeprefix("data:"))
+                elif line.startswith(":"):
+                    yield {}
+
 
 def _iter_sse(response: httpx.Response) -> Iterator[tuple[str, Any]]:
     """Parse an SSE body into (event, decoded JSON data) pairs."""

--- a/nixbot_cli/nixbot_cli/api.py
+++ b/nixbot_cli/nixbot_cli/api.py
@@ -7,10 +7,14 @@ response models in the server's OpenAPI spec and /llms.txt.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class ApiError(Exception):
@@ -176,3 +180,32 @@ class NixbotClient:
         return self._request(
             "GET", f"/api/repos/{repo}/builds/{number}/logs/{attr}/text", params
         ).text
+
+    # --- streams -------------------------------------------------------
+
+    def log_stream(
+        self, repo: RepoRef, number: int, attr: str
+    ) -> Iterator[tuple[str, Any]]:
+        """SSE events of a running attribute's structured log as
+        (event, payload) pairs. The stream ends with ("done", {})."""
+        url = f"/api/repos/{repo}/builds/{number}/logs/{attr}/stream"
+        with self.http.stream("GET", url, timeout=None) as response:
+            if response.is_error:
+                response.read()
+                raise ApiError(response.status_code, response.text)
+            yield from _iter_sse(response)
+
+
+def _iter_sse(response: httpx.Response) -> Iterator[tuple[str, Any]]:
+    """Parse an SSE body into (event, decoded JSON data) pairs."""
+    event = "message"
+    data: list[str] = []
+    for line in response.iter_lines():
+        if not line:
+            if data:
+                yield event, json.loads("\n".join(data))
+            event, data = "message", []
+        elif line.startswith("event:"):
+            event = line.removeprefix("event:").strip()
+        elif line.startswith("data:"):
+            data.append(line.removeprefix("data:").strip())

--- a/nixbot_cli/nixbot_cli/api.py
+++ b/nixbot_cli/nixbot_cli/api.py
@@ -131,6 +131,19 @@ class NixbotClient:
         """Build detail: {build, attributes}."""
         return self._json("GET", f"/api/repos/{repo}/builds/{number}")
 
+    def finished_attrs(
+        self,
+        repo: RepoRef,
+        number: int,
+        *,
+        finished_after: str | None = None,
+        after_id: int = 0,
+    ) -> dict:
+        """Build status plus attributes finished after the cursor:
+        {build, items} with items in cursor order."""
+        params = {"finished_after": finished_after, "after_id": after_id}
+        return self._json("GET", f"/api/repos/{repo}/builds/{number}/attrs", params)
+
     def failures(self, repo: RepoRef, number: int, *, tail: int | None = None) -> dict:
         """Why a build failed: failed attributes with log tails."""
         params = {"tail": tail}

--- a/nixbot_cli/nixbot_cli/api.py
+++ b/nixbot_cli/nixbot_cli/api.py
@@ -170,7 +170,7 @@ class NixbotClient:
         drv: str | None = None,
         ansi: bool = False,
     ) -> str:
-        """Plain-text log; drv selects one derivation by store path or
+        """Plain-text log. drv selects one derivation by store path or
         name substring."""
         params = {"tail": tail, "drv": drv, "ansi": "1" if ansi else None}
         return self._request(

--- a/nixbot_cli/nixbot_cli/api.py
+++ b/nixbot_cli/nixbot_cli/api.py
@@ -1,0 +1,178 @@
+"""Synchronous httpx client for the nixbot /api surface.
+
+Standalone on purpose: no imports from the server package, so the CLI
+installs without the service. Responses are decoded JSON matching the
+response models in the server's OpenAPI spec and /llms.txt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+class ApiError(Exception):
+    """Non-2xx response from the nixbot API."""
+
+    def __init__(self, status: int, detail: str) -> None:
+        super().__init__(f"HTTP {status}: {detail}")
+        self.status = status
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class RepoRef:
+    """forge/owner/name triple identifying a repository."""
+
+    forge: str
+    owner: str
+    name: str
+
+    @classmethod
+    def parse(cls, slug: str) -> RepoRef:
+        parts = slug.strip("/").split("/")
+        if len(parts) != 3 or not all(parts):
+            msg = f"expected forge/owner/name, got {slug!r}"
+            raise ValueError(msg)
+        return cls(*parts)
+
+    def __str__(self) -> str:
+        return f"{self.forge}/{self.owner}/{self.name}"
+
+
+class NixbotClient:
+    """Thin wrapper over the /api endpoints."""
+
+    def __init__(
+        self,
+        url: str = "",
+        token: str | None = None,
+        *,
+        http: httpx.Client | None = None,
+    ) -> None:
+        self.http = http or httpx.Client(base_url=url, timeout=30)
+        if token:
+            self.http.headers["Authorization"] = f"Bearer {token}"
+
+    def close(self) -> None:
+        self.http.close()
+
+    def __enter__(self) -> NixbotClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        query = {k: v for k, v in (params or {}).items() if v is not None}
+        response = self.http.request(method, path, params=query)
+        if response.is_error:
+            try:
+                detail = response.json().get("detail", response.text)
+            except ValueError:
+                detail = response.text
+            raise ApiError(response.status_code, str(detail))
+        return response
+
+    def _json(
+        self, method: str, path: str, params: dict[str, Any] | None = None
+    ) -> Any:
+        return self._request(method, path, params).json()
+
+    # --- repos ---------------------------------------------------------
+
+    def repos(self) -> list[dict]:
+        return self._json("GET", "/api/repos")
+
+    def repo(self, repo: RepoRef) -> dict:
+        return self._json("GET", f"/api/repos/{repo}")
+
+    def set_enabled(self, repo: RepoRef, *, enabled: bool) -> dict:
+        action = "enable" if enabled else "disable"
+        return self._json("POST", f"/api/repos/{repo}/{action}")
+
+    def queue(self) -> list[dict]:
+        return self._json("GET", "/api/queue")
+
+    # --- builds --------------------------------------------------------
+
+    def builds(  # noqa: PLR0913
+        self,
+        repo: RepoRef,
+        *,
+        status: str | None = None,
+        branch: str | None = None,
+        pr_number: int | None = None,
+        commit: str | None = None,
+        page: int | None = None,
+    ) -> dict:
+        """One page of builds: {items, page, has_next}."""
+        params = {
+            "status": status,
+            "branch": branch,
+            "pr_number": pr_number,
+            "commit": commit,
+            "page": page,
+        }
+        return self._json("GET", f"/api/repos/{repo}/builds", params)
+
+    def build(self, repo: RepoRef, number: int) -> dict:
+        """Build detail: {build, attributes}."""
+        return self._json("GET", f"/api/repos/{repo}/builds/{number}")
+
+    def failures(self, repo: RepoRef, number: int, *, tail: int | None = None) -> dict:
+        """Why a build failed: failed attributes with log tails."""
+        params = {"tail": tail}
+        return self._json("GET", f"/api/repos/{repo}/builds/{number}/failures", params)
+
+    def attr_history(self, repo: RepoRef, attr: str) -> list[dict]:
+        return self._json("GET", f"/api/repos/{repo}/attrs/{attr}")
+
+    def restart_build(self, repo: RepoRef, number: int) -> dict:
+        return self._json("POST", f"/api/repos/{repo}/builds/{number}/restart")
+
+    def cancel_build(self, repo: RepoRef, number: int) -> dict:
+        return self._json("POST", f"/api/repos/{repo}/builds/{number}/cancel")
+
+    def restart_attr(self, repo: RepoRef, number: int, attr: str) -> dict:
+        return self._json(
+            "POST", f"/api/repos/{repo}/builds/{number}/attrs/{attr}/restart"
+        )
+
+    def cancel_attr(self, repo: RepoRef, number: int, attr: str) -> dict:
+        return self._json(
+            "POST", f"/api/repos/{repo}/builds/{number}/attrs/{attr}/cancel"
+        )
+
+    def restart_effects(self, repo: RepoRef, number: int) -> dict:
+        return self._json("POST", f"/api/repos/{repo}/builds/{number}/effects/restart")
+
+    # --- logs ----------------------------------------------------------
+
+    def log_toc(self, repo: RepoRef, number: int, attr: str) -> dict:
+        """Table of contents of one attribute's structured log."""
+        return self._json("GET", f"/api/repos/{repo}/builds/{number}/logs/{attr}")
+
+    def log_text(  # noqa: PLR0913
+        self,
+        repo: RepoRef,
+        number: int,
+        attr: str,
+        *,
+        tail: int | None = None,
+        drv: str | None = None,
+        ansi: bool = False,
+    ) -> str:
+        """Plain-text log; drv selects one derivation by store path or
+        name substring."""
+        params = {"tail": tail, "drv": drv, "ansi": "1" if ansi else None}
+        return self._request(
+            "GET", f"/api/repos/{repo}/builds/{number}/logs/{attr}/text", params
+        ).text

--- a/nixbot_cli/nixbot_cli/api.py
+++ b/nixbot_cli/nixbot_cli/api.py
@@ -131,6 +131,14 @@ class NixbotClient:
         """Build detail: {build, attributes}."""
         return self._json("GET", f"/api/repos/{repo}/builds/{number}")
 
+    def log_url(
+        self, repo: RepoRef, number: int, attr: str, *, raw: bool = False
+    ) -> str:
+        """Web viewer (or raw text) URL of one attribute's log."""
+        base = str(self.http.base_url).rstrip("/")
+        logs = f"{base}/repos/{repo}/builds/{number}/logs"
+        return f"{logs}/raw/{attr}" if raw else f"{logs}/{attr}"
+
     def finished_attrs(
         self,
         repo: RepoRef,

--- a/nixbot_cli/nixbot_cli/config.py
+++ b/nixbot_cli/nixbot_cli/config.py
@@ -1,0 +1,36 @@
+"""Server URL and token from the environment or hosts.toml."""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def config_path() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+    return Path(base) / "nixbot" / "hosts.toml"
+
+
+@dataclass(frozen=True)
+class Settings:
+    url: str
+    token: str | None
+
+    @classmethod
+    def load(cls) -> Settings:
+        """NIXBOT_URL/NIXBOT_TOKEN override hosts.toml. Without a URL the
+        config's single host is used."""
+        url = os.environ.get("NIXBOT_URL")
+        token = os.environ.get("NIXBOT_TOKEN")
+        hosts: dict[str, dict] = {}
+        path = config_path()
+        if path.exists():
+            hosts = tomllib.loads(path.read_text())
+        if not url:
+            if len(hosts) != 1:
+                msg = f"no server configured: set NIXBOT_URL or add one host to {path}"
+                raise ValueError(msg)
+            url = next(iter(hosts))
+        return cls(url.rstrip("/"), token or hosts.get(url, {}).get("token"))

--- a/nixbot_cli/nixbot_cli/config.py
+++ b/nixbot_cli/nixbot_cli/config.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import shlex
+import subprocess
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,4 +35,22 @@ class Settings:
                 msg = f"no server configured: set NIXBOT_URL or add one host to {path}"
                 raise ValueError(msg)
             url = next(iter(hosts))
-        return cls(url.rstrip("/"), token or hosts.get(url, {}).get("token"))
+        entry = hosts.get(url, {})
+        token = token or entry.get("token") or _run_token_command(entry)
+        return cls(url.rstrip("/"), token)
+
+
+def _run_token_command(entry: dict) -> str | None:
+    """Fetch the token from a secret manager (pass, rbw, ...) via the
+    host's token_command. The first line of its stdout is the token."""
+    command = entry.get("token_command")
+    if not command:
+        return None
+    try:
+        out = subprocess.run(  # noqa: S603
+            shlex.split(command), capture_output=True, text=True, check=True
+        )
+    except (OSError, subprocess.CalledProcessError) as err:
+        msg = f"token_command {command!r} failed: {err}"
+        raise ValueError(msg) from err
+    return out.stdout.splitlines()[0].strip() if out.stdout.strip() else None

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -441,13 +441,31 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     b_view.add_argument("--web", action="store_true", help="open in the browser")
     b_view.set_defaults(func=cmd_build_view)
 
-    b_watch = build.add_parser("watch", help="follow a build until it finishes")
+    b_watch = build.add_parser(
+        "watch",
+        help="follow a build until it finishes",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""examples:
+  nbo build watch                   the current commit's build, exit 1 on failure
+  nbo build watch 412               build #412 of the repo in the CWD
+  nbo build watch 412 -R github/Mic92/dotfiles   without a local checkout
+
+On a terminal this shows finished attributes above a live view of the
+running ones. Piped or in CI it prints one line per finished attribute.""",
+    )
     b_watch.add_argument("number", type=int, nargs="?")
     _add_repo_arg(b_watch)
     b_watch.set_defaults(func=cmd_build_watch)
 
     b_restart = build.add_parser(
-        "restart", help="restart a build, attribute or effects"
+        "restart",
+        help="restart a build, attribute or effects",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""examples:
+  nbo build restart                 rebuild the current commit's build
+  nbo build restart 412             rebuild everything of build #412
+  nbo build restart 412 --attr x86_64-linux.nixos-eve   one attribute only
+  nbo build restart 412 --effects   re-run the effects""",
     )
     b_restart.add_argument("number", type=int, nargs="?")
     _add_repo_arg(b_restart)
@@ -461,7 +479,19 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     b_cancel.add_argument("--attr", help="cancel only this attribute")
     b_cancel.set_defaults(func=cmd_build_cancel)
 
-    log = sub.add_parser("log", help="failure summary or an attribute's log")
+    log = sub.add_parser(
+        "log",
+        help="failure summary or an attribute's log",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""examples:
+  nbo log                           why the current commit's build failed
+  nbo log 412                       failure summary of build #412
+  nbo log 412 nixos-eve             log of the attribute matching "nixos-eve"
+  nbo log 412 nixos-eve --tail 100  only the last 100 lines
+  nbo log 412 nixos-eve --follow    stream while it is still building
+  nbo log 412 /nix/store/…-foo.drv  log of one derivation by store path
+  nbo log 412 -R github/Mic92/dotfiles   without a local checkout""",
+    )
     log.add_argument("number", type=int, nargs="?")
     log.add_argument(
         "attr",

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -13,7 +13,7 @@ from .api import ApiError, NixbotClient, RepoRef
 from .config import Settings, config_path
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
 EXIT_OK = 0
 EXIT_BUILD_FAILED = 1
@@ -204,6 +204,52 @@ def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+RUNNING_STATUSES = {"pending", "evaluating", "building"}
+
+
+def cmd_build_watch(client: NixbotClient, args: argparse.Namespace) -> int:
+    repo = resolve_repo(client, args.repo)
+    number = resolve_build(client, repo, args.number)
+    return watch_build(client, repo, number)
+
+
+def watch_build(client: NixbotClient, repo: RepoRef, number: int) -> int:
+    """Append-only progress: one verdict line per finished attribute,
+    then the failure summary. Refetches on every /api/events hint."""
+    reported: set[str] = set()
+    events: Iterator[dict] | None = None
+    while True:
+        detail = client.build(repo, number)
+        build = detail["build"]
+        for a in detail["attributes"]:
+            if a["attr"] in reported or a["status"] in RUNNING_STATUSES:
+                continue
+            reported.add(a["attr"])
+            cached = " (cached)" if a.get("cached") else ""
+            print(f"{status_str(a['status'])} {a['attr']}{cached}", flush=True)
+        if build["status"] not in RUNNING_STATUSES:
+            break
+        if events is None:
+            events = client.events(build=build["id"])
+        # Any change hint or keepalive triggers a refetch. A closed
+        # stream reconnects on the next round.
+        if next(events, None) is None:
+            events = None
+
+    summary = client.failures(repo, number, tail=20)
+    counts = f"{len(reported)} finished, {len(summary['failures'])} failed"
+    print(f"{status_str(build['status'])} build #{number}: {counts}")
+    if summary.get("error"):
+        print(summary["error"])
+    for failure in summary["failures"]:
+        print(f"\n── {failure['attr']} ── {status_str(failure['status'])}")
+        if failure.get("error"):
+            print(failure["error"])
+        if failure.get("log_tail"):
+            print(failure["log_tail"])
+    return EXIT_BUILD_FAILED if build["status"] in FAILED_STATUSES else EXIT_OK
+
+
 def cmd_build_restart(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
@@ -387,6 +433,11 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     _add_json_arg(b_view)
     b_view.add_argument("--web", action="store_true", help="open in the browser")
     b_view.set_defaults(func=cmd_build_view)
+
+    b_watch = build.add_parser("watch", help="follow a build until it finishes")
+    b_watch.add_argument("number", type=int, nargs="?")
+    _add_repo_arg(b_watch)
+    b_watch.set_defaults(func=cmd_build_watch)
 
     b_restart = build.add_parser(
         "restart", help="restart a build, attribute or effects"

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -27,7 +27,15 @@ FAILED_STATUSES = {
     "cached_failure",
     "failed_eval",
 }
-STATUS_GLYPHS = {"succeeded": "✓", "failed": "✗", "building": "⏵", "pending": "·"}
+GOOD_STATUSES = {"succeeded", "skipped_local"}
+# Human wording for the raw database statuses.
+STATUS_LABELS = {
+    "succeeded": "built",
+    "skipped_local": "cached",
+    "cached_failure": "failed (cached)",
+    "dependency_failed": "dependency failed",
+    "failed_eval": "eval failed",
+}
 
 
 class UsageError(Exception):
@@ -40,13 +48,16 @@ def _color(text: str, code: str) -> str:
     return f"\x1b[{code}m{text}\x1b[0m"
 
 
-def status_str(status: str) -> str:
-    glyph = STATUS_GLYPHS.get(status, "·")
-    if status == "succeeded":
-        return _color(f"{glyph} {status}", "32")
+def status_str(status: str, *, cached: bool = False) -> str:
+    label = STATUS_LABELS.get(status, status)
+    if status == "succeeded" and cached:
+        label = "cached"
+    if status in GOOD_STATUSES:
+        return _color(f"✓ {label}", "32")
     if status in FAILED_STATUSES:
-        return _color(f"{glyph} {status}", "31")
-    return _color(f"{glyph} {status}", "33")
+        return _color(f"✗ {label}", "31")
+    glyph = "⏵" if status in ("building", "evaluating") else "·"
+    return _color(f"{glyph} {label}", "33")
 
 
 def print_table(rows: list[dict[str, Any]], columns: list[str]) -> None:
@@ -194,7 +205,9 @@ def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
     counts: dict[str, int] = {}
     for a in attrs:
         counts[a["status"]] = counts.get(a["status"], 0) + 1
-    summary = " · ".join(f"{n} {s}" for s, n in sorted(counts.items()))
+    summary = " · ".join(
+        f"{n} {STATUS_LABELS.get(s, s)}" for s, n in sorted(counts.items())
+    )
     print(f"attributes: {len(attrs)}" + (f" ({summary})" if attrs else ""))
     failed = [a for a in attrs if a["status"] in FAILED_STATUSES]
     for a in failed:
@@ -225,8 +238,8 @@ def watch_build(client: NixbotClient, repo: RepoRef, number: int) -> int:
             if a["attr"] in reported or a["status"] in RUNNING_STATUSES:
                 continue
             reported.add(a["attr"])
-            cached = " (cached)" if a.get("cached") else ""
-            print(f"{status_str(a['status'])} {a['attr']}{cached}", flush=True)
+            verdict = status_str(a["status"], cached=bool(a.get("cached")))
+            print(f"{verdict} {a['attr']}", flush=True)
         if build["status"] not in RUNNING_STATUSES:
             break
         if events is None:

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -228,18 +228,25 @@ def cmd_build_watch(client: NixbotClient, args: argparse.Namespace) -> int:
 
 def watch_build(client: NixbotClient, repo: RepoRef, number: int) -> int:
     """Append-only progress: one verdict line per finished attribute,
-    then the failure summary. Refetches on every /api/events hint."""
-    reported: set[str] = set()
+    then the failure summary. On every /api/events hint only the
+    attributes finished since the last cursor are fetched."""
+    cursor: tuple[str, int] | None = None
+    finished = 0
     events: Iterator[dict] | None = None
     while True:
-        detail = client.build(repo, number)
-        build = detail["build"]
-        for a in detail["attributes"]:
-            if a["attr"] in reported or a["status"] in RUNNING_STATUSES:
-                continue
-            reported.add(a["attr"])
+        delta = client.finished_attrs(
+            repo,
+            number,
+            finished_after=cursor[0] if cursor else None,
+            after_id=cursor[1] if cursor else 0,
+        )
+        build, attrs = delta["build"], delta["items"]
+        for a in attrs:
             verdict = status_str(a["status"], cached=bool(a.get("cached")))
             print(f"{verdict} {a['attr']}", flush=True)
+        if attrs:
+            cursor = (attrs[-1]["finished_at"], attrs[-1]["id"])
+            finished += len(attrs)
         if build["status"] not in RUNNING_STATUSES:
             break
         if events is None:
@@ -250,7 +257,7 @@ def watch_build(client: NixbotClient, repo: RepoRef, number: int) -> int:
             events = None
 
     summary = client.failures(repo, number, tail=20)
-    counts = f"{len(reported)} finished, {len(summary['failures'])} failed"
+    counts = f"{finished} finished, {len(summary['failures'])} failed"
     print(f"{status_str(build['status'])} build #{number}: {counts}")
     if summary.get("error"):
         print(summary["error"])

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -257,6 +257,9 @@ def cmd_log(client: NixbotClient, args: argparse.Namespace) -> int:
     detail = client.build(repo, number)
     build_failed = detail["build"]["status"] in FAILED_STATUSES
 
+    if args.follow and args.attr is None:
+        msg = "--follow needs an attribute"
+        raise UsageError(msg)
     if args.attr is None:  # whole build: print the failure summary
         summary = client.failures(repo, number, tail=args.tail)
         if args.json is not None:
@@ -275,7 +278,10 @@ def cmd_log(client: NixbotClient, args: argparse.Namespace) -> int:
 
     attr = _match_attr(detail["attributes"], args.attr)
     drv = args.attr if args.attr.endswith(".drv") else None
-    if args.json is not None:
+    if args.follow:
+        follow_attr(client, repo, number, attr["attr"], tail=args.tail)
+        attr = _match_attr(client.build(repo, number)["attributes"], attr["attr"])
+    elif args.json is not None:
         toc = client.log_toc(repo, number, attr["attr"])
         print_json(toc, args.json)
     else:
@@ -284,6 +290,34 @@ def cmd_log(client: NixbotClient, args: argparse.Namespace) -> int:
         )
     failed = attr["status"] in FAILED_STATUSES
     return EXIT_BUILD_FAILED if failed else EXIT_OK
+
+
+def follow_attr(
+    client: NixbotClient, repo: RepoRef, number: int, attr: str, *, tail: int | None
+) -> None:
+    """Append-only rendering of the structured stream. A finished
+    attribute has no stream, so its stored log is printed instead."""
+    names: dict[int, str] = {}
+    streamed = False
+    for event, data in client.log_stream(repo, number, attr):
+        if event == "state":
+            names = {e["idx"]: e["name"] for e in data}
+        elif event == "drv":
+            names[data["idx"]] = data["name"]
+            print(f"── {data['name']} ──")
+            streamed = True
+        elif event == "phase":
+            print(f"── {names.get(data['idx'], attr)}: {data['phase']} ──")
+        elif event == "line":
+            print(data["text"])
+            streamed = True
+        elif event == "drv-done":
+            name = names.get(data["idx"], attr)
+            print(f"── {name}: {status_str(data['status'])} ──")
+        elif event == "done":
+            break
+    if not streamed:
+        print(client.log_text(repo, number, attr, tail=tail), end="")
 
 
 def cmd_auth_status(client: NixbotClient, args: argparse.Namespace) -> int:  # noqa: ARG001
@@ -379,6 +413,9 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     )
     _add_repo_arg(log)
     log.add_argument("--tail", type=int, metavar="N", help="last N lines")
+    log.add_argument(
+        "-f", "--follow", action="store_true", help="stream a running attribute's log"
+    )
     _add_json_arg(log)
     log.set_defaults(func=cmd_log)
 

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -221,6 +221,35 @@ def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
 RUNNING_STATUSES = {"pending", "evaluating", "building"}
 
 
+def log_url(
+    client: NixbotClient, repo: RepoRef, number: int, attr: str, *, raw: bool = False
+) -> str:
+    base = str(client.http.base_url).rstrip("/")
+    logs = f"{base}/repos/{repo}/builds/{number}/logs"
+    return f"{logs}/raw/{attr}" if raw else f"{logs}/{attr}"
+
+
+def print_failures(  # noqa: PLR0913
+    client: NixbotClient, repo: RepoRef, number: int, status: str, finished: int
+) -> None:
+    """Result line plus a failure block with a clickable log URL per
+    failed attribute."""
+    summary = client.failures(repo, number, tail=20)
+    counts = f"{finished} finished, {len(summary['failures'])} failed"
+    print(f"{status_str(status)} build #{number}: {counts}")
+    if summary.get("error"):
+        print(summary["error"])
+    for failure in summary["failures"]:
+        print(f"\n── {failure['attr']} ── {status_str(failure['status'])}")
+        url = log_url(
+            client, repo, number, failure["attr"], raw=not sys.stdout.isatty()
+        )
+        print(f"log: {url}")
+        if failure.get("error"):
+            print(failure["error"])
+        if failure.get("log_tail"):
+            print(failure["log_tail"])
+
 def cmd_build_watch(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
@@ -257,17 +286,7 @@ def watch_build(client: NixbotClient, repo: RepoRef, number: int) -> int:
         if next(events, None) is None:
             events = None
 
-    summary = client.failures(repo, number, tail=20)
-    counts = f"{finished} finished, {len(summary['failures'])} failed"
-    print(f"{status_str(build['status'])} build #{number}: {counts}")
-    if summary.get("error"):
-        print(summary["error"])
-    for failure in summary["failures"]:
-        print(f"\n── {failure['attr']} ── {status_str(failure['status'])}")
-        if failure.get("error"):
-            print(failure["error"])
-        if failure.get("log_tail"):
-            print(failure["log_tail"])
+    print_failures(client, repo, number, build["status"], finished)
     return EXIT_BUILD_FAILED if build["status"] in FAILED_STATUSES else EXIT_OK
 
 

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -12,7 +12,14 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 from .api import ApiError, NixbotClient, RepoRef
 from .config import Settings, config_path
-from .term import sanitize_block, sanitize_line
+from .term import (
+    FAILED_STATUSES,
+    RUNNING_STATUSES,
+    STATUS_LABELS,
+    sanitize_block,
+    sanitize_line,
+    status_str,
+)
 from .watch_tty import TtyWatch
 
 if TYPE_CHECKING:
@@ -23,44 +30,9 @@ EXIT_BUILD_FAILED = 1
 EXIT_USAGE = 2
 EXIT_AUTH = 4
 
-FAILED_STATUSES = {
-    "failed",
-    "cancelled",
-    "dependency_failed",
-    "cached_failure",
-    "failed_eval",
-}
-GOOD_STATUSES = {"succeeded", "skipped_local"}
-# Human wording for the raw database statuses.
-STATUS_LABELS = {
-    "succeeded": "built",
-    "skipped_local": "cached",
-    "cached_failure": "failed (cached)",
-    "dependency_failed": "dependency failed",
-    "failed_eval": "eval failed",
-}
-
 
 class UsageError(Exception):
     """Bad invocation: reported on stderr, exit 2."""
-
-
-def _color(text: str, code: str) -> str:
-    if not sys.stdout.isatty():
-        return text
-    return f"\x1b[{code}m{text}\x1b[0m"
-
-
-def status_str(status: str, *, cached: bool = False) -> str:
-    label = STATUS_LABELS.get(status, status)
-    if status == "succeeded" and cached:
-        label = "cached"
-    if status in GOOD_STATUSES:
-        return _color(f"✓ {label}", "32")
-    if status in FAILED_STATUSES:
-        return _color(f"✗ {label}", "31")
-    glyph = "⏵" if status in ("building", "evaluating") else "·"
-    return _color(f"{glyph} {label}", "33")
 
 
 def print_table(rows: list[dict[str, Any]], columns: list[str]) -> None:
@@ -220,17 +192,6 @@ def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
-RUNNING_STATUSES = {"pending", "evaluating", "building"}
-
-
-def log_url(
-    client: NixbotClient, repo: RepoRef, number: int, attr: str, *, raw: bool = False
-) -> str:
-    base = str(client.http.base_url).rstrip("/")
-    logs = f"{base}/repos/{repo}/builds/{number}/logs"
-    return f"{logs}/raw/{attr}" if raw else f"{logs}/{attr}"
-
-
 def print_failures(  # noqa: PLR0913
     client: NixbotClient, repo: RepoRef, number: int, status: str, finished: int
 ) -> None:
@@ -243,9 +204,7 @@ def print_failures(  # noqa: PLR0913
         print(summary["error"])
     for failure in summary["failures"]:
         print(f"\n── {failure['attr']} ── {status_str(failure['status'])}")
-        url = log_url(
-            client, repo, number, failure["attr"], raw=not sys.stdout.isatty()
-        )
+        url = client.log_url(repo, number, failure["attr"], raw=not sys.stdout.isatty())
         print(f"log: {url}")
         if failure.get("error"):
             print(failure["error"])

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 from .api import ApiError, NixbotClient, RepoRef
 from .config import Settings, config_path
+from .term import sanitize_block, sanitize_line
 from .watch_tty import TtyWatch
 
 if TYPE_CHECKING:
@@ -249,7 +250,7 @@ def print_failures(  # noqa: PLR0913
         if failure.get("error"):
             print(failure["error"])
         if failure.get("log_tail"):
-            print(failure["log_tail"])
+            print(sanitize_block(failure["log_tail"]))
 
 
 def cmd_build_watch(client: NixbotClient, args: argparse.Namespace) -> int:
@@ -366,7 +367,7 @@ def cmd_log(client: NixbotClient, args: argparse.Namespace) -> int:
                 if failure.get("error"):
                     print(failure["error"])
                 if failure.get("log_tail"):
-                    print(failure["log_tail"])
+                    print(sanitize_block(failure["log_tail"]))
         return EXIT_BUILD_FAILED if build_failed else EXIT_OK
 
     attr = _match_attr(detail["attributes"], args.attr)
@@ -402,7 +403,7 @@ def follow_attr(
         elif event == "phase":
             print(f"── {names.get(data['idx'], attr)}: {data['phase']} ──")
         elif event == "line":
-            print(data["text"])
+            print(sanitize_line(data["text"]))
             streamed = True
         elif event == "drv-done":
             name = names.get(data["idx"], attr)

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import subprocess
@@ -215,6 +216,8 @@ def print_failures(  # noqa: PLR0913
 def cmd_build_watch(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
+    if args.attr:
+        return watch_attrs(client, repo, number, args.attr)
     if sys.stdout.isatty():
         watcher = TtyWatch(client, repo, number, sys.stdout)
         status = watcher.run()
@@ -257,6 +260,65 @@ def watch_build(client: NixbotClient, repo: RepoRef, number: int) -> int:
     return EXIT_BUILD_FAILED if build["status"] in FAILED_STATUSES else EXIT_OK
 
 
+def watch_attrs(
+    client: NixbotClient, repo: RepoRef, number: int, selectors: list[str]
+) -> int:
+    """Wait for the given attributes to finish. Prints one verdict per
+    attribute, and on failure its log tail plus a log URL. Exit 1 when
+    any of them failed."""
+    detail = client.build(repo, number)
+    watched = {
+        a["attr"]: a for s in selectors for a in [_match_attr(detail["attributes"], s)]
+    }
+    failed = False
+
+    def report(attr: dict) -> None:
+        nonlocal failed
+        verdict = status_str(attr["status"], cached=bool(attr.get("cached")))
+        print(f"{verdict} {attr['attr']}", flush=True)
+        if attr["status"] not in FAILED_STATUSES:
+            return
+        failed = True
+        if attr.get("error"):
+            print(attr["error"])
+        print(f"log: {client.log_url(repo, number, attr['attr'], raw=True)}")
+        with contextlib.suppress(ApiError):
+            print(sanitize_block(client.log_text(repo, number, attr["attr"], tail=20)))
+
+    pending = {}
+    for name, attr in watched.items():
+        if attr["status"] in RUNNING_STATUSES:
+            pending[name] = attr
+        else:
+            report(attr)
+    events: Iterator[dict] | None = None
+    while pending:
+        if events is None:
+            events = client.events(build=detail["build"]["id"])
+        if next(events, None) is None:
+            events = None
+        delta = client.finished_attrs(repo, number)
+        for a in delta["items"]:
+            if a["attr"] in pending:
+                del pending[a["attr"]]
+                report(a)
+        if pending and delta["build"]["status"] not in RUNNING_STATUSES:
+            # The build ended without them finishing (e.g. eval failure).
+            final = client.build(repo, number)["attributes"]
+            for name in list(pending):
+                report(_match_attr(final, name))
+            break
+
+    return EXIT_BUILD_FAILED if failed else EXIT_OK
+
+
+def resolve_attr(
+    client: NixbotClient, repo: RepoRef, number: int, selector: str
+) -> str:
+    """Full attribute name for a selector (exact, substring or drv path)."""
+    return _match_attr(client.build(repo, number)["attributes"], selector)["attr"]
+
+
 def cmd_build_restart(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
@@ -264,8 +326,9 @@ def cmd_build_restart(client: NixbotClient, args: argparse.Namespace) -> int:
         client.restart_effects(repo, number)
         print(f"restarting effects of build #{number}")
     elif args.attr:
-        client.restart_attr(repo, number, args.attr)
-        print(f"restarting {args.attr} of build #{number}")
+        attr = resolve_attr(client, repo, number, args.attr)
+        client.restart_attr(repo, number, attr)
+        print(f"restarting {attr} of build #{number}")
     else:
         client.restart_build(repo, number)
         print(f"restarting build #{number}")
@@ -276,8 +339,9 @@ def cmd_build_cancel(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
     if args.attr:
-        client.cancel_attr(repo, number, args.attr)
-        print(f"cancelling {args.attr} of build #{number}")
+        attr = resolve_attr(client, repo, number, args.attr)
+        client.cancel_attr(repo, number, attr)
+        print(f"cancelling {attr} of build #{number}")
     else:
         client.cancel_build(repo, number)
         print(f"cancelling build #{number}")
@@ -449,11 +513,18 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
   nbo build watch                   the current commit's build, exit 1 on failure
   nbo build watch 412               build #412 of the repo in the CWD
   nbo build watch 412 -R github/Mic92/dotfiles   without a local checkout
+  nbo build watch 412 --attr treefmt --attr nixos-eve   wait only for these, exit 1 if any fails
 
 On a terminal this shows finished attributes above a live view of the
 running ones. Piped or in CI it prints one line per finished attribute.""",
     )
     b_watch.add_argument("number", type=int, nargs="?")
+    b_watch.add_argument(
+        "--attr",
+        action="append",
+        metavar="ATTR|DRV-PATH",
+        help="wait only for this attribute (repeatable)",
+    )
     _add_repo_arg(b_watch)
     b_watch.set_defaults(func=cmd_build_watch)
 
@@ -464,7 +535,7 @@ running ones. Piped or in CI it prints one line per finished attribute.""",
         epilog="""examples:
   nbo build restart                 rebuild the current commit's build
   nbo build restart 412             rebuild everything of build #412
-  nbo build restart 412 --attr x86_64-linux.nixos-eve   one attribute only
+  nbo build restart 412 --attr nixos-eve   one attribute only (substring is enough)
   nbo build restart 412 --effects   re-run the effects""",
     )
     b_restart.add_argument("number", type=int, nargs="?")

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -1,0 +1,414 @@
+"""nbo: gh-style command line client for the nixbot CI service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import webbrowser
+from typing import TYPE_CHECKING, Any, NoReturn
+
+from .api import ApiError, NixbotClient, RepoRef
+from .config import Settings, config_path
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+EXIT_OK = 0
+EXIT_BUILD_FAILED = 1
+EXIT_USAGE = 2
+EXIT_AUTH = 4
+
+FAILED_STATUSES = {
+    "failed",
+    "cancelled",
+    "dependency_failed",
+    "cached_failure",
+    "failed_eval",
+}
+STATUS_GLYPHS = {"succeeded": "✓", "failed": "✗", "building": "⏵", "pending": "·"}
+
+
+class UsageError(Exception):
+    """Bad invocation: reported on stderr, exit 2."""
+
+
+def _color(text: str, code: str) -> str:
+    if not sys.stdout.isatty():
+        return text
+    return f"\x1b[{code}m{text}\x1b[0m"
+
+
+def status_str(status: str) -> str:
+    glyph = STATUS_GLYPHS.get(status, "·")
+    if status == "succeeded":
+        return _color(f"{glyph} {status}", "32")
+    if status in FAILED_STATUSES:
+        return _color(f"{glyph} {status}", "31")
+    return _color(f"{glyph} {status}", "33")
+
+
+def print_table(rows: list[dict[str, Any]], columns: list[str]) -> None:
+    """Aligned columns like gh. The header row only appears on a TTY."""
+    cells = [
+        [str(row.get(c, "") if row.get(c) is not None else "") for c in columns]
+        for row in rows
+    ]
+    if sys.stdout.isatty():
+        cells.insert(0, [c.upper() for c in columns])
+    widths = [max(len(r[i]) for r in cells) for i in range(len(columns))]
+    for row in cells:
+        print(
+            "  ".join(
+                cell.ljust(w) for cell, w in zip(row, widths, strict=True)
+            ).rstrip()
+        )
+
+
+def print_json(data: Any, fields: str | None) -> None:
+    """--json output. fields is a comma-separated projection of the rows."""
+    if fields:
+        keys = fields.split(",")
+        rows = data if isinstance(data, list) else [data]
+        data = [{k: row.get(k) for k in keys} for row in rows]
+    print(json.dumps(data, indent=2))
+
+
+def _git(*args: str) -> str | None:
+    try:
+        out = subprocess.run(["git", *args], capture_output=True, text=True, check=True)
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return out.stdout.strip()
+
+
+def resolve_repo(client: NixbotClient, spec: str | None) -> RepoRef:
+    """-R forge/owner/name, or owner/name / the CWD's git remote matched
+    against the server's repositories."""
+    if spec and spec.count("/") == 2:
+        return RepoRef.parse(spec)
+    if spec:
+        parts = spec.strip("/").split("/")
+        if len(parts) != 2 or not all(parts):
+            msg = f"expected [forge/]owner/name, got {spec!r}"
+            raise UsageError(msg)
+        owner, name = parts
+    else:
+        remote = _git("remote", "get-url", "origin")
+        if not remote:
+            msg = "not in a git repository: pass --repo forge/owner/name"
+            raise UsageError(msg)
+        parts = remote.rstrip("/").removesuffix(".git").replace(":", "/").split("/")
+        owner, name = parts[-2], parts[-1]
+    matches = [r for r in client.repos() if r["owner"] == owner and r["name"] == name]
+    if not matches:
+        msg = f"repository {owner}/{name} is not known to the server"
+        raise UsageError(msg)
+    return RepoRef(matches[0]["forge"], owner, name)
+
+
+def resolve_build(client: NixbotClient, repo: RepoRef, number: int | None) -> int:
+    """Explicit build number, or the latest build of the CWD's HEAD commit."""
+    if number is not None:
+        return number
+    commit = _git("rev-parse", "HEAD")
+    if not commit:
+        msg = "not in a git repository: pass a build number"
+        raise UsageError(msg)
+    builds = client.builds(repo, commit=commit)["items"]
+    if not builds:
+        msg = f"no build for commit {commit[:12]} in {repo}"
+        raise UsageError(msg)
+    return int(builds[0]["number"])
+
+
+# --- commands ----------------------------------------------------------
+
+
+def cmd_repo_list(client: NixbotClient, args: argparse.Namespace) -> int:
+    repos = client.repos()
+    if args.json is not None:
+        print_json(repos, args.json)
+        return EXIT_OK
+    rows = [
+        {
+            **r,
+            "repo": f"{r['forge']}/{r['owner']}/{r['name']}",
+            "enabled": "enabled" if r["enabled"] else "disabled",
+        }
+        for r in repos
+    ]
+    print_table(rows, ["repo", "enabled", "default_branch", "url"])
+    return EXIT_OK
+
+
+def cmd_repo_set_enabled(client: NixbotClient, args: argparse.Namespace) -> int:
+    repo = resolve_repo(client, args.repository)
+    result = client.set_enabled(repo, enabled=args.action == "enable")
+    state = "enabled" if result["enabled"] else "disabled"
+    print(f"{repo} {state}")
+    return EXIT_OK
+
+
+def cmd_build_list(client: NixbotClient, args: argparse.Namespace) -> int:
+    repo = resolve_repo(client, args.repo)
+    page = client.builds(
+        repo,
+        status=args.status,
+        branch=args.branch,
+        pr_number=args.pr,
+        commit=args.commit,
+    )
+    if args.json is not None:
+        print_json(page["items"], args.json)
+        return EXIT_OK
+    rows = [
+        {
+            **b,
+            "status": status_str(b["status"]),
+            "commit": b["commit_sha"][:12],
+            "pr": b["pr_number"],
+        }
+        for b in page["items"]
+    ]
+    print_table(rows, ["number", "status", "branch", "pr", "commit", "created_at"])
+    return EXIT_OK
+
+
+def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
+    repo = resolve_repo(client, args.repo)
+    number = resolve_build(client, repo, args.number)
+    if args.web:
+        webbrowser.open(f"{client.http.base_url}/repos/{repo}/builds/{number}")
+        return EXIT_OK
+    detail = client.build(repo, number)
+    if args.json is not None:
+        print_json(detail, args.json)
+        return EXIT_OK
+    build, attrs = detail["build"], detail["attributes"]
+    print(f"build #{number} {repo} {build['branch']} @ {build['commit_sha'][:12]}")
+    print(f"status: {status_str(build['status'])}")
+    if build.get("error"):
+        print(f"error: {build['error']}")
+    counts: dict[str, int] = {}
+    for a in attrs:
+        counts[a["status"]] = counts.get(a["status"], 0) + 1
+    summary = " · ".join(f"{n} {s}" for s, n in sorted(counts.items()))
+    print(f"attributes: {len(attrs)}" + (f" ({summary})" if attrs else ""))
+    failed = [a for a in attrs if a["status"] in FAILED_STATUSES]
+    for a in failed:
+        print(f"  {status_str(a['status'])}  {a['attr']}")
+    if failed:
+        print(f"logs: nbo log {number} <attr> [-R {repo}]")
+    return EXIT_OK
+
+
+def cmd_build_restart(client: NixbotClient, args: argparse.Namespace) -> int:
+    repo = resolve_repo(client, args.repo)
+    number = resolve_build(client, repo, args.number)
+    if args.effects:
+        client.restart_effects(repo, number)
+        print(f"restarting effects of build #{number}")
+    elif args.attr:
+        client.restart_attr(repo, number, args.attr)
+        print(f"restarting {args.attr} of build #{number}")
+    else:
+        client.restart_build(repo, number)
+        print(f"restarting build #{number}")
+    return EXIT_OK
+
+
+def cmd_build_cancel(client: NixbotClient, args: argparse.Namespace) -> int:
+    repo = resolve_repo(client, args.repo)
+    number = resolve_build(client, repo, args.number)
+    if args.attr:
+        client.cancel_attr(repo, number, args.attr)
+        print(f"cancelling {args.attr} of build #{number}")
+    else:
+        client.cancel_build(repo, number)
+        print(f"cancelling build #{number}")
+    return EXIT_OK
+
+
+def _match_attr(attrs: list[dict], selector: str) -> dict:
+    """Attribute by exact name, unambiguous substring, or drv store path."""
+    if selector.endswith(".drv"):
+        matches = [a for a in attrs if a.get("drv_path") == selector]
+        if matches:
+            return matches[0]
+    exact = [a for a in attrs if a["attr"] == selector]
+    if exact:
+        return exact[0]
+    matches = [a for a in attrs if selector in a["attr"]]
+    if not matches:
+        msg = f"no attribute matches {selector!r}"
+        raise UsageError(msg)
+    if len(matches) > 1:
+        names = ", ".join(a["attr"] for a in matches)
+        msg = f"{selector!r} is ambiguous: {names}"
+        raise UsageError(msg)
+    return matches[0]
+
+
+def cmd_log(client: NixbotClient, args: argparse.Namespace) -> int:
+    repo = resolve_repo(client, args.repo)
+    number = resolve_build(client, repo, args.number)
+    detail = client.build(repo, number)
+    build_failed = detail["build"]["status"] in FAILED_STATUSES
+
+    if args.attr is None:  # whole build: print the failure summary
+        summary = client.failures(repo, number, tail=args.tail)
+        if args.json is not None:
+            print_json(summary, args.json)
+        else:
+            print(f"build #{number}: {status_str(summary['status'])}")
+            if summary.get("error"):
+                print(summary["error"])
+            for failure in summary["failures"]:
+                print(f"\n── {failure['attr']} ── {status_str(failure['status'])}")
+                if failure.get("error"):
+                    print(failure["error"])
+                if failure.get("log_tail"):
+                    print(failure["log_tail"])
+        return EXIT_BUILD_FAILED if build_failed else EXIT_OK
+
+    attr = _match_attr(detail["attributes"], args.attr)
+    drv = args.attr if args.attr.endswith(".drv") else None
+    if args.json is not None:
+        toc = client.log_toc(repo, number, attr["attr"])
+        print_json(toc, args.json)
+    else:
+        print(
+            client.log_text(repo, number, attr["attr"], tail=args.tail, drv=drv), end=""
+        )
+    failed = attr["status"] in FAILED_STATUSES
+    return EXIT_BUILD_FAILED if failed else EXIT_OK
+
+
+def cmd_auth_status(client: NixbotClient, args: argparse.Namespace) -> int:  # noqa: ARG001
+    settings = Settings.load()
+    print(f"server: {settings.url}")
+    if settings.token:
+        print(f"token: {settings.token[:8]}… (NIXBOT_TOKEN or {config_path()})")
+    else:
+        print("token: none (anonymous). Set NIXBOT_TOKEN for control commands.")
+    client.repos()  # verifies the server answers and the token is accepted
+    print("server is reachable")
+    return EXIT_OK
+
+
+# --- argument parsing ---------------------------------------------------
+
+
+def _add_repo_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "-R",
+        "--repo",
+        metavar="[FORGE/]OWNER/NAME",
+        help="repository (default: inferred from the git remote)",
+    )
+
+
+def _add_json_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--json",
+        nargs="?",
+        const="",
+        metavar="FIELDS",
+        help="JSON output, optionally projected to comma-separated fields",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
+    parser = argparse.ArgumentParser(prog="nbo", description="nixbot CI client")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    repo = sub.add_parser("repo", help="manage repositories").add_subparsers(
+        dest="subcommand", required=True
+    )
+    repo_list = repo.add_parser("list", help="enabled repositories")
+    _add_json_arg(repo_list)
+    repo_list.set_defaults(func=cmd_repo_list)
+    for action in ("enable", "disable"):
+        p = repo.add_parser(action, help=f"{action} CI for a repository")
+        p.add_argument("repository", metavar="[FORGE/]OWNER/NAME")
+        p.set_defaults(func=cmd_repo_set_enabled, action=action)
+
+    build = sub.add_parser("build", help="inspect and control builds").add_subparsers(
+        dest="subcommand", required=True
+    )
+    b_list = build.add_parser("list", help="list builds")
+    _add_repo_arg(b_list)
+    b_list.add_argument("--branch")
+    b_list.add_argument("--pr", type=int)
+    b_list.add_argument("--commit")
+    b_list.add_argument("--status")
+    _add_json_arg(b_list)
+    b_list.set_defaults(func=cmd_build_list)
+
+    b_view = build.add_parser("view", help="show one build")
+    b_view.add_argument("number", type=int, nargs="?")
+    _add_repo_arg(b_view)
+    _add_json_arg(b_view)
+    b_view.add_argument("--web", action="store_true", help="open in the browser")
+    b_view.set_defaults(func=cmd_build_view)
+
+    b_restart = build.add_parser(
+        "restart", help="restart a build, attribute or effects"
+    )
+    b_restart.add_argument("number", type=int, nargs="?")
+    _add_repo_arg(b_restart)
+    b_restart.add_argument("--attr", help="restart only this attribute")
+    b_restart.add_argument("--effects", action="store_true", help="restart the effects")
+    b_restart.set_defaults(func=cmd_build_restart)
+
+    b_cancel = build.add_parser("cancel", help="cancel a build or attribute")
+    b_cancel.add_argument("number", type=int, nargs="?")
+    _add_repo_arg(b_cancel)
+    b_cancel.add_argument("--attr", help="cancel only this attribute")
+    b_cancel.set_defaults(func=cmd_build_cancel)
+
+    log = sub.add_parser("log", help="failure summary or an attribute's log")
+    log.add_argument("number", type=int, nargs="?")
+    log.add_argument(
+        "attr",
+        nargs="?",
+        metavar="ATTR|DRV-PATH",
+        help="attribute (substring) or .drv store path",
+    )
+    _add_repo_arg(log)
+    log.add_argument("--tail", type=int, metavar="N", help="last N lines")
+    _add_json_arg(log)
+    log.set_defaults(func=cmd_log)
+
+    auth = sub.add_parser("auth", help="authentication").add_subparsers(
+        dest="subcommand", required=True
+    )
+    auth.add_parser("status", help="configured server and token").set_defaults(
+        func=cmd_auth_status
+    )
+    return parser
+
+
+def make_client() -> NixbotClient:
+    settings = Settings.load()
+    return NixbotClient(settings.url, settings.token)
+
+
+def main(argv: Sequence[str] | None = None) -> NoReturn:
+    args = build_parser().parse_args(argv)
+    try:
+        with make_client() as client:
+            code = args.func(client, args)
+    except (UsageError, ValueError) as err:
+        print(f"nbo: {err}", file=sys.stderr)
+        code = EXIT_USAGE
+    except ApiError as err:
+        print(f"nbo: {err}", file=sys.stderr)
+        code = EXIT_AUTH if err.status in (401, 403) else EXIT_USAGE
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import webbrowser
@@ -515,6 +516,13 @@ def main(argv: Sequence[str] | None = None) -> NoReturn:
     except ApiError as err:
         print(f"nbo: {err}", file=sys.stderr)
         code = EXIT_AUTH if err.status in (401, 403) else EXIT_USAGE
+    except KeyboardInterrupt:
+        code = 130
+    except BrokenPipeError:
+        # Downstream pager/head closed the pipe. Point stdout at devnull
+        # so the interpreter's final flush stays quiet too.
+        os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+        code = EXIT_OK
     sys.exit(code)
 
 

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 from .api import ApiError, NixbotClient, RepoRef
 from .config import Settings, config_path
+from .watch_tty import TtyWatch
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -250,9 +251,15 @@ def print_failures(  # noqa: PLR0913
         if failure.get("log_tail"):
             print(failure["log_tail"])
 
+
 def cmd_build_watch(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
+    if sys.stdout.isatty():
+        watcher = TtyWatch(client, repo, number, sys.stdout)
+        status = watcher.run()
+        print_failures(client, repo, number, status, watcher.finished)
+        return EXIT_BUILD_FAILED if status in FAILED_STATUSES else EXIT_OK
     return watch_build(client, repo, number)
 
 

--- a/nixbot_cli/nixbot_cli/term.py
+++ b/nixbot_cli/nixbot_cli/term.py
@@ -1,4 +1,5 @@
-"""Sanitizing of build log output before it is re-emitted to a terminal.
+"""Terminal presentation helpers: status wording and colors, durations,
+and sanitizing of build log output before it is re-emitted.
 
 The escape-sequence grammar mirrors nixbot.ansi (the server keeps the
 colored original, the CLI is standalone and cannot import it).
@@ -7,6 +8,55 @@ colored original, the CLI is standalone and cannot import it).
 from __future__ import annotations
 
 import re
+import sys
+
+RUNNING_STATUSES = {"pending", "evaluating", "building"}
+GOOD_STATUSES = {"succeeded", "skipped_local"}
+FAILED_STATUSES = {
+    "failed",
+    "cancelled",
+    "dependency_failed",
+    "cached_failure",
+    "failed_eval",
+}
+# Human wording for the raw database statuses.
+STATUS_LABELS = {
+    "succeeded": "built",
+    "skipped_local": "cached",
+    "cached_failure": "failed (cached)",
+    "dependency_failed": "dependency failed",
+    "failed_eval": "eval failed",
+}
+
+MINUTE = 60
+HOUR = 3600
+
+
+def _color(text: str, code: str) -> str:
+    if not sys.stdout.isatty():
+        return text
+    return f"\x1b[{code}m{text}\x1b[0m"
+
+
+def status_str(status: str, *, cached: bool = False) -> str:
+    label = STATUS_LABELS.get(status, status)
+    if status == "succeeded" and cached:
+        label = "cached"
+    if status in GOOD_STATUSES:
+        return _color(f"✓ {label}", "32")
+    if status in FAILED_STATUSES:
+        return _color(f"✗ {label}", "31")
+    glyph = "⏵" if status in ("building", "evaluating") else "·"
+    return _color(f"{glyph} {label}", "33")
+
+
+def fmt_duration(seconds: float) -> str:
+    if seconds < MINUTE:
+        return f"{seconds:.0f}s"
+    if seconds < HOUR:
+        return f"{seconds / MINUTE:.0f}m{seconds % MINUTE:.0f}s"
+    return f"{seconds / HOUR:.0f}h{seconds % HOUR / MINUTE:.0f}m"
+
 
 # One token per escape sequence. Only the named SGR group is allowed
 # through; every other form (cursor moves, clear-screen, OSC titles,

--- a/nixbot_cli/nixbot_cli/term.py
+++ b/nixbot_cli/nixbot_cli/term.py
@@ -1,0 +1,61 @@
+"""Sanitizing of build log output before it is re-emitted to a terminal.
+
+The escape-sequence grammar mirrors nixbot.ansi (the server keeps the
+colored original, the CLI is standalone and cannot import it).
+"""
+
+from __future__ import annotations
+
+import re
+
+# One token per escape sequence. Only the named SGR group is allowed
+# through; every other form (cursor moves, clear-screen, OSC titles,
+# charset selects from BIOS/boot logs) is consumed and dropped.
+ANSI_TOKEN_RE = re.compile(
+    r"\x1b\[(?P<sgr>[0-9;:]*)m"
+    r"|\x1b\](?P<osc>[^\x07\x1b]*)(?:\x07|\x1b\\)"
+    r"|\x1b\[[0-9;:?<=>]*[ -/]*[@-~]"
+    r"|\x1b[()*+]."
+    r"|\x1b[^\[\]]"
+)
+# C0 controls that mean nothing in a log line (tabs are expanded first).
+CTRL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f]")
+# Mega-lines (minified JS etc.) choke terminals.
+MAX_LINE_LEN = 4096
+SGR_RESET = "\x1b[0m"
+_TRAILING_PARTIAL_SGR_RE = re.compile(r"\x1b[^m]*$")
+
+
+def sanitize_line(s: str) -> str:
+    """Make one captured log line safe to re-emit.
+
+    Whitelist approach: only SGR color sequences and printable text
+    survive. Carriage-return overwrite is emulated, the length is
+    capped, and a kept color always ends with a reset so it cannot
+    bleed into our own output.
+    """
+    if "\r" in s:
+        s = next((p for p in reversed(s.split("\r")) if p), "")
+    kept_sgr = False
+
+    def repl(m: re.Match[str]) -> str:
+        nonlocal kept_sgr
+        if m.group("sgr") is None:
+            return ""
+        kept_sgr = True
+        return m.group(0)
+
+    s = CTRL_RE.sub("", ANSI_TOKEN_RE.sub(repl, s)).expandtabs(4)
+    if len(s) > MAX_LINE_LEN:
+        # Do not cut an SGR in half: an unterminated CSI makes the
+        # terminal swallow the text that follows.
+        s = _TRAILING_PARTIAL_SGR_RE.sub("", s[:MAX_LINE_LEN])
+        s += " …[line truncated]"
+    if kept_sgr:
+        s += SGR_RESET
+    return s
+
+
+def sanitize_block(text: str) -> str:
+    """sanitize_line applied to every line of a multi-line string."""
+    return "\n".join(sanitize_line(line) for line in text.splitlines())

--- a/nixbot_cli/nixbot_cli/watch_tty.py
+++ b/nixbot_cli/nixbot_cli/watch_tty.py
@@ -20,6 +20,8 @@ import tty
 from datetime import UTC, datetime
 from typing import IO, TYPE_CHECKING
 
+from .term import sanitize_line
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -267,7 +269,7 @@ class TtyWatch:
                     return
                 if event == "line":
                     with self.lock:
-                        self.gist[attr] = data["text"]
+                        self.gist[attr] = sanitize_line(data["text"])
                 elif event == "done":
                     return
 

--- a/nixbot_cli/nixbot_cli/watch_tty.py
+++ b/nixbot_cli/nixbot_cli/watch_tty.py
@@ -17,6 +17,7 @@ import termios
 import threading
 import time
 import tty
+from collections import deque
 from datetime import UTC, datetime
 from typing import IO, TYPE_CHECKING
 
@@ -71,6 +72,10 @@ class Display:
         self.margin = 0  # bottom row of the DECSTBM margin, 0 = none
         self.cols = 0
         self.rows = 0
+        self.resizing = False  # size changed within the last frame
+        # Recent verdicts, enough to rebuild the visible screen after a
+        # resize rewrapped the old rows underneath us.
+        self.history: deque[str] = deque(maxlen=1000)
 
     def _emit(self, buf: str) -> None:
         # DEC 2026 synchronized output: capable terminals paint atomically.
@@ -83,12 +88,31 @@ class Display:
         region = region[: max(rows - 2, 1)]
         limit = rows - len(region)  # last row verdicts may occupy
         buf = f"{CSI}?25l"
+        self.history.extend(permanent)
         if (cols, rows) != (self.cols, self.rows):
+            # A resize rewraps the scrollback under us, so absolute rows
+            # are unreliable until the size settles. Never erase anything:
+            # release the margin, keep appending verdicts and skip the
+            # region until the next frame sees a stable size.
             buf += f"{CSI}r"
             self.margin = 0
+            first_size = self.rows == 0
             self.cols, self.rows = cols, rows
             self.row = min(self.row, rows)
-        if self.row > limit + 1:
+            self.resizing = not first_size
+        elif self.resizing:
+            # The size settled: rebuild the visible screen from the model.
+            # The cleared rows are repainted from history, older lines are
+            # ordinary scrollback and rewrap on their own.
+            self.resizing = False
+            buf += f"{CSI}2J{CSI}1;1H"
+            tail = list(self.history)[-(limit - 1) :] if limit > 1 else []
+            buf += "".join(
+                f"{CSI}{i + 1};1H{line}{CSI}K" for i, line in enumerate(tail)
+            )
+            self.row = len(tail) + 1
+            permanent = []
+        if not self.resizing and self.row > limit + 1:
             # The region grew past the space left below the output:
             # scroll the flow area up to make room.
             buf += self._set_margin(limit)
@@ -102,10 +126,12 @@ class Display:
                 buf += self._set_margin(limit)
                 buf += f"{CSI}{limit};1H\n\r{line}{CSI}K"
         self.top = min(self.row, limit + 1)
-        for i, line in enumerate(region):
-            buf += f"{CSI}{self.top + i};1H{_clip(line, cols)}{RESET}{CSI}K"
-        # Clear stale rows under the region (it may have moved or shrunk).
-        buf += f"{CSI}J{CSI}{self.top};1H"
+        if not self.resizing:
+            for i, line in enumerate(region):
+                buf += f"{CSI}{self.top + i};1H{_clip(line, cols)}{RESET}{CSI}K"
+            # Clear stale rows under the region (it may have moved or shrunk).
+            buf += f"{CSI}J"
+        buf += f"{CSI}{self.top};1H"
         self._emit(buf)
 
     def _set_margin(self, limit: int) -> str:

--- a/nixbot_cli/nixbot_cli/watch_tty.py
+++ b/nixbot_cli/nixbot_cli/watch_tty.py
@@ -217,7 +217,7 @@ class TtyWatch:
         self.finished = 0
         self.failed = 0
         self.build_status = "pending"
-        self.started_at = time.time()
+        self.started_at = time.time()  # replaced by the build's start time
         self.spin = 0
 
     # --- worker: events + finished-attribute cursor ---------------------
@@ -226,6 +226,9 @@ class TtyWatch:
         detail = self.client.build(self.repo, self.number)
         with self.lock:
             self.build_status = detail["build"]["status"]
+            self.started_at = _epoch(
+                detail["build"].get("started_at") or detail["build"].get("created_at")
+            )
             for a in detail["attributes"]:
                 if a["status"] == "building":
                     self.running[a["attr"]] = _epoch(a.get("started_at"))

--- a/nixbot_cli/nixbot_cli/watch_tty.py
+++ b/nixbot_cli/nixbot_cli/watch_tty.py
@@ -1,0 +1,337 @@
+"""Interactive TTY renderer for nbo build watch.
+
+Verdicts of finished attributes go to normal scrollback, while a region
+at the bottom is redrawn in place with the running attributes and a live
+last log line for the longest-running ones.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+import select
+import shutil
+import sys
+import termios
+import threading
+import time
+import tty
+from datetime import UTC, datetime
+from typing import IO, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .api import NixbotClient, RepoRef
+
+CSI = "\x1b["
+DIM = f"{CSI}2m"
+RED = f"{CSI}31m"
+GREEN = f"{CSI}32m"
+YELLOW = f"{CSI}33m"
+BOLD = f"{CSI}1m"
+RESET = f"{CSI}0m"
+SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+RUNNING_STATUSES = {"pending", "evaluating", "building"}
+LIVE_LOGS = 5  # log streams followed for the longest-running attributes
+
+
+def fmt_duration(seconds: float) -> str:
+    if seconds < 60:  # noqa: PLR2004
+        return f"{seconds:.0f}s"
+    if seconds < 3600:  # noqa: PLR2004
+        return f"{seconds / 60:.0f}m{seconds % 60:.0f}s"
+    return f"{seconds / 3600:.0f}h{seconds % 3600 / 60:.0f}m"
+
+
+class Display:
+    """Scrollback for verdicts plus a live region redrawn in place.
+
+    The region floats directly below the last verdict and only becomes
+    pinned to the bottom once the output reaches it. From then on the
+    verdicts scroll inside a DECSTBM margin above the region, so wrapped
+    or bursty output cannot corrupt or duplicate the region by
+    construction.
+    """
+
+    def __init__(
+        self,
+        out: IO[str],
+        size: Callable[[], tuple[int, int]] = shutil.get_terminal_size,
+        origin: int = 1,
+    ) -> None:
+        self.out = out
+        self.size = size  # () -> (columns, rows)
+        self.row = origin  # row the next verdict goes to
+        self.top = origin  # first row of the drawn region
+        self.margin = 0  # bottom row of the DECSTBM margin, 0 = none
+        self.cols = 0
+        self.rows = 0
+
+    def _emit(self, buf: str) -> None:
+        # DEC 2026 synchronized output: capable terminals paint atomically.
+        self.out.write(f"{CSI}?2026h{buf}{CSI}?2026l")
+        self.out.flush()
+
+    def frame(self, permanent: list[str], region: list[str]) -> None:
+        """One atomic update: append verdicts, redraw the live region."""
+        cols, rows = self.size()
+        region = region[: max(rows - 2, 1)]
+        limit = rows - len(region)  # last row verdicts may occupy
+        buf = f"{CSI}?25l"
+        if (cols, rows) != (self.cols, self.rows):
+            buf += f"{CSI}r"
+            self.margin = 0
+            self.cols, self.rows = cols, rows
+            self.row = min(self.row, rows)
+        if self.row > limit + 1:
+            # The region grew past the space left below the output:
+            # scroll the flow area up to make room.
+            buf += self._set_margin(limit)
+            buf += f"{CSI}{limit};1H" + "\n" * (self.row - limit - 1)
+            self.row = limit + 1
+        for line in permanent:
+            if self.row <= limit:
+                buf += f"{CSI}{self.row};1H{line}{CSI}K"
+                self.row += 1
+            else:
+                buf += self._set_margin(limit)
+                buf += f"{CSI}{limit};1H\n\r{line}{CSI}K"
+        self.top = min(self.row, limit + 1)
+        for i, line in enumerate(region):
+            buf += f"{CSI}{self.top + i};1H{_clip(line, cols)}{RESET}{CSI}K"
+        # Clear stale rows under the region (it may have moved or shrunk).
+        buf += f"{CSI}J{CSI}{self.top};1H"
+        self._emit(buf)
+
+    def _set_margin(self, limit: int) -> str:
+        if self.margin == limit:
+            return ""
+        self.margin = limit
+        return f"{CSI}r{CSI}1;{limit}r"
+
+    def close(self) -> None:
+        """Release the margin and clear the region."""
+        self._emit(f"{CSI}r{CSI}{self.top};1H{CSI}J{CSI}?25h")
+        self.margin = 0
+
+
+def _clip(line: str, width: int) -> str:
+    """Crude ANSI-aware clip: drop the tail once the visible width is hit."""
+    visible = 0
+    out = []
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if ch == "\x1b":  # skip a CSI sequence
+            j = i + 2
+            while j < len(line) and not ("@" <= line[j] <= "~"):
+                j += 1
+            out.append(line[i : j + 1])
+            i = j + 1
+            continue
+        if visible >= width - 1:
+            break
+        out.append(ch)
+        visible += 1
+        i += 1
+    return "".join(out)
+
+
+def _epoch(iso: str | None) -> float:
+    if not iso:
+        return time.time()
+    return datetime.fromisoformat(iso).replace(tzinfo=UTC).timestamp()
+
+
+def cursor_row(out: IO[str], rows: int) -> int:
+    """Current cursor row via a CPR query, so the live region can start
+    right below the shell prompt instead of at the bottom of the screen."""
+    if not (sys.stdin.isatty() and out.isatty()):
+        return rows
+    fd = sys.stdin.fileno()
+    saved = termios.tcgetattr(fd)
+    try:
+        tty.setcbreak(fd)
+        out.write(f"{CSI}6n")
+        out.flush()
+        reply = ""
+        while not reply.endswith("R"):
+            if not select.select([fd], [], [], 0.2)[0]:
+                return rows
+            reply += os.read(fd, 32).decode(errors="replace")
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+    match = re.search(r"\[(\d+);\d+R", reply)
+    return int(match.group(1)) if match else rows
+
+
+class TtyWatch:
+    """Runs the watch loop in a worker thread and renders in the caller."""
+
+    def __init__(
+        self,
+        client: NixbotClient,
+        repo: RepoRef,
+        number: int,
+        out: IO[str],
+        size: Callable[[], tuple[int, int]] = shutil.get_terminal_size,
+    ) -> None:
+        self.client = client
+        self.repo = repo
+        self.number = number
+        self.display = Display(out, size=size, origin=cursor_row(out, size()[1]))
+        self.error: BaseException | None = None
+        self.lock = threading.Lock()
+        self.done = threading.Event()
+        self.running: dict[str, float] = {}  # attr -> started (epoch)
+        self.gist: dict[str, str] = {}  # attr -> last live log line
+        self.followers: set[str] = set()
+        self.pending: list[str] = []  # verdict lines waiting for the next tick
+        self.finished = 0
+        self.failed = 0
+        self.build_status = "pending"
+        self.started_at = time.time()
+        self.spin = 0
+
+    # --- worker: events + finished-attribute cursor ---------------------
+
+    def _seed_running(self) -> None:
+        detail = self.client.build(self.repo, self.number)
+        with self.lock:
+            self.build_status = detail["build"]["status"]
+            for a in detail["attributes"]:
+                if a["status"] == "building":
+                    self.running[a["attr"]] = _epoch(a.get("started_at"))
+
+    def _record_finished(self, attrs: list[dict]) -> None:
+        # Imported here: main imports this module for cmd_build_watch.
+        from .main import FAILED_STATUSES, log_url, status_str  # noqa: PLC0415
+
+        for a in attrs:
+            verdict = status_str(a["status"], cached=bool(a.get("cached")))
+            duration = ""
+            if a.get("started_at") and a.get("finished_at"):
+                took = _epoch(a["finished_at"]) - _epoch(a["started_at"])
+                duration = f"  {DIM}{fmt_duration(took)}{RESET}"
+            lines = [f"{verdict} {a['attr']}{duration}"]
+            if a["status"] in FAILED_STATUSES:
+                url = log_url(self.client, self.repo, self.number, a["attr"])
+                lines.append(f"  {DIM}log: {url}{RESET}")
+            with self.lock:
+                self.running.pop(a["attr"], None)
+                self.gist.pop(a["attr"], None)
+                self.finished += 1
+                self.failed += a["status"] in FAILED_STATUSES
+                self.pending.extend(lines)
+
+    def _watch(self) -> None:
+        try:
+            self._watch_loop()
+        except BaseException as err:  # noqa: BLE001 (re-raised by run())
+            self.error = err
+
+    def _watch_loop(self) -> None:
+        cursor: tuple[str, int] | None = None
+        events = None
+        while not self.done.is_set():
+            delta = self.client.finished_attrs(
+                self.repo,
+                self.number,
+                finished_after=cursor[0] if cursor else None,
+                after_id=cursor[1] if cursor else 0,
+            )
+            build, attrs = delta["build"], delta["items"]
+            with self.lock:
+                self.build_status = build["status"]
+            self._record_finished(attrs)
+            if attrs:
+                cursor = (attrs[-1]["finished_at"], attrs[-1]["id"])
+            if build["status"] not in RUNNING_STATUSES:
+                return
+            if events is None:
+                events = self.client.events(build=build["id"])
+            hint = next(events, None)
+            if hint is None:
+                events = None
+            elif hint.get("attr") and hint.get("status") == "building":
+                with self.lock:
+                    self.running.setdefault(hint["attr"], time.time())
+
+    def _follow_log(self, attr: str) -> None:
+        with contextlib.suppress(Exception):
+            for event, data in self.client.log_stream(self.repo, self.number, attr):
+                if self.done.is_set():
+                    return
+                if event == "line":
+                    with self.lock:
+                        self.gist[attr] = data["text"]
+                elif event == "done":
+                    return
+
+    # --- renderer --------------------------------------------------------
+
+    def _rows(self) -> list[str]:
+        self.spin += 1
+        spin = SPINNER[self.spin % len(SPINNER)]
+        with self.lock:
+            running = sorted(self.running.items(), key=lambda kv: kv[1])
+            finished, failed = self.finished, self.failed
+            status = self.build_status
+            gist = dict(self.gist)
+        elapsed = fmt_duration(time.time() - self.started_at)
+        _, term_rows = self.display.size()
+        lines = [
+            f" {BOLD}build #{self.number}{RESET} {status} · "
+            f"{GREEN}✓{finished - failed}{RESET} {RED}✗{failed}{RESET} "
+            f"⏵{len(running)} · {elapsed}"
+        ]
+        budget = max(2, term_rows - 3)
+        now = time.time()
+        for shown, (attr, started) in enumerate(running):
+            live = gist.get(attr)
+            rows = 2 if live else 1
+            if budget - rows < (1 if shown < len(running) - 1 else 0):
+                lines.append(f"   {DIM}… +{len(running) - shown} more{RESET}")
+                break
+            budget -= rows
+            lines.append(
+                f" {YELLOW}{spin}{RESET} {attr:<50} {fmt_duration(now - started):>7}"
+            )
+            if live:
+                lines.append(f"   {DIM}{live}{RESET}")
+        return lines
+
+    def _spawn_followers(self) -> None:
+        with self.lock:
+            top = sorted(self.running.items(), key=lambda kv: kv[1])[:LIVE_LOGS]
+            new = [attr for attr, _ in top if attr not in self.followers]
+            self.followers.update(new)
+        for attr in new:
+            threading.Thread(target=self._follow_log, args=(attr,), daemon=True).start()
+
+    def run(self) -> str:
+        """Render until the build is terminal. Returns the final status."""
+        self._seed_running()
+        worker = threading.Thread(target=self._watch, daemon=True)
+        worker.start()
+        try:
+            while True:
+                alive = worker.is_alive()
+                self._spawn_followers()
+                # Single writer: one frame per tick appends the queued
+                # verdicts and redraws the live region.
+                with self.lock:
+                    verdicts, self.pending = self.pending, []
+                self.display.frame(verdicts, self._rows())
+                if not alive:
+                    break
+                worker.join(timeout=0.25)
+        finally:
+            self.done.set()
+            self.display.close()
+        if self.error is not None:
+            raise self.error
+        return self.build_status

--- a/nixbot_cli/nixbot_cli/watch_tty.py
+++ b/nixbot_cli/nixbot_cli/watch_tty.py
@@ -21,7 +21,13 @@ from collections import deque
 from datetime import UTC, datetime
 from typing import IO, TYPE_CHECKING
 
-from .term import sanitize_line
+from .term import (
+    FAILED_STATUSES,
+    RUNNING_STATUSES,
+    fmt_duration,
+    sanitize_line,
+    status_str,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -37,16 +43,7 @@ BOLD = f"{CSI}1m"
 RESET = f"{CSI}0m"
 SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
-RUNNING_STATUSES = {"pending", "evaluating", "building"}
 LIVE_LOGS = 5  # log streams followed for the longest-running attributes
-
-
-def fmt_duration(seconds: float) -> str:
-    if seconds < 60:  # noqa: PLR2004
-        return f"{seconds:.0f}s"
-    if seconds < 3600:  # noqa: PLR2004
-        return f"{seconds / 60:.0f}m{seconds % 60:.0f}s"
-    return f"{seconds / 3600:.0f}h{seconds % 3600 / 60:.0f}m"
 
 
 class Display:
@@ -96,10 +93,9 @@ class Display:
             # region until the next frame sees a stable size.
             buf += f"{CSI}r"
             self.margin = 0
-            first_size = self.rows == 0
+            self.resizing = self.rows != 0
             self.cols, self.rows = cols, rows
             self.row = min(self.row, rows)
-            self.resizing = not first_size
         elif self.resizing:
             # The size settled: rebuild the visible screen from the model.
             # The cleared rows are repainted from history, older lines are
@@ -153,7 +149,7 @@ def _clip(line: str, width: int) -> str:
     i = 0
     while i < len(line):
         ch = line[i]
-        if ch == "\x1b":  # skip a CSI sequence
+        if ch == "\x1b":  # copy an escape sequence, it occupies no cells
             j = i + 2
             while j < len(line) and not ("@" <= line[j] <= "~"):
                 j += 1
@@ -235,9 +231,6 @@ class TtyWatch:
                     self.running[a["attr"]] = _epoch(a.get("started_at"))
 
     def _record_finished(self, attrs: list[dict]) -> None:
-        # Imported here: main imports this module for cmd_build_watch.
-        from .main import FAILED_STATUSES, log_url, status_str  # noqa: PLC0415
-
         for a in attrs:
             verdict = status_str(a["status"], cached=bool(a.get("cached")))
             duration = ""
@@ -246,7 +239,7 @@ class TtyWatch:
                 duration = f"  {DIM}{fmt_duration(took)}{RESET}"
             lines = [f"{verdict} {a['attr']}{duration}"]
             if a["status"] in FAILED_STATUSES:
-                url = log_url(self.client, self.repo, self.number, a["attr"])
+                url = self.client.log_url(self.repo, self.number, a["attr"])
                 lines.append(f"  {DIM}log: {url}{RESET}")
             with self.lock:
                 self.running.pop(a["attr"], None)
@@ -349,8 +342,7 @@ class TtyWatch:
             while True:
                 alive = worker.is_alive()
                 self._spawn_followers()
-                # Single writer: one frame per tick appends the queued
-                # verdicts and redraws the live region.
+                # Only this loop writes to the terminal.
                 with self.lock:
                     verdicts, self.pending = self.pending, []
                 self.display.frame(verdicts, self._rows())

--- a/nixbot_cli/pyproject.toml
+++ b/nixbot_cli/pyproject.toml
@@ -12,3 +12,6 @@ authors = [
 version = "0.0.1"
 requires-python = ">=3.12"
 dependencies = ["httpx"]
+
+[project.scripts]
+nbo = "nixbot_cli.main:main"

--- a/nixbot_cli/pyproject.toml
+++ b/nixbot_cli/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "nixbot-cli"
+description = "Command-line client (nbo) for the nixbot CI service."
+license = { text = "MIT" }
+authors = [
+    { name = "Jörg Thalheim", email = "joerg@thalheim.io" },
+]
+version = "0.0.1"
+requires-python = ">=3.12"
+dependencies = ["httpx"]

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -6,6 +6,7 @@ let
     self:
     {
       nixbot = self.callPackage ./nixbot.nix { };
+      nixbot-cli = self.callPackage ./nixbot-cli.nix { };
       docs = self.callPackage ./docs.nix { };
     }
     // lib.optionalAttrs pkgs.stdenv.isLinux {

--- a/packages/docs.nix
+++ b/packages/docs.nix
@@ -33,6 +33,7 @@ let
       pages = [
         "EFFECTS.md"
         "OIDC.md"
+        "CLI.md"
       ];
     }
     {

--- a/packages/nixbot-cli.nix
+++ b/packages/nixbot-cli.nix
@@ -1,0 +1,24 @@
+{
+  buildPythonPackage,
+  hatchling,
+  httpx,
+  lib,
+}:
+buildPythonPackage {
+  name = "nixbot-cli";
+  pyproject = true;
+  src = ./../nixbot_cli;
+  build-system = [ hatchling ];
+  dependencies = [ httpx ];
+
+  # The CLI tests live in the server's suite (nixbot.passthru.tests.pytest)
+  # because they run against the real web app.
+
+  meta = {
+    description = "Command-line client (nbo) for the nixbot CI service";
+    homepage = "https://github.com/nix-community/nixbot";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.mic92 ];
+    mainProgram = "nbo";
+  };
+}

--- a/packages/nixbot.nix
+++ b/packages/nixbot.nix
@@ -19,6 +19,7 @@
   postgresql,
   playwright,
   playwright-driver,
+  pyte,
   makeFontsConf,
   dejavu_fonts,
   # Optional: the NixOS module calls this file with python.pkgs.callPackage,
@@ -62,6 +63,7 @@ buildPythonPackage (finalAttrs: {
     pytest-benchmark
     postgresql
     playwright
+    pyte
   ]
   # The CLI's tests (test_cli*.py) run against this app in-process.
   ++ lib.optional (nixbot-cli != null) nixbot-cli;

--- a/packages/nixbot.nix
+++ b/packages/nixbot.nix
@@ -21,6 +21,9 @@
   playwright-driver,
   makeFontsConf,
   dejavu_fonts,
+  # Optional: the NixOS module calls this file with python.pkgs.callPackage,
+  # which cannot supply it. Only the pytest passthru check needs the CLI.
+  nixbot-cli ? null,
   lib,
 }:
 buildPythonPackage (finalAttrs: {
@@ -59,7 +62,9 @@ buildPythonPackage (finalAttrs: {
     pytest-benchmark
     postgresql
     playwright
-  ];
+  ]
+  # The CLI's tests (test_cli*.py) run against this app in-process.
+  ++ lib.optional (nixbot-cli != null) nixbot-cli;
 
   # Browser tests run headless Chromium from the pinned playwright
   # driver; the version matches the python playwright package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.uv.workspace]
+members = ["nixbot", "nixbot_cli"]
+
 [tool.pytest.ini_options]
 pythonpath = ["nixbot"]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ timeout = 60
 asyncio_mode = "auto"
 
 [tool.mypy]
+# so the server tests importing the CLI package resolve
+mypy_path = "nixbot_cli"
+
 # asyncpg ships no type stubs and no py.typed marker.
 [[tool.mypy.overrides]]
 module = "asyncpg.*"


### PR DESCRIPTION
`nbo` is a command line client for nixbot: watch CI, read failure logs and restart or cancel work without opening the web UI. It talks to the new `/api` endpoints with a personal API token and installs standalone (`nix run .#nixbot-cli`).

Repository and build number are inferred from the current git checkout; `-R [forge/]owner/name` and an explicit number override that.

```console
$ nbo build list
$ nbo build view 412

$ nbo build watch             # exit 1 on failure
✓ built x86_64-linux.treefmt  8s
✓ built aarch64-linux.nixbot-tests  5s
 build #144 building · ✓11 ✗0 ⏵1 · 2m18s
 ⠋ x86_64-linux.nixbot-gitlab  2m26s
   gitlab # [   72.5] systemd[1]: Reached target multi-user.target

$ nbo build watch --attr treefmt --attr nixos-eve   # wait only for these

$ nbo log                     # why HEAD's build failed: errors, log tails, log URLs
$ nbo log 412 nixos-eve --follow

$ nbo build restart 412 --attr treefmt
$ nbo build cancel 412
$ nbo repo enable github/acme/widget
```

<img width="2372" height="884" alt="image" src="https://github.com/user-attachments/assets/019c1d3b-1a77-442e-b247-39a0a5317463" />


On a terminal, watch shows finished attributes above a live view of the running ones. Piped or in CI it prints one line per attribute. List/view/log commands take `--json [fields]` and exit codes are stable (0 ok, 1 build failed, 2 usage, 4 auth).

Setup: create a token under *Settings → API tokens*, then set `NIXBOT_URL`/`NIXBOT_TOKEN` or add `~/.config/nixbot/hosts.toml` with `url` and `token` (or `token_command = "rbw get …"`). Details in `docs/CLI.md`.

