### PR TITLE
nixbot_effects: pass a single --chdir to bwrap

### DIFF
--- a/nixbot_effects/nixbot_effects/run.py
+++ b/nixbot_effects/nixbot_effects/run.py
@@ -66,8 +66,9 @@ def _bubblewrap_command(  # noqa: PLR0913
         "--die-with-parent",
         "--dir",
         "/build",
-        "--chdir",
-        "/build",
+        # bwrap warns about repeated --chdir, so the default working
+        # directory only applies when the checkout does not set one.
+        *([] if "--chdir" in checkout_args else ["--chdir", "/build"]),
         # Disk-backed like hercules-ci-agent's work dirs: deploys
         # unpack closures that don't fit a tmpfs.
         "--bind",

--- a/nixbot_effects/nixbot_effects/sandbox.py
+++ b/nixbot_effects/nixbot_effects/sandbox.py
@@ -106,7 +106,7 @@ def effect_checkout_mount(
         "--bind",
         str(effect_checkout),
         EFFECT_CHECKOUT_PATH,
-        # Overrides the default /build working directory (last --chdir wins).
+        # Replaces the default /build working directory.
         "--chdir",
         EFFECT_CHECKOUT_PATH,
     ], {"NIXBOT_EFFECT_CHECKOUT": EFFECT_CHECKOUT_PATH}

--- a/nixbot_effects/nixbot_effects/tests/test_effect_checkout.py
+++ b/nixbot_effects/nixbot_effects/tests/test_effect_checkout.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from nixbot_effects import EffectError
+from nixbot_effects.run import _bubblewrap_command
 from nixbot_effects.sandbox import effect_checkout_mount
 
 
@@ -34,3 +35,42 @@ def test_declared_checkout_mounts_and_exports_path() -> None:
 def test_declared_checkout_without_clone_errors() -> None:
     with pytest.raises(EffectError, match="no checkout clone"):
         effect_checkout_mount({"__nixbot_effect_checkout": "1"}, None)
+
+
+def test_checkout_chdir_replaces_default() -> None:
+    # bwrap warns when --chdir is passed twice, so the checkout's
+    # working directory must replace the default /build one.
+    checkout_args, _ = effect_checkout_mount(
+        {"__nixbot_effect_checkout": "1"}, Path("/var/lib/clone")
+    )
+    cmd = _bubblewrap_command(
+        "/nix/store/x.drv",
+        "bwrap",
+        build_dir=Path("/work/build"),
+        etc_dir=Path("/work/etc"),
+        daemon_socket=Path("/work/socket"),
+        uid=1000,
+        gid=100,
+        extra_sandbox_paths=[],
+        bind_mounts=[],
+        checkout_args=checkout_args,
+    )
+    assert cmd.count("--chdir") == 1
+    assert cmd[cmd.index("--chdir") + 1] == "/build/checkout"
+
+
+def test_default_chdir_without_checkout() -> None:
+    cmd = _bubblewrap_command(
+        "/nix/store/x.drv",
+        "bwrap",
+        build_dir=Path("/work/build"),
+        etc_dir=Path("/work/etc"),
+        daemon_socket=Path("/work/socket"),
+        uid=1000,
+        gid=100,
+        extra_sandbox_paths=[],
+        bind_mounts=[],
+        checkout_args=[],
+    )
+    assert cmd.count("--chdir") == 1
+    assert cmd[cmd.index("--chdir") + 1] == "/build"


### PR DESCRIPTION
Effects using the pushable checkout trigger a bwrap warning: `Only the last --chdir option will take effect`. Emit the default `--chdir /build` only when the checkout does not override the working directory.