### PR TITLE
prefetch flake inputs outside the eval sandbox

### DIFF
--- a/docs/GITEA.md
+++ b/docs/GITEA.md
@@ -55,7 +55,12 @@ services.nixbot = {
     oauthId = "<oauth-client-id>";
     oauthSecretFile = "/path/to/oauth-secret";
 
-    # Optional: SSH authentication for private repositories
+    # Optional: SSH authentication for private repositories and
+    # private ssh:// flake inputs. Anyone who can open a pull request
+    # against a built repository can add any repo this key can read as
+    # a flake input and thus read its contents. Use a deploy key or
+    # machine user scoped to the repositories you intend to expose,
+    # not a forge-wide/admin key.
     sshPrivateKeyFile = "/path/to/ssh-key";
     sshKnownHostsFile = "/path/to/known-hosts";
 

--- a/docs/GITLAB.md
+++ b/docs/GITLAB.md
@@ -31,7 +31,11 @@ services.nixbot = {
     userAllowlist = [ "mygroup" ];
     # repoAllowlist = [ "mygroup/myrepo" ];
 
-    # Optional: SSH authentication for fetching
+    # Optional: SSH authentication for fetching and for private ssh://
+    # flake inputs. Anyone who can open a merge request against a built
+    # repository can add any repo this key can read as a flake input and
+    # thus read its contents. Use a deploy key or machine user scoped to
+    # the repositories you intend to expose, not an instance-wide key.
     # sshPrivateKeyFile = "/path/to/ssh-key";
     # sshKnownHostsFile = "/path/to/known-hosts";
   };

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -219,6 +219,38 @@ async def _settle_aborted(
     )
 
 
+async def _record_eval_success(
+    o: Orchestrator,
+    event: ChangeEvent,
+    build: BuildRecord,
+    jobs: Sequence[NixEvalJob],
+    live_warnings: LiveWarningAggregator,
+) -> None:
+    """Persist a completed evaluation and report it to the forge."""
+    # Idempotent backstop for the streaming inserts during eval;
+    # pending rows are what crash recovery resumes from. The
+    # scheduler drops unsupported systems. Their pending rows
+    # would never turn terminal, so don't record them.
+    buildable = [
+        job
+        for job in jobs
+        if isinstance(job, NixEvalJobSuccess) and job.system in o.config.build_systems
+    ]
+    await record_attributes(o.pool, build.id, buildable)
+    # The full eval result is recorded in build_attributes. A later
+    # build of the same tree may reuse it instead of re-evaluating.
+    await q.mark_eval_completed(o.pool, id_=build.id)
+    await o.reporter.eval_finished(
+        event,
+        build,
+        EvalReport(
+            success=True,
+            warnings=[str(g["message"]) for g in live_warnings.snapshot()],
+            jobs=buildable,
+        ),
+    )
+
+
 async def _reap(*tasks: asyncio.Future[Any]) -> None:
     """Cancel and await tasks, swallowing their errors."""
     for task in tasks:
@@ -316,29 +348,7 @@ async def _run_build_inner(
                     o.pool, id_=build.id, warnings=json.dumps(live_warnings.snapshot())
                 )
         await db.set_build_status(o.pool, build.id, BuildStatus.BUILDING)
-        # Idempotent backstop for the streaming inserts above;
-        # pending rows are what crash recovery resumes from. The
-        # scheduler drops unsupported systems. Their pending rows
-        # would never turn terminal, so don't record them.
-        buildable = [
-            job
-            for job in eval_result.jobs
-            if isinstance(job, NixEvalJobSuccess)
-            and job.system in o.config.build_systems
-        ]
-        await record_attributes(o.pool, build.id, buildable)
-        # The full eval result is recorded in build_attributes. A later
-        # build of the same tree may reuse it instead of re-evaluating.
-        await q.mark_eval_completed(o.pool, id_=build.id)
-        await o.reporter.eval_finished(
-            event,
-            build,
-            EvalReport(
-                success=True,
-                warnings=[str(g["message"]) for g in live_warnings.snapshot()],
-                jobs=buildable,
-            ),
-        )
+        await _record_eval_success(o, event, build, eval_result.jobs, live_warnings)
 
         # Re-send the complete eval result: the scheduler dedupes
         # by attr, so this only schedules jobs a streamed batch

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -27,6 +27,7 @@ from .db import BuildStatus
 from .db_gen import builds as q
 from .events import BuildResult, EvalReport
 from .executor import failure_excerpt
+from .flake_prefetch import PrefetchError, prefetch_flake_inputs
 from .live_warnings import LiveWarningAggregator
 from .memory import calculate_eval_workers
 from .models import CacheStatus, NixEvalJobSuccess
@@ -251,6 +252,32 @@ async def _record_eval_success(
     )
 
 
+async def _prefetch_inputs(
+    o: Orchestrator,
+    build: BuildRecord,
+    worktree_path: Path,
+    branch_config: BranchConfig,
+    credentials: FetchCredentials | None,
+) -> None:
+    """Fetch flake inputs into the store outside the eval sandbox, with
+    the same credentials as the git fetch, so private ssh:// inputs
+    work even though the sandboxed evaluator has no SSH key (#86)."""
+    try:
+        async with asyncio.timeout(o.config.eval_timeout):
+            await prefetch_flake_inputs(
+                worktree_path,
+                branch_config,
+                o.gcroots_dir(build),
+                credentials=credentials,
+            )
+    except TimeoutError:
+        msg = (
+            "prefetching flake inputs timed out after "
+            f"{o.config.eval_timeout:.0f} seconds"
+        )
+        raise PrefetchError(msg) from None
+
+
 async def _reap(*tasks: asyncio.Future[Any]) -> None:
     """Cancel and await tasks, swallowing their errors."""
     for task in tasks:
@@ -274,6 +301,7 @@ async def _run_build_inner(
         return
 
     branch_config = BranchConfig.load(worktree_path)
+    await _prefetch_inputs(o, build, worktree_path, branch_config, credentials)
     eval_settings = _eval_settings(o, event, build, credentials)
     # Race the evaluation against the cancel event: a superseded
     # build must not hold the eval slot to completion.

--- a/nixbot/nixbot/flake_prefetch.py
+++ b/nixbot/nixbot/flake_prefetch.py
@@ -1,0 +1,163 @@
+"""Prefetch flake inputs outside the eval sandbox.
+
+The sandboxed evaluator has no SSH keys, so it cannot fetch private
+`ssh://` flake inputs (issue #86). `nix flake archive` copies all
+locked inputs into the local store beforehand, with the same
+credentials as the git fetch. Locked inputs are addressed by narHash,
+so the evaluator then finds them in the store without network access.
+Each input path is gc-rooted under the per-build gc-roots directory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import shutil
+import signal
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .environ import passthrough_env
+from .gcroots import register_gcroot
+from .nix_eval import EvalError
+
+if TYPE_CHECKING:
+    from .gitrepo import FetchCredentials
+    from .repo_config import BranchConfig
+
+logger = logging.getLogger(__name__)
+
+STDERR_TAIL_LINES = 50
+
+
+class PrefetchError(EvalError):
+    """Prefetching flake inputs failed. Settled like an eval failure."""
+
+
+def build_prefetch_command(flake_dir: Path, branch_config: BranchConfig) -> list[str]:
+    return [
+        "nix",
+        # Flakes may not be enabled in the system nix.conf.
+        "--option",
+        "extra-experimental-features",
+        "nix-command flakes",
+        "--option",
+        "accept-flake-config",
+        "true",
+        "flake",
+        "archive",
+        "--json",
+        "--no-write-lock-file",
+        *(
+            ["--reference-lock-file", branch_config.lock_file]
+            if branch_config.lock_file != "flake.lock"
+            else []
+        ),
+        str(flake_dir),
+    ]
+
+
+def collect_input_paths(archive_json: dict[str, Any]) -> set[str]:
+    """Store paths of all transitive inputs from `nix flake archive
+    --json` output. The top-level flake itself needs no gc-root."""
+    paths: set[str] = set()
+
+    def walk(inputs: dict[str, Any]) -> None:
+        for node in inputs.values():
+            if node.get("path"):
+                paths.add(node["path"])
+            walk(node.get("inputs", {}))
+
+    walk(archive_json.get("inputs", {}))
+    return paths
+
+
+def _prefetch_env(credentials: FetchCredentials | None, home: Path) -> dict[str, str]:
+    """nix shells out to `git fetch` for git inputs, which honors
+    GIT_SSH_COMMAND and $HOME/.netrc. nix's own downloader reads the
+    netrc-file setting instead."""
+    env = {
+        **passthrough_env(),
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "GIT_TERMINAL_PROMPT": "0",
+        "HOME": str(home),
+    }
+    # Environment-based git config, e.g. protocol.file.allow in tests.
+    for key, value in os.environ.items():
+        if key.startswith("GIT_CONFIG_") and key not in env:
+            env[key] = value
+    if credentials is None:
+        return env
+    ssh_command = credentials.git_ssh_command()
+    if ssh_command is not None:
+        env["GIT_SSH_COMMAND"] = ssh_command
+    if credentials.netrc_file is not None:
+        (home / ".netrc").symlink_to(credentials.netrc_file)
+        env["NIX_CONFIG"] = f"netrc-file = {credentials.netrc_file}"
+    return env
+
+
+async def _run(cmd: list[str], env: dict[str, str], cwd: Path) -> bytes:
+    """Run one prefetch command. On cancellation the process group is
+    killed so git/ssh children don't linger."""
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=cwd,
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = await proc.communicate()
+    except BaseException:
+        with contextlib.suppress(ProcessLookupError, OSError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        await proc.wait()
+        raise
+    if proc.returncode != 0:
+        tail = "\n".join(
+            stderr.decode(errors="replace").splitlines()[-STDERR_TAIL_LINES:]
+        )
+        msg = f"{' '.join(cmd[:2])} failed with exit code {proc.returncode}:\n{tail}"
+        raise PrefetchError(msg)
+    return stdout
+
+
+async def _register_gcroots(paths: set[str], gc_roots_dir: Path) -> None:
+    for path in sorted(paths):
+        await register_gcroot(gc_roots_dir, "inputs", Path(path).name, path)
+
+
+async def prefetch_flake_inputs(
+    worktree_path: Path,
+    branch_config: BranchConfig,
+    gc_roots_dir: Path,
+    credentials: FetchCredentials | None = None,
+) -> None:
+    """Copy all locked flake inputs into the local store and gc-root
+    them. No-op without a flake. Callers bound the runtime with
+    asyncio.timeout()."""
+    flake_dir = worktree_path / branch_config.flake_dir
+    if not await asyncio.to_thread((flake_dir / "flake.nix").exists):
+        return
+    # Throwaway HOME for the scoped .netrc and the fetcher cache.
+    home = Path(await asyncio.to_thread(tempfile.mkdtemp, prefix="flake-prefetch-"))
+    try:
+        env = _prefetch_env(credentials, home)
+        logger.info("prefetching flake inputs", extra={"flake_dir": str(flake_dir)})
+        stdout = await _run(
+            build_prefetch_command(flake_dir, branch_config), env, worktree_path
+        )
+        try:
+            archive = json.loads(stdout)
+        except json.JSONDecodeError as e:
+            msg = f"failed to parse nix flake archive output: {e}"
+            raise PrefetchError(msg) from None
+        await _register_gcroots(collect_input_paths(archive), gc_roots_dir)
+    finally:
+        await asyncio.to_thread(shutil.rmtree, home, ignore_errors=True)

--- a/nixbot/nixbot/tests/test_flake_prefetch.py
+++ b/nixbot/nixbot/tests/test_flake_prefetch.py
@@ -1,0 +1,159 @@
+"""Tests for the flake input prefetch step (pure parts plus an
+optional integration test against a real nix)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nixbot.flake_prefetch import (
+    PrefetchError,
+    _prefetch_env,
+    build_prefetch_command,
+    collect_input_paths,
+    prefetch_flake_inputs,
+)
+from nixbot.gitrepo import FetchCredentials
+from nixbot.nix_eval import EvalRunner, EvalSettings
+from nixbot.repo_config import BranchConfig
+from nixbot.tests.support import init_upstream
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+needs_nix = pytest.mark.skipif(shutil.which("nix") is None, reason="nix not available")
+
+
+def test_prefetch_command(tmp_path: Path) -> None:
+    cmd = build_prefetch_command(tmp_path, BranchConfig())
+    assert cmd[0] == "nix"
+    assert "archive" in cmd
+    assert "--no-write-lock-file" in cmd
+    assert "--reference-lock-file" not in cmd
+    assert cmd[-1] == str(tmp_path)
+
+    cmd = build_prefetch_command(tmp_path, BranchConfig(lock_file="alt.lock"))
+    assert cmd[cmd.index("--reference-lock-file") + 1] == "alt.lock"
+
+
+def test_collect_input_paths_recursive() -> None:
+    archive = {
+        "path": "/nix/store/aaa-source",
+        "inputs": {
+            "a": {
+                "path": "/nix/store/bbb-source",
+                "inputs": {"nested": {"path": "/nix/store/ccc-source", "inputs": {}}},
+            },
+            # follows-style entries without a path are skipped.
+            "b": {"inputs": {}},
+        },
+    }
+    assert collect_input_paths(archive) == {
+        "/nix/store/bbb-source",
+        "/nix/store/ccc-source",
+    }
+
+
+def test_prefetch_env_uses_credentials(tmp_path: Path) -> None:
+    netrc = tmp_path / "netrc"
+    netrc.write_text("machine x login y password z\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    creds = FetchCredentials(netrc_file=netrc, ssh_private_key_file=tmp_path / "key")
+    env = _prefetch_env(creds, home)
+    assert str(tmp_path / "key") in env["GIT_SSH_COMMAND"]
+    assert (home / ".netrc").readlink() == netrc
+    assert env["NIX_CONFIG"] == f"netrc-file = {netrc}"
+    assert env["HOME"] == str(home)
+
+
+async def test_prefetch_skips_repo_without_flake(tmp_path: Path) -> None:
+    await prefetch_flake_inputs(tmp_path, BranchConfig(), tmp_path / "gcroots")
+    assert not (tmp_path / "gcroots").exists()
+
+
+def _nix_flake_lock(repo: Path) -> None:
+    subprocess.run(
+        [
+            "nix",
+            "--option",
+            "extra-experimental-features",
+            "nix-command flakes",
+            "flake",
+            "lock",
+        ],
+        cwd=repo,
+        check=True,
+        env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null"},
+    )
+
+
+@needs_nix
+async def test_prefetch_integration(tmp_path: Path) -> None:
+    """A locked git input is copied to the store and gc-rooted; after
+    the input's source repo is gone, evaluation still succeeds purely
+    from the store (the sandboxed eval has no credentials for private
+    inputs)."""
+    dep = init_upstream(
+        tmp_path / "dep",
+        {"flake.nix": '{ outputs = { self }: { greeting = "hello"; }; }'},
+    )
+    repo = init_upstream(
+        tmp_path / "repo",
+        {
+            "flake.nix": f"""
+            {{
+              inputs.dep.url = "git+file://{dep}";
+              outputs = {{ self, dep }}: {{
+                checks.x86_64-linux.ok = derivation {{
+                  name = "ok-" + dep.greeting;
+                  system = "x86_64-linux";
+                  builder = "/bin/sh";
+                  args = [ "-c" "echo ok > $out" ];
+                }};
+              }};
+            }}
+            """
+        },
+    )
+    _nix_flake_lock(repo)
+
+    gcroots = tmp_path / "gcroots"
+    await prefetch_flake_inputs(repo, BranchConfig(), gcroots)
+
+    roots = list((gcroots / "inputs").iterdir())
+    assert len(roots) == 1
+    assert roots[0].is_symlink()
+    assert roots[0].resolve().is_dir()
+
+    # The eval must not need the input's origin anymore.
+    shutil.rmtree(dep)
+
+    if shutil.which("nix-eval-jobs") is None:
+        pytest.skip("nix-eval-jobs not available")
+    settings = EvalSettings(
+        gc_roots_dir=tmp_path / "eval-gcroots", sandbox=False, systemd_scope=False
+    )
+    result = await EvalRunner().run(repo, BranchConfig(), settings)
+    assert [j.attr for j in result.jobs] == ["default.checks.x86_64-linux.ok"]
+
+
+@needs_nix
+async def test_prefetch_failure_raises(tmp_path: Path) -> None:
+    repo = init_upstream(
+        tmp_path / "repo",
+        {
+            "flake.nix": """
+            {
+              inputs.missing.url = "git+file:///does/not/exist";
+              outputs = { self, missing }: { };
+            }
+            """
+        },
+    )
+    with pytest.raises(PrefetchError):
+        await prefetch_flake_inputs(repo, BranchConfig(), tmp_path / "gcroots")

--- a/packages/nixbot.nix
+++ b/packages/nixbot.nix
@@ -3,6 +3,7 @@
   git,
   hatchling,
   nix,
+  nix-eval-jobs,
   pydantic,
   pytestCheckHook,
   pytest-asyncio,
@@ -61,6 +62,10 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     git
+    # For the eval/prefetch integration tests: nix works daemon-less
+    # against a scratch store set up in preCheck.
+    nix
+    nix-eval-jobs
     pytestCheckHook
     pytest-asyncio
     pytest-timeout
@@ -78,6 +83,11 @@ buildPythonPackage (finalAttrs: {
   # Chromium refuses to start with the unwritable default HOME.
   preCheck = ''
     export HOME=$(mktemp -d)
+    # Daemon-less scratch nix store for the eval/prefetch integration
+    # tests; the real /nix/store is read-only inside the build sandbox.
+    export NIX_STORE_DIR=$TMPDIR/nix/store
+    export NIX_STATE_DIR=$TMPDIR/nix/var
+    export NIX_CONF_DIR=$TMPDIR/nix/etc
     # On huge builders more workers only add scheduling overhead and postgres connection pressure.
     export PYTEST_XDIST_AUTO_NUM_WORKERS=$(( NIX_BUILD_CORES > 64 ? 64 : NIX_BUILD_CORES ))
   '';


### PR DESCRIPTION

The evaluator runs in a bwrap sandbox without SSH keys, so private
ssh:// flake inputs cannot be fetched during evaluation (#86). Copy
locked inputs into the store beforehand with 'nix flake archive',
using the same credentials as the git fetch, and gc-root them per
build. Locked inputs are addressed by narHash, so the sandboxed eval
then finds them in the store without network or credentials.

Flake inputs are PR-controlled, so document that the SSH key must be
scoped to the intended repositories, not forge-wide.

Fixes #86
