### PR TITLE
nixbot: add reverse-proxy authentication via trusted header

### DIFF
--- a/examples/default.nix
+++ b/examples/default.nix
@@ -39,6 +39,17 @@ in
     ];
   };
 
+  # The base example plus header auth from a reverse proxy.
+  "example-nixbot-proxy-auth-${system}" = nixosSystem {
+    inherit system;
+    modules = [
+      dummy
+      nixbot.nixosModules.nixbot
+      ./nixbot.nix
+      ./proxy-auth.nix
+    ];
+  };
+
   # The base example plus OIDC login backed by Authelia.
   "example-nixbot-oidc-authelia-${system}" = nixosSystem {
     inherit system;

--- a/examples/nixbot.nix
+++ b/examples/nixbot.nix
@@ -57,6 +57,11 @@
     # behind a VPN where network access implies trust.
     # allowUnauthenticatedControl = true;
 
+    # Trust a username header set by an authenticating reverse proxy.
+    # The proxy MUST set or strip this header on every request. Users
+    # appear as "proxy:<name>", e.g. admins = [ "proxy:alice" ];
+    # proxyAuthHeader = "X-Remote-User";
+
     # Local PostgreSQL over the unix socket is provisioned by default.
     # Remote database instead:
     # database.createLocally = false;

--- a/examples/proxy-auth.nix
+++ b/examples/proxy-auth.nix
@@ -1,0 +1,19 @@
+{ ... }:
+{
+  # Header-based auth: an authenticating reverse proxy in front of the
+  # nixbot vhost sets the username header; nixbot trusts it as the user
+  # identity ("proxy:<username>"). The proxy MUST set or strip the
+  # header on every request, otherwise clients can impersonate any user.
+  services.nixbot = {
+    proxyAuthHeader = "X-Remote-User";
+    admins = [ "proxy:alice" ];
+  };
+
+  # Example: nginx in front terminates auth (e.g. via auth_request or
+  # basic auth) and forwards the verified username to nixbot's vhost.
+  services.nginx.virtualHosts."nixbot.thalheim.io".locations."/".extraConfig = ''
+    auth_basic "nixbot";
+    auth_basic_user_file /var/lib/secrets/nixbot-htpasswd; # FIXME: use a secret manager
+    proxy_set_header X-Remote-User $remote_user;
+  '';
+}

--- a/nixbot/nixbot/bootstrap.py
+++ b/nixbot/nixbot/bootstrap.py
@@ -325,6 +325,7 @@ async def build_service(config: Config) -> tuple[CIService, FastAPI]:
     ctx.webhook_base_url = config.webhook_base_url or config.url
     ctx.token_store = ApiTokenStore(pool)
     ctx.forge_tokens = ForgeTokenStore(pool)
+    ctx.proxy_auth_header = config.proxy_auth_header
     ctx.visibility = VisibilityService(
         pool,
         authz,

--- a/nixbot/nixbot/config.py
+++ b/nixbot/nixbot/config.py
@@ -350,6 +350,8 @@ class Config(BaseModel):
     show_trace_on_failure: bool = False
     cache_failed_builds: bool = False
     allow_unauthenticated_control: bool = False
+    # Reverse-proxy auth header for the authenticated username (e.g. X-Remote-User).
+    proxy_auth_header: str | None = None
     build_max_silent_time: int = 60 * 20  # stop stuck builds after 20 minutes
     build_timeout: int = 60 * 60 * 3  # 3 hours default for nix build
     # Wall-clock limit for one nix-eval-jobs run. A hung evaluation

--- a/nixbot/nixbot/tests/test_auth.py
+++ b/nixbot/nixbot/tests/test_auth.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 import base64
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
 from nixbot.auth import (
     AuthzConfig,
@@ -30,6 +32,7 @@ from nixbot.auth import (
     rotate_signing_key,
 )
 from nixbot.forge_tokens import ForgeTokenRefresher, RefreshCredentials
+from nixbot.web.app import WebContext
 from nixbot.web.auth_routes import (
     SESSION_COOKIE,
     STATE_COOKIE,
@@ -759,3 +762,49 @@ async def test_oauth_callback_filters_session_groups() -> None:
         user = signer.user_from(session)
         assert user is not None
         assert user.groups == ("ci",)
+
+
+async def test_proxy_auth_header() -> None:
+    """The proxy auth header authenticates users through _request_user."""
+    app = FastAPI()
+    ctx = WebContext(pool=AsyncMock())
+    ctx.proxy_auth_header = "X-Remote-User"
+    app.state.web_context = ctx
+
+    @app.get("/me")
+    async def whoami(request: Request) -> JSONResponse:
+        user = await ctx.request_user(request)
+        if user is None:
+            return JSONResponse({"user": None})
+        return JSONResponse({"user": user.qualified})
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        # Without the header, no user is authenticated.
+        resp = await client.get("/me")
+        assert resp.status_code == 200
+        assert resp.json()["user"] is None
+
+        # With the header, the user is authenticated as proxy:alice.
+        resp = await client.get("/me", headers={"X-Remote-User": "alice"})
+        assert resp.status_code == 200
+        assert resp.json()["user"] == "proxy:alice"
+
+        # An empty header value should not authenticate.
+        resp = await client.get("/me", headers={"X-Remote-User": ""})
+        assert resp.status_code == 200
+        assert resp.json()["user"] is None
+
+        # A different header name does not authenticate when the
+        # configured header is X-Remote-User.
+        resp = await client.get("/me", headers={"X-Forwarded-User": "alice"})
+        assert resp.status_code == 200
+        assert resp.json()["user"] is None
+
+        # When proxy_auth_header is None (disabled), the header is
+        # not checked.
+        ctx.proxy_auth_header = None
+        resp = await client.get("/me", headers={"X-Remote-User": "alice"})
+        assert resp.status_code == 200
+        assert resp.json()["user"] is None

--- a/nixbot/nixbot/tests/test_auth.py
+++ b/nixbot/nixbot/tests/test_auth.py
@@ -767,7 +767,9 @@ async def test_oauth_callback_filters_session_groups() -> None:
 async def test_proxy_auth_header() -> None:
     """The proxy auth header authenticates users through _request_user."""
     app = FastAPI()
-    ctx = WebContext(pool=AsyncMock())
+    signer = SessionSigner([b"k" * 32])
+    ctx = WebContext(pool=AsyncMock(), signer=signer)
+    ctx.revoked_sessions = None
     ctx.proxy_auth_header = "X-Remote-User"
     app.state.web_context = ctx
 
@@ -801,6 +803,14 @@ async def test_proxy_auth_header() -> None:
         resp = await client.get("/me", headers={"X-Forwarded-User": "alice"})
         assert resp.status_code == 200
         assert resp.json()["user"] is None
+
+        # A session cookie takes precedence over the proxy header.
+        cookie = signer.session_for(User(provider="github", username="bob"))
+        client.cookies.set(SESSION_COOKIE, cookie)
+        resp = await client.get("/me", headers={"X-Remote-User": "alice"})
+        client.cookies.clear()
+        assert resp.status_code == 200
+        assert resp.json()["user"] == "github:bob"
 
         # When proxy_auth_header is None (disabled), the header is
         # not checked.

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -36,7 +36,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from nixbot.effects_state import TaskTokens
 
-from ..auth import can_control_build, is_admin  # noqa: TID252
+from ..auth import User, can_control_build, is_admin  # noqa: TID252
 from ..forge_tokens import RevokedSessionStore  # noqa: TID252
 from ..recovery import check_db_health  # noqa: TID252
 from ..schedules import ScheduledEffectsStore, schedule_overview  # noqa: TID252
@@ -54,7 +54,7 @@ from .templating import STATIC_DIR, CachedStaticFiles, make_env
 
 if TYPE_CHECKING:
     from ..api_tokens import ApiTokenStore  # noqa: TID252
-    from ..auth import AuthzConfig, SessionSigner, User  # noqa: TID252
+    from ..auth import AuthzConfig, SessionSigner  # noqa: TID252
     from ..forge_tokens import (  # noqa: TID252
         ForgeTokenRefresher,
         SessionRevocations,
@@ -113,6 +113,9 @@ class WebContext:
         # Logout denylist: stateless cookies stay verifiable until
         # expiry, so revoked session ids are checked server-side.
         self.revoked_sessions: SessionRevocations | None = RevokedSessionStore(pool)
+        # Reverse-proxy auth header for the authenticated username.
+        # Wired by bootstrap.
+        self.proxy_auth_header: str | None = None
 
     async def can_control(self, request: Request, build: dict[str, Any]) -> bool:
         """Whether the requester may restart/cancel this build (drives
@@ -148,9 +151,10 @@ class WebContext:
         return user
 
     async def request_user(self, request: Request) -> User | None:
-        """Session cookie or personal API token (Authorization: Bearer).
-        Cached per request: routes ask several times (authz checks,
-        visibility, toggleability) and token auth hits the database."""
+        """Session cookie, proxy auth header, or personal API token
+        (Authorization: ***). Cached per request: routes ask several
+        times (authz checks, visibility, toggleability) and token auth
+        hits the database."""
         if not hasattr(request.state, "bn_user"):
             request.state.bn_user = await self._request_user(request)
         return request.state.bn_user
@@ -161,6 +165,13 @@ class WebContext:
             return await self.token_store.authenticate(
                 auth_header.removeprefix("Bearer ")
             )
+        if self.proxy_auth_header is not None:
+            remote_user = request.headers.get(self.proxy_auth_header)
+            if remote_user:
+                return User(
+                    provider="proxy",
+                    username=remote_user,
+                )
         return await self.current_user(request)
 
     async def render(

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -151,10 +151,10 @@ class WebContext:
         return user
 
     async def request_user(self, request: Request) -> User | None:
-        """Session cookie, proxy auth header, or personal API token
-        (Authorization: ***). Cached per request: routes ask several
-        times (authz checks, visibility, toggleability) and token auth
-        hits the database."""
+        """Session cookie, personal API token (Authorization: Bearer),
+        or reverse-proxy auth header. Cached per request: routes ask
+        several times (authz checks, visibility, toggleability) and
+        token auth hits the database."""
         if not hasattr(request.state, "bn_user"):
             request.state.bn_user = await self._request_user(request)
         return request.state.bn_user
@@ -165,14 +165,16 @@ class WebContext:
             return await self.token_store.authenticate(
                 auth_header.removeprefix("Bearer ")
             )
+        # Session cookie wins over the proxy header so forge/OIDC
+        # identities keep their authz rules.
+        user = await self.current_user(request)
+        if user is not None:
+            return user
         if self.proxy_auth_header is not None:
-            remote_user = request.headers.get(self.proxy_auth_header)
+            remote_user = request.headers.get(self.proxy_auth_header, "").strip()
             if remote_user:
-                return User(
-                    provider="proxy",
-                    username=remote_user,
-                )
-        return await self.current_user(request)
+                return User(provider="proxy", username=remote_user)
+        return None
 
     async def render(
         self, template: str, request: Request | None = None, **context: Any

--- a/nixosModules/nixbot.nix
+++ b/nixosModules/nixbot.nix
@@ -287,7 +287,9 @@ in
       default = null;
       description = ''
         HTTP header carrying the authenticated username, set by the reverse
-        proxy. When set, nixbot trusts this header as the user identity.
+        proxy. Users are qualified as `proxy:<username>` (e.g. in `admins`).
+        The proxy MUST set or strip this header on every request, otherwise
+        clients can impersonate any user.
       '';
       example = "X-Remote-User";
     };

--- a/nixosModules/nixbot.nix
+++ b/nixosModules/nixbot.nix
@@ -149,6 +149,7 @@ let
       show_trace_on_failure = cfg.showTrace;
       cache_failed_builds = cfg.cacheFailedBuilds;
       allow_unauthenticated_control = cfg.allowUnauthenticatedControl;
+      proxy_auth_header = cfg.proxyAuthHeader;
       build_max_silent_time = cfg.buildMaxSilentTime;
       build_timeout = cfg.buildTimeout;
       http_port = cfg.port;
@@ -280,6 +281,16 @@ in
       unauthenticated control actions (cancel, restart). Useful behind a VPN
       where network access implies trust
     '';
+
+    proxyAuthHeader = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        HTTP header carrying the authenticated username, set by the reverse
+        proxy. When set, nixbot trusts this header as the user identity.
+      '';
+      example = "X-Remote-User";
+    };
 
     statusContextPrefix = lib.mkOption {
       type = lib.types.str;


### PR DESCRIPTION
I've gone ahead and gone with your suggestion on #102, I've deployed this on my homelab and its working nicely.
This branch allows nixbot to trust an HTTP header set by a reverse proxy (e.g. X-Remote-User) as the user identity. 

This allows using all the admin functionality without the need to rely on an authentication provider or external service.

Let me know if you have any suggestion.