### PR TITLE
Support per-repo build_branches in nixbot.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,22 +135,14 @@ See the [OIDC documentation](./docs/OIDC.md) for configuration details.
 
 Currently `nixbot` will look for a file named `nixbot.toml` (falling back to the
 legacy `buildbot-nix.toml`) in the root of whichever branch it's currently
-evaluating, parse it as TOML and apply the configuration specified. The
-following table illustrates the supported options.
+evaluating, parse it as TOML and apply the configuration specified. See
+[examples/nixbot.toml](./examples/nixbot.toml) for a commented example with all
+supported options.
 
-|                          | key                        | type        | description                                                                                                                                                      | default      | example                                                                                                                                                                                                 |
-| :----------------------- | :------------------------- | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| lock file                | `lock_file`                | `str`       | dictates which lock file `nixbot` will use when evaluating your flake                                                                                            | `flake.lock` | have multiple lockfiles, one for `nixpkgs-stable`, one for `nixpkgs-unstable` or by default pin an input to a private repo, but have a lockfile with that private repo replaced by a public repo for CI |
-| attribute                | `attribute`                | `str`       | which attribute in the flake to evaluate and build                                                                                                               | `checks`     | using a different attribute, like `hydraJobs`                                                                                                                                                           |
-| flake_dir                | `flake_dir`                | `str`       | which directory the flake is located                                                                                                                             | `.`          | using a different flake, like `./tests`                                                                                                                                                                 |
-| effects on pull requests | `effects_on_pull_requests` | `bool`      | run hercules-ci effects on pull requests                                                                                                                         | `false`      | set to `true` to run effects on PRs                                                                                                                                                                     |
-| effects branches         | `effects_branches`         | `list[str]` | glob patterns for additional branches that run effects                                                                                                           | `[]`         | `["staging", "release/*"]`                                                                                                                                                                              |
-| legacy eval (deprecated) | `legacy_eval`              | `bool`      | evaluate `flake_dir#attribute` directly like buildbot-nix did: no `herculesCI`/`onPush` jobs, no build modifiers, attribute names keep their old unprefixed form | `false`      | ease migration of existing repos that rely on the old attribute names; will be removed in a future release                                                                                              |
-
-By default, effects only run on the default branch. The `effects_branches` and
-`effects_on_pull_requests` settings are always read from the **default
-branch's** `nixbot.toml` (via `git show`) so that pull request authors cannot
-grant themselves effects access.
+By default, effects only run on the default branch. The `build_branches`,
+`effects_branches` and `effects_on_pull_requests` settings are always read from
+the **default branch's** `nixbot.toml` (via `git show`) so that pull request
+authors cannot grant themselves builds or effects access.
 
 > **⚠️ Security warning:** PR effects receive the same
 > `effects_per_repo_secrets` as default-branch effects. A malicious PR can

--- a/examples/nixbot.toml
+++ b/examples/nixbot.toml
@@ -1,0 +1,36 @@
+# Per-repository configuration, placed as `nixbot.toml` in the root of the
+# repository (the legacy name `buildbot-nix.toml` also works).
+#
+# All values are optional. `build_branches`, `effects_branches` and
+# `effects_on_pull_requests` are always read from the default branch's
+# nixbot.toml, so pull request authors cannot grant themselves builds or
+# effects.
+
+# Flake attribute to evaluate and build.
+#attribute = "checks"
+
+# Directory the flake is located in.
+#flake_dir = "."
+
+# Lock file to use during evaluation. Useful for a CI lockfile that replaces a
+# private input with a public one, or separate stable/unstable lockfiles.
+#lock_file = "flake.lock"
+
+# Glob patterns for branches to build on push. Replaces the globally
+# configured branch globs of the nixbot instance. The default branch and
+# merge-queue branches always build.
+#build_branches = ["release-*", "nixos-25.05"]
+
+# Glob patterns for additional branches that run hercules-ci effects.
+#effects_branches = ["staging", "release/*"]
+
+# Run hercules-ci effects on pull requests.
+# WARNING: PR effects receive the same effects_per_repo_secrets as
+# default-branch effects. Only enable this when you trust all contributors or
+# no secrets are configured.
+#effects_on_pull_requests = false
+
+# Deprecated: evaluate `flake_dir#attribute` directly like buildbot-nix did
+# (no herculesCI/onPush jobs, no build modifiers, unprefixed attribute names).
+# Eases migration of existing repos and will be removed in a future release.
+#legacy_eval = false

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -30,7 +30,6 @@ from .effects import (
 )
 from .events import effects_event_for_build
 from .executor import failure_excerpt
-from .repo_config import CONFIG_FILENAMES, BranchConfig
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -55,19 +54,9 @@ async def maybe_run_effects(
     # Gating config comes from the default branch of the central
     # clone: the worktree is PR-controlled, so its nixbot.toml
     # could grant the PR effects (and deploy secrets).
-    # refs/heads/ prefix: a bare branch name would resolve a tag
-    # of the same name first (tags auto-follow into the clone).
-    config_text = None
-    for filename in CONFIG_FILENAMES:
-        config_text = await o.repos.show_file(
-            repo.key,
-            f"refs/heads/{repo.default_branch}",
-            filename,
-            credentials=credentials,
-        )
-        if config_text is not None:
-            break
-    default_branch_config = BranchConfig.loads(config_text)
+    default_branch_config = await o.default_branch_repo_config(
+        repo, credentials=credentials
+    )
     if not should_run_effects(
         default_branch_config,
         repo.default_branch,

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -51,6 +51,8 @@ from .executor import (
     log_path_for_key,
 )
 from .gitrepo import MergeConflictError, pr_refspec
+from .repo_config import CONFIG_FILENAMES
+from .repo_config import BranchConfig as RepoBranchConfig
 from .web.logs import LogRegistry
 from .work_queue import WorkQueue
 
@@ -160,6 +162,32 @@ class Orchestrator:
 
     def gcroots_dir(self, build: BuildRecord) -> Path:
         return self.config.state_dir / "eval-gcroots" / str(build.id)
+
+    async def default_branch_repo_config(
+        self,
+        repo: RepoInfo,
+        credentials: FetchCredentials | None = None,
+        *,
+        fetch: bool = False,
+    ) -> RepoBranchConfig:
+        """Read `nixbot.toml` from the repo's default branch in the
+        central clone. The default branch is the trust anchor: PRs must
+        not grant themselves effects or extra branch builds.
+        `refs/heads/` prefix: a bare branch name would resolve a
+        same-named tag first."""
+        ref = f"refs/heads/{repo.default_branch}"
+        if fetch:
+            await self.repos.fetch(
+                repo.key, repo.clone_url, [f"+{ref}:{ref}"], credentials
+            )
+        config_text = None
+        for filename in CONFIG_FILENAMES:
+            config_text = await self.repos.show_file(
+                repo.key, ref, filename, credentials=credentials
+            )
+            if config_text is not None:
+                break
+        return RepoBranchConfig.loads(config_text)
 
     async def handle_change_event(
         self, event: ChangeEvent, credentials: FetchCredentials | None = None

--- a/nixbot/nixbot/repo_config.py
+++ b/nixbot/nixbot/repo_config.py
@@ -35,6 +35,10 @@ class BranchConfig(BaseModel):
     attribute: str = "checks"
     effects_on_pull_requests: bool = False
     effects_branches: list[str] = []
+    # Branch globs whose pushes build, replacing the globally
+    # configured branch globs. Default branch and merge-queue
+    # branches always build. None means the global config applies.
+    build_branches: list[str] | None = None
     # Deprecated: evaluate `flake_dir#attribute` directly like
     # buildbot-nix did (no herculesCI traversal, no job prefix).
     legacy_eval: bool = False

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -13,6 +13,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Any
 
 from . import db, discovery, restart_dispatch, schedule_runner
@@ -48,6 +49,7 @@ from .webhooks import (
     CheckRerequested,
     PrClosed,
     WebhookEvent,
+    is_merge_queue_branch,
     should_build_branch,
 )
 from .work_queue import WorkItem, WorkQueue
@@ -301,12 +303,27 @@ class CIService:
         project = await self.repo_store.by_forge_id(change.forge, change.forge_repo_id)
         if project is None or not project.enabled:
             return
-        if change.pr_number is None and not should_build_branch(
-            self.config.branches, project.default_branch, change.branch
-        ):
-            return
         info = repo_info(project)
         credentials = await self.credentials_provider(info.forge).get(info.clone_url)
+        if change.pr_number is None and not (
+            change.branch == project.default_branch
+            or is_merge_queue_branch(change.branch)
+        ):
+            # `build_branches` in the default branch's nixbot.toml
+            # decides which extra branches build. Without it the
+            # globally configured branch globs apply.
+            repo_config = await self.orchestrator.default_branch_repo_config(
+                info, credentials, fetch=True
+            )
+            if repo_config.build_branches is None:
+                if not should_build_branch(
+                    self.config.branches, project.default_branch, change.branch
+                ):
+                    return
+            elif not any(
+                fnmatch(change.branch, glob) for glob in repo_config.build_branches
+            ):
+                return
         event = ChangeEvent(
             repo=info,
             branch=change.branch,

--- a/nixbot/nixbot/tests/test_repo_config.py
+++ b/nixbot/nixbot/tests/test_repo_config.py
@@ -54,6 +54,15 @@ def test_branch_config_from_toml(tmp_path: Path) -> None:
     assert config.effects_on_pull_requests
 
 
+def test_build_branches_default_is_none(tmp_path: Path) -> None:
+    assert BranchConfig.load(tmp_path).build_branches is None
+
+
+def test_build_branches_from_toml(tmp_path: Path) -> None:
+    (tmp_path / "nixbot.toml").write_text('build_branches = ["release-*"]\n')
+    assert BranchConfig.load(tmp_path).build_branches == ["release-*"]
+
+
 def test_branch_config_rejects_traversal(tmp_path: Path) -> None:
     (tmp_path / "nixbot.toml").write_text('flake_dir = "../../etc"\n')
     # Falls back to defaults on invalid config.

--- a/nixbot/nixbot/tests/test_service.py
+++ b/nixbot/nixbot/tests/test_service.py
@@ -221,6 +221,41 @@ async def test_pr_close_discards_queued_changes(service: CIService) -> None:
     assert status == "done"
 
 
+async def test_build_branches_gates_branch_pushes(
+    service: CIService, git_repo: tuple[Path, str]
+) -> None:
+    """`build_branches` in the default branch's nixbot.toml decides
+    which non-default branches build."""
+    repo, sha = git_repo
+    (repo / "nixbot.toml").write_text('build_branches = ["release-*"]\n')
+    git(repo, "add", "nixbot.toml")
+    git(repo, "commit", "-m", "opt release branches into CI")
+
+    pool = service.pool
+    project_id = await seed_project(pool, f"file://{repo}")
+    forge_repo_id = await pool.fetchval(
+        "SELECT forge_repo_id FROM projects WHERE id = $1", project_id
+    )
+    handled: list[Any] = []
+
+    async def fake_handle(event: Any, credentials: Any = None) -> None:
+        handled.append(event.branch)
+
+    service.orchestrator.handle_change_event = fake_handle  # type: ignore[method-assign]
+
+    for branch in ("release-1.0", "random-feature"):
+        await service.submit(
+            ChangeRequest(
+                forge="github",
+                forge_repo_id=forge_repo_id,
+                branch=branch,
+                commit_sha=sha,
+            )
+        )
+    await service.drain_work()
+    assert handled == ["release-1.0"]
+
+
 async def test_restart_gitlab_mr_build_fetches_mr_refs(
     service: CIService, git_repo: tuple[Path, str]
 ) -> None:


### PR DESCRIPTION
Shared instances like nix-community host repos with different stable branch naming schemes, so a global branch glob in the service config does not scale. Let each repository opt its branches into push builds via build_branches in the default branch's nixbot.toml, which replaces the global globs when set.

Fixes #99