### PR TITLE
flake_prefetch: don't re-fetch the worktree, keep persistent fetcher cache

### DIFF
--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -269,6 +269,7 @@ async def _prefetch_inputs(
                 branch_config,
                 o.gcroots_dir(build),
                 credentials=credentials,
+                cache_dir=o.config.state_dir / "cache" / "nix",
             )
     except TimeoutError:
         msg = (

--- a/nixbot/nixbot/flake_prefetch.py
+++ b/nixbot/nixbot/flake_prefetch.py
@@ -1,11 +1,17 @@
 """Prefetch flake inputs outside the eval sandbox.
 
 The sandboxed evaluator has no SSH keys, so it cannot fetch private
-`ssh://` flake inputs (issue #86). `nix flake archive` copies all
-locked inputs into the local store beforehand, with the same
+`ssh://` flake inputs (issue #86). `nix flake prefetch-inputs` copies
+all locked inputs into the local store beforehand, with the same
 credentials as the git fetch. Locked inputs are addressed by narHash,
 so the evaluator then finds them in the store without network access.
-Each input path is gc-rooted under the per-build gc-roots directory.
+`nix flake archive --dry-run --json` then reports the input store
+paths (computed from the locked narHashes, no fetching) so each one
+can be gc-rooted under the per-build gc-roots directory.
+
+The worktree itself is never re-fetched as a git input: Nix's workdir
+and rev-based exports of a repo with submodules produce different
+narHashes, which fails the `__final` lock check.
 """
 
 from __future__ import annotations
@@ -38,7 +44,9 @@ class PrefetchError(EvalError):
     """Prefetching flake inputs failed. Settled like an eval failure."""
 
 
-def build_prefetch_command(flake_dir: Path, branch_config: BranchConfig) -> list[str]:
+def _nix_flake_command(
+    subcommand: list[str], flake_dir: Path, branch_config: BranchConfig
+) -> list[str]:
     return [
         "nix",
         # Flakes may not be enabled in the system nix.conf.
@@ -49,8 +57,7 @@ def build_prefetch_command(flake_dir: Path, branch_config: BranchConfig) -> list
         "accept-flake-config",
         "true",
         "flake",
-        "archive",
-        "--json",
+        *subcommand,
         "--no-write-lock-file",
         *(
             ["--reference-lock-file", branch_config.lock_file]
@@ -59,6 +66,18 @@ def build_prefetch_command(flake_dir: Path, branch_config: BranchConfig) -> list
         ),
         str(flake_dir),
     ]
+
+
+def build_prefetch_command(flake_dir: Path, branch_config: BranchConfig) -> list[str]:
+    return _nix_flake_command(["prefetch-inputs"], flake_dir, branch_config)
+
+
+def build_input_paths_command(
+    flake_dir: Path, branch_config: BranchConfig
+) -> list[str]:
+    return _nix_flake_command(
+        ["archive", "--dry-run", "--json"], flake_dir, branch_config
+    )
 
 
 def collect_input_paths(archive_json: dict[str, Any]) -> set[str]:
@@ -150,8 +169,9 @@ async def prefetch_flake_inputs(
     try:
         env = _prefetch_env(credentials, home)
         logger.info("prefetching flake inputs", extra={"flake_dir": str(flake_dir)})
+        await _run(build_prefetch_command(flake_dir, branch_config), env, worktree_path)
         stdout = await _run(
-            build_prefetch_command(flake_dir, branch_config), env, worktree_path
+            build_input_paths_command(flake_dir, branch_config), env, worktree_path
         )
         try:
             archive = json.loads(stdout)

--- a/nixbot/nixbot/flake_prefetch.py
+++ b/nixbot/nixbot/flake_prefetch.py
@@ -95,7 +95,9 @@ def collect_input_paths(archive_json: dict[str, Any]) -> set[str]:
     return paths
 
 
-def _prefetch_env(credentials: FetchCredentials | None, home: Path) -> dict[str, str]:
+def _prefetch_env(
+    credentials: FetchCredentials | None, home: Path, cache_dir: Path | None = None
+) -> dict[str, str]:
     """nix shells out to `git fetch` for git inputs, which honors
     GIT_SSH_COMMAND and $HOME/.netrc. nix's own downloader reads the
     netrc-file setting instead."""
@@ -105,6 +107,10 @@ def _prefetch_env(credentials: FetchCredentials | None, home: Path) -> dict[str,
         "GIT_TERMINAL_PROMPT": "0",
         "HOME": str(home),
     }
+    if cache_dir is not None:
+        # Persistent fetcher/git cache across builds; HOME stays throwaway
+        # because it holds the per-build .netrc.
+        env["NIX_CACHE_HOME"] = str(cache_dir)
     # Environment-based git config, e.g. protocol.file.allow in tests.
     for key, value in os.environ.items():
         if key.startswith("GIT_CONFIG_") and key not in env:
@@ -157,6 +163,7 @@ async def prefetch_flake_inputs(
     branch_config: BranchConfig,
     gc_roots_dir: Path,
     credentials: FetchCredentials | None = None,
+    cache_dir: Path | None = None,
 ) -> None:
     """Copy all locked flake inputs into the local store and gc-root
     them. No-op without a flake. Callers bound the runtime with
@@ -164,10 +171,12 @@ async def prefetch_flake_inputs(
     flake_dir = worktree_path / branch_config.flake_dir
     if not await asyncio.to_thread((flake_dir / "flake.nix").exists):
         return
-    # Throwaway HOME for the scoped .netrc and the fetcher cache.
+    # Throwaway HOME for the per-build .netrc.
     home = Path(await asyncio.to_thread(tempfile.mkdtemp, prefix="flake-prefetch-"))
     try:
-        env = _prefetch_env(credentials, home)
+        if cache_dir is not None:
+            await asyncio.to_thread(cache_dir.mkdir, parents=True, exist_ok=True)
+        env = _prefetch_env(credentials, home, cache_dir)
         logger.info("prefetching flake inputs", extra={"flake_dir": str(flake_dir)})
         await _run(build_prefetch_command(flake_dir, branch_config), env, worktree_path)
         stdout = await _run(

--- a/nixbot/nixbot/tests/test_flake_prefetch.py
+++ b/nixbot/nixbot/tests/test_flake_prefetch.py
@@ -69,6 +69,12 @@ def test_prefetch_env_uses_credentials(tmp_path: Path) -> None:
     assert (home / ".netrc").readlink() == netrc
     assert env["NIX_CONFIG"] == f"netrc-file = {netrc}"
     assert env["HOME"] == str(home)
+    assert "NIX_CACHE_HOME" not in env
+
+    home2 = tmp_path / "home2"
+    home2.mkdir()
+    env = _prefetch_env(creds, home2, cache_dir=tmp_path / "cache")
+    assert env["NIX_CACHE_HOME"] == str(tmp_path / "cache")
 
 
 async def test_prefetch_skips_repo_without_flake(tmp_path: Path) -> None:

--- a/nixbot/nixbot/tests/test_flake_prefetch.py
+++ b/nixbot/nixbot/tests/test_flake_prefetch.py
@@ -31,7 +31,7 @@ needs_nix = pytest.mark.skipif(shutil.which("nix") is None, reason="nix not avai
 def test_prefetch_command(tmp_path: Path) -> None:
     cmd = build_prefetch_command(tmp_path, BranchConfig())
     assert cmd[0] == "nix"
-    assert "archive" in cmd
+    assert "prefetch-inputs" in cmd
     assert "--no-write-lock-file" in cmd
     assert "--reference-lock-file" not in cmd
     assert cmd[-1] == str(tmp_path)


### PR DESCRIPTION
Fixes prefetch failures like:

```
error: mismatch in field 'narHash' of input 'git+file:///var/lib/nixbot/worktrees/...'
```

`nix flake archive` re-fetches the top-level flake by its locked rev. For repos with submodules, Nix's workdir export and rev-based export produce different narHashes, so the `__final` lock check fails and the build errors out.

- Fetch only the inputs with `nix flake prefetch-inputs`; get the store paths for gc-rooting from `nix flake archive --dry-run --json` (no fetching), so the worktree is never re-fetched.
- Keep a persistent `NIX_CACHE_HOME` under the state dir so inputs are not re-downloaded on every build (HOME stays throwaway for the per-build .netrc).