### PR TITLE
nixbot: authenticate git fetches through netrc helper

### DIFF
--- a/nixbot/nixbot/git_credential_netrc.py
+++ b/nixbot/nixbot/git_credential_netrc.py
@@ -1,0 +1,49 @@
+"""Git credential helper backed by a single netrc file."""
+
+from __future__ import annotations
+
+import netrc
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+EXPECTED_ARGC = 3
+
+
+def _credential_input() -> dict[str, str]:
+    return {
+        key: value
+        for line in sys.stdin
+        if "=" in line
+        for key, value in (line.rstrip("\n").split("=", 1),)
+    }
+
+
+def main() -> None:
+    if len(sys.argv) != EXPECTED_ARGC or sys.argv[2] != "get":
+        return
+
+    request = _credential_input()
+    raw_host = request.get("host")
+    if raw_host is None:
+        return
+    host = urlsplit(f"//{raw_host}").hostname
+    if host is None:
+        return
+
+    auth = netrc.netrc(Path(sys.argv[1])).authenticators(host)
+    if auth is None:
+        return
+    login, account, password = auth
+    username = login or account
+    if username is None or password is None:
+        return
+    if any(char in username or char in password for char in "\r\n"):
+        return
+
+    print(f"username={username}")
+    print(f"password={password}")
+
+
+if __name__ == "__main__":
+    main()

--- a/nixbot/nixbot/gitrepo.py
+++ b/nixbot/nixbot/gitrepo.py
@@ -22,7 +22,9 @@ import asyncio
 import contextlib
 import logging
 import os
+import shlex
 import shutil
+import sys
 import tempfile
 import time
 from dataclasses import dataclass
@@ -142,16 +144,28 @@ async def run_git(
         if ssh_command is not None:
             env["GIT_SSH_COMMAND"] = ssh_command
     if credentials is not None and credentials.netrc_file is not None:
-        # git's libcurl reads $HOME/.netrc (CURL_NETRC_OPTIONAL). Point
-        # HOME at a throwaway directory containing only the scoped netrc.
+        # Git does not enable libcurl's netrc support. Install a helper for
+        # this invocation that answers Git's credential protocol from the
+        # scoped netrc. Keep HOME isolated as defense in depth.
         home = Path(tempfile.mkdtemp(prefix="git-netrc-"))
         (home / ".netrc").symlink_to(credentials.netrc_file)
         env["HOME"] = str(home)
+        helper = Path(__file__).with_name("git_credential_netrc.py")
+        helper_command = " ".join(
+            (
+                f"!{shlex.quote(sys.executable)}",
+                shlex.quote(str(helper)),
+                shlex.quote(str(credentials.netrc_file)),
+            )
+        )
+        git_options = ["-c", f"credential.helper={helper_command}"]
     else:
         home = None
+        git_options = []
     try:
         proc = await asyncio.create_subprocess_exec(
             "git",
+            *git_options,
             *args,
             cwd=cwd,
             env=env,

--- a/nixbot/nixbot/tests/test_gitrepo.py
+++ b/nixbot/nixbot/tests/test_gitrepo.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import base64
+import functools
+import http.server
 import os
 import shutil
 import subprocess
+import threading
 import time
 from typing import TYPE_CHECKING
 
@@ -423,6 +427,48 @@ async def test_static_credentials_provider(tmp_path: Path) -> None:
     creds = await provider.get("https://example.com/r.git")
     assert creds.netrc_file == netrc
     assert (await StaticCredentialsProvider().get("https://x/y.git")).netrc_file is None
+
+
+async def test_run_git_uses_netrc_credentials(tmp_path: Path, upstream: Path) -> None:
+    """Git itself does not read $HOME/.netrc; run_git must bridge the
+    scoped netrc through Git's credential-helper protocol."""
+    git(upstream, "update-server-info")
+    username = "oauth2"
+    password = "repo-scoped-token"
+    authorization = (
+        "Basic " + base64.b64encode(f"{username}:{password}".encode()).decode()
+    )
+
+    class AuthenticatedGitHandler(http.server.SimpleHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.headers.get("Authorization") != authorization:
+                self.send_response(http.HTTPStatus.UNAUTHORIZED)
+                self.send_header("WWW-Authenticate", 'Basic realm="git"')
+                self.end_headers()
+                return
+            super().do_GET()
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            pass
+
+    handler = functools.partial(AuthenticatedGitHandler, directory=str(tmp_path))
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        netrc = tmp_path / "netrc"
+        netrc.write_text(f"machine 127.0.0.1 login {username} password {password}\n")
+        netrc.chmod(0o600)
+        port = server.server_address[1]
+        output = await run_git(
+            ["ls-remote", f"http://127.0.0.1:{port}/upstream/.git"],
+            credentials=FetchCredentials(netrc_file=netrc),
+        )
+        assert "HEAD" in output
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
 
 
 async def test_run_git_error_includes_stderr(tmp_path: Path) -> None:


### PR DESCRIPTION
Git does not enable libcurl netrc authentication merely because `$HOME/.netrc` exists. As a result, GitHub App installation tokens were written correctly but private repository clones still failed with `could not read Username`.

Install an invocation-scoped Git credential helper that reads the existing scoped netrc. The credential remains out of command-line arguments and persistent Git config.

Includes an integration test with an authenticated dumb-HTTP Git repository.

Validation:
- `pytest -q nixbot/nixbot/tests/test_gitrepo.py -n 0` (22 passed)
- `ruff check` on changed files
- `mypy` on changed source files