### PR TITLE
Add OIDC workload identification to ci effects

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -19,4 +19,5 @@ in
 // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   nixbot = import ./nixbot.nix checkArgs;
   nixbot-gitlab = import ./nixbot-gitlab.nix checkArgs;
+  nixbot-workload-identity = import ./nixbot-workload-identity.nix checkArgs;
 }

--- a/checks/github-helpers.py
+++ b/checks/github-helpers.py
@@ -1,0 +1,41 @@
+# Shared testScript helpers for the fake-GitHub based checks
+# (prepended to the testScript, see github-node.nix).
+import hashlib
+import hmac
+import json
+import shlex
+
+
+def push_webhook(node, ref="refs/heads/master", message="initial commit"):
+    """Deliver a signed push webhook for the current tip of the bare repo."""
+    sha = node.succeed("git -C /var/lib/test-repo rev-parse master").strip()
+    body = json.dumps(
+        {
+            "ref": ref,
+            "after": sha,
+            "repository": {"id": 1, "default_branch": "master"},
+            "head_commit": {"message": message},
+        }
+    ).encode()
+    sig = hmac.new(b"test-webhook-secret", body, hashlib.sha256).hexdigest()
+    node.succeed(
+        "curl --fail -s -X POST http://127.0.0.1:8010/webhooks/github "
+        "-H 'Content-Type: application/json' "
+        "-H 'X-GitHub-Event: push' "
+        "-H 'X-GitHub-Delivery: test-delivery-1' "
+        f"-H 'X-Hub-Signature-256: sha256={sig}' "
+        f"-d {shlex.quote(body.decode())}"
+    )
+    return sha
+
+
+def completed_check_runs(node):
+    """Conclusions of completed check runs posted to the fake GitHub, by name."""
+    out = node.execute("cat /var/lib/fake-github/check_runs.jsonl")[1]
+    check_runs = [json.loads(line) for line in out.splitlines() if line]
+    print(check_runs)
+    return {
+        cr["name"]: cr.get("conclusion")
+        for cr in check_runs
+        if cr.get("status") == "completed"
+    }

--- a/checks/github-node.nix
+++ b/checks/github-node.nix
@@ -1,0 +1,155 @@
+# Shared github-mode node for the NixOS tests: nixbot against a fake
+# GitHub API, with a bare test repository at /var/lib/test-repo built
+# from `flakeText` (a function of pkgs, so it can embed store paths).
+# Check runs posted by nixbot are appended to
+# /var/lib/fake-github/check_runs.jsonl for the test scripts to assert
+# on.
+{ flakeText }:
+{ self, pkgs, ... }:
+let
+  fakeGithubPort = 8970;
+  fakeGithub = pkgs.writers.writePython3Bin "fake-github" { } ''
+    import json
+    import re
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    CHECK_RUNS_LOG = "/var/lib/fake-github/check_runs.jsonl"
+
+    REPO = {
+        "id": 1,
+        "name": "test-flake",
+        "owner": {"login": "acme"},
+        "default_branch": "master",
+        "clone_url": "file:///var/lib/test-repo",
+        "private": False,
+        "topics": ["build-with-buildbot"],
+    }
+
+
+    class Handler(BaseHTTPRequestHandler):
+        def _json(self, payload, code=200):
+            body = json.dumps(payload).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            path = self.path.split("?")[0]
+            if path == "/app/installations":
+                self._json([{"id": 1}])
+            elif path == "/installation/repositories":
+                self._json({"repositories": [REPO]})
+            elif path == "/repos/acme/test-flake/pulls":
+                # Reconciliation polls open PRs; none exist here.
+                self._json([])
+            else:
+                self._json({"message": "not found"}, 404)
+
+        def do_PATCH(self):
+            length = int(self.headers.get("Content-Length") or 0)
+            body = self.rfile.read(length)
+            path = self.path.split("?")[0]
+            if re.fullmatch(r"/repos/acme/test-flake/check-runs/[0-9]+", path):
+                entry = json.loads(body)
+                with open(CHECK_RUNS_LOG, "a") as f:
+                    f.write(json.dumps(entry) + "\n")
+                self._json({"id": int(path.rsplit("/", 1)[1])}, 200)
+            else:
+                self._json({"message": "not found"}, 404)
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length") or 0)
+            body = self.rfile.read(length)
+            path = self.path.split("?")[0]
+            if re.fullmatch(r"/app/installations/1/access_tokens", path):
+                self._json({"token": "fake-token"}, 201)
+            elif path == "/repos/acme/test-flake/check-runs":
+                entry = json.loads(body)
+                # The poster stores this id to PATCH the run on
+                # completion; key it by name so each check keeps a
+                # distinct id like the real API.
+                check_run_id = abs(hash(entry["name"])) % 1_000_000
+                with open(CHECK_RUNS_LOG, "a") as f:
+                    f.write(json.dumps(entry) + "\n")
+                self._json({"id": check_run_id}, 201)
+            else:
+                self._json({"message": "not found"}, 404)
+
+        def log_message(self, fmt, *args):
+            pass
+
+
+    HTTPServer(("127.0.0.1", ${toString fakeGithubPort}), Handler).serve_forever()
+  '';
+  testFlake = pkgs.writeText "flake.nix" (flakeText pkgs);
+in
+{
+  imports = [ self.nixosModules.nixbot ];
+
+  services.nixbot = {
+    enable = true;
+    domain = "localhost";
+    nginx.enable = false;
+    github = {
+      enable = true;
+      appId = 123;
+      apiUrl = "http://127.0.0.1:${toString fakeGithubPort}";
+      appSecretKeyFile = "/var/lib/secrets/github-app-key.pem";
+      webhookSecretFile = pkgs.writeText "webhook-secret" "test-webhook-secret";
+    };
+  };
+
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
+
+  environment.systemPackages = [
+    pkgs.git
+    pkgs.curl
+    pkgs.jq
+  ];
+
+  systemd.services.fake-github = {
+    wantedBy = [ "multi-user.target" ];
+    before = [ "nixbot.service" ];
+    requiredBy = [ "nixbot.service" ];
+    serviceConfig = {
+      ExecStart = "${fakeGithub}/bin/fake-github";
+      StateDirectory = "fake-github";
+    };
+  };
+
+  systemd.services.setup-test-repo = {
+    wantedBy = [ "multi-user.target" ];
+    before = [ "nixbot.service" ];
+    requiredBy = [ "nixbot.service" ];
+    path = [
+      pkgs.git
+      pkgs.openssl
+    ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      mkdir -p /var/lib/secrets
+      openssl genrsa -out /var/lib/secrets/github-app-key.pem 2048
+      chmod 644 /var/lib/secrets/github-app-key.pem
+
+      rm -rf /var/lib/test-repo /tmp/test-flake
+      mkdir -p /tmp/test-flake
+      cd /tmp/test-flake
+      git init -b master
+      git config user.name test
+      git config user.email test@example.com
+      cp ${testFlake} flake.nix
+      git add flake.nix
+      git commit -m "initial commit"
+      git clone --bare /tmp/test-flake /var/lib/test-repo
+      chmod -R a+rX /var/lib/test-repo
+    '';
+  };
+}

--- a/checks/nixbot-workload-identity.nix
+++ b/checks/nixbot-workload-identity.nix
@@ -1,0 +1,159 @@
+# End-to-end workload identity, mirroring the docs/WORKLOAD_IDENTITY.md
+# example: an effect requests an ID token from nixbot, logs into OpenBao
+# (which verifies it against nixbot's JWKS), trades it for a short-lived
+# SSH certificate from OpenBao's SSH CA and logs into the host with it.
+let
+  audience = "https://openbao.example";
+  openbaoAddr = "http://127.0.0.1:8200";
+  deployScript =
+    pkgs:
+    pkgs.writeShellScript "vault-ssh-deploy" ''
+      set -euo pipefail
+      export PATH=${pkgs.curl}/bin:${pkgs.jq}/bin:${pkgs.openbao}/bin:${pkgs.openssh}/bin:$PATH
+      export BAO_ADDR=${openbaoAddr}
+      # The sandbox has an empty /etc; ssh needs a passwd entry for its uid.
+      echo "root:x:0:0:root:$HOME:/bin/sh" > /etc/passwd
+
+      # Authenticate to OpenBao with the nixbot-issued identity token.
+      jwt=$(curl -fsS -X POST "$NIXBOT_ID_TOKEN_REQUEST_URL" \
+        -H "Authorization: Bearer $NIXBOT_ID_TOKEN_REQUEST_TOKEN" \
+        -H "Content-Type: application/json" \
+        --data '{"audience": "${audience}"}' | jq -re .token)
+      BAO_TOKEN=$(bao write -field=token auth/jwt/login role=deploy jwt="$jwt")
+      export BAO_TOKEN
+
+      # Trade it for a short-lived SSH certificate and deploy with it:
+      # no deploy key is stored in CI.
+      ssh-keygen -t ed25519 -N "" -f ./id_deploy
+      bao write -field=signed_key ssh/sign/deploy \
+        public_key=@./id_deploy.pub valid_principals=deploy > ./id_deploy-cert.pub
+      ssh -i ./id_deploy -o CertificateFile=./id_deploy-cert.pub \
+        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        deploy@127.0.0.1 'echo deployed > /home/deploy/deployed'
+    '';
+  flakeText = pkgs: ''
+    {
+      outputs = { self }: {
+        checks.${pkgs.stdenv.hostPlatform.system}.test = derivation {
+          name = "test";
+          system = "${pkgs.stdenv.hostPlatform.system}";
+          builder = "/bin/sh";
+          args = [ "-c" "echo hello > $out" ];
+        };
+        herculesCI.onPush.default.outputs.effects.deploy = derivation {
+          name = "deploy";
+          system = "${pkgs.stdenv.hostPlatform.system}";
+          # The effect sandbox uses `nix develop`, which requires bash as
+          # the builder and an `outputs` env var for its env dump.
+          builder = "${pkgs.runtimeShell}";
+          args = [ "${deployScript pkgs}" ];
+          outputs = [ "out" ];
+          isEffect = true;
+          idTokenAudiences = builtins.toJSON [ "${audience}" ];
+        };
+      };
+    }
+  '';
+in
+(import ./lib.nix) {
+  name = "nixbot-workload-identity";
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ (import ./github-node.nix { inherit flakeText; }) ];
+
+      # The raw test effect references bash and the login script without
+      # declaring them as derivation inputs, so they are only visible to
+      # the builder without the nix build sandbox (the host store is
+      # mounted into the VM).
+      nix.settings.sandbox = false;
+
+      environment.systemPackages = [ pkgs.openbao ];
+
+      # Deploy target: the effect logs in as "deploy" with a certificate
+      # signed by OpenBao's SSH CA. sshd reads the CA key per
+      # authentication, so the test script can install it after the SSH
+      # engine is configured.
+      services.openssh = {
+        enable = true;
+        extraConfig = "TrustedUserCAKeys /etc/ssh/vault-ca.pub";
+      };
+      users.users.deploy.isNormalUser = true;
+
+      systemd.services.openbao-dev = {
+        wantedBy = [ "multi-user.target" ];
+        # Dev mode shells out to `sh` and needs a writable HOME when
+        # expanding its config paths.
+        path = [ pkgs.bash ];
+        environment.HOME = "/var/lib/openbao-dev";
+        serviceConfig = {
+          ExecStart = "${pkgs.openbao}/bin/bao server -dev -dev-root-token-id=root -dev-listen-address=127.0.0.1:8200";
+          StateDirectory = "openbao-dev";
+        };
+      };
+    };
+
+  testScript = ''
+    ${builtins.readFile ./github-helpers.py}
+
+    machine.start()
+    machine.wait_for_unit("nixbot.service")
+    machine.wait_until_succeeds(
+        "curl --fail -s http://127.0.0.1:8010/health", timeout=120
+    )
+
+    with subtest("nixbot serves OIDC discovery and JWKS"):
+        doc = json.loads(machine.succeed(
+            "curl --fail -s http://127.0.0.1:8010/.well-known/openid-configuration"
+        ))
+        assert doc["issuer"] == "http://localhost:8010", doc
+        jwks = json.loads(machine.succeed(
+            "curl --fail -s http://127.0.0.1:8010/.well-known/jwks.json"
+        ))
+        assert jwks["keys"], jwks
+
+    with subtest("openbao trusts nixbot as JWT auth backend"):
+        machine.wait_for_open_port(8200)
+        bao = "BAO_ADDR=${openbaoAddr} BAO_TOKEN=root bao "
+        machine.succeed(bao + "auth enable jwt")
+        machine.succeed(
+            bao + "write auth/jwt/config oidc_discovery_url=http://localhost:8010"
+        )
+        machine.succeed(
+            "echo 'path \"ssh/sign/deploy\" { capabilities = [\"update\"] }' | "
+            + bao + "policy write ssh-deploy -"
+        )
+        machine.succeed(
+            bao + "write auth/jwt/role/deploy role_type=jwt user_claim=sub "
+            "bound_audiences=${audience} "
+            "bound_subject=repo:github:acme/test-flake:ref:refs/heads/master "
+            "policies=ssh-deploy token_ttl=5m"
+        )
+
+    with subtest("openbao's SSH CA can sign certificates for the deploy user"):
+        machine.succeed(bao + "secrets enable ssh")
+        machine.succeed(bao + "write ssh/config/ca generate_signing_key=true")
+        machine.succeed(
+            bao + "write ssh/roles/deploy key_type=ca allow_user_certificates=true "
+            "allowed_users=deploy default_user=deploy ttl=10m"
+        )
+        machine.succeed(
+            bao + "read -field=public_key ssh/config/ca > /etc/ssh/vault-ca.pub"
+        )
+
+    with subtest("push webhook triggers build and the SSH deploy effect"):
+        push_webhook(machine)
+
+        def effect_succeeded(_ignore):
+            done = completed_check_runs(machine)
+            effects = {
+                name: conclusion
+                for name, conclusion in done.items()
+                if "default.deploy" in name
+            }
+            return effects and all(c == "success" for c in effects.values())
+
+        retry(effect_succeeded, timeout_seconds=600)
+        machine.succeed("test -e /home/deploy/deployed")
+  '';
+}

--- a/checks/nixbot.nix
+++ b/checks/nixbot.nix
@@ -1,12 +1,6 @@
 let
   # Both nodes build the same minimal flake with one check.
-  setupTestFlake = ''
-    mkdir -p /tmp/test-flake
-    cd /tmp/test-flake
-    git init -b master
-    git config user.name test
-    git config user.email test@example.com
-    cat > flake.nix <<'EOF'
+  testFlake = ''
     {
       outputs = { self }: {
         checks.x86_64-linux.test = derivation {
@@ -17,6 +11,15 @@ let
         };
       };
     }
+  '';
+  setupTestFlake = ''
+    mkdir -p /tmp/test-flake
+    cd /tmp/test-flake
+    git init -b master
+    git config user.name test
+    git config user.email test@example.com
+    cat > flake.nix <<'EOF'
+    ${testFlake}
     EOF
     git add flake.nix
     git commit -m "initial commit"
@@ -27,147 +30,7 @@ in
   nodes = {
     # GitHub mode against a fake GitHub API: discovery, webhook, eval,
     # build, and commit-status assertions all run against local fakes.
-    github =
-      { self, pkgs, ... }:
-      let
-        fakeGithubPort = 8970;
-        fakeGithub = pkgs.writers.writePython3Bin "fake-github" { } ''
-          import json
-          import re
-          from http.server import BaseHTTPRequestHandler, HTTPServer
-
-          CHECK_RUNS_LOG = "/var/lib/fake-github/check_runs.jsonl"
-
-          REPO = {
-              "id": 1,
-              "name": "test-flake",
-              "owner": {"login": "acme"},
-              "default_branch": "master",
-              "clone_url": "file:///var/lib/test-repo",
-              "private": False,
-              "topics": ["build-with-buildbot"],
-          }
-
-
-          class Handler(BaseHTTPRequestHandler):
-              def _json(self, payload, code=200):
-                  body = json.dumps(payload).encode()
-                  self.send_response(code)
-                  self.send_header("Content-Type", "application/json")
-                  self.send_header("Content-Length", str(len(body)))
-                  self.end_headers()
-                  self.wfile.write(body)
-
-              def do_GET(self):
-                  path = self.path.split("?")[0]
-                  if path == "/app/installations":
-                      self._json([{"id": 1}])
-                  elif path == "/installation/repositories":
-                      self._json({"repositories": [REPO]})
-                  elif path == "/repos/acme/test-flake/pulls":
-                      # Reconciliation polls open PRs; none exist here.
-                      self._json([])
-                  else:
-                      self._json({"message": "not found"}, 404)
-
-              def do_PATCH(self):
-                  length = int(self.headers.get("Content-Length") or 0)
-                  body = self.rfile.read(length)
-                  path = self.path.split("?")[0]
-                  if re.fullmatch(r"/repos/acme/test-flake/check-runs/[0-9]+", path):
-                      entry = json.loads(body)
-                      with open(CHECK_RUNS_LOG, "a") as f:
-                          f.write(json.dumps(entry) + "\n")
-                      self._json({"id": int(path.rsplit("/", 1)[1])}, 200)
-                  else:
-                      self._json({"message": "not found"}, 404)
-
-              def do_POST(self):
-                  length = int(self.headers.get("Content-Length") or 0)
-                  body = self.rfile.read(length)
-                  path = self.path.split("?")[0]
-                  if re.fullmatch(r"/app/installations/1/access_tokens", path):
-                      self._json({"token": "fake-token"}, 201)
-                  elif path == "/repos/acme/test-flake/check-runs":
-                      entry = json.loads(body)
-                      # The poster stores this id to PATCH the run on
-                      # completion; key it by name so each check keeps a
-                      # distinct id like the real API.
-                      check_run_id = abs(hash(entry["name"])) % 1_000_000
-                      with open(CHECK_RUNS_LOG, "a") as f:
-                          f.write(json.dumps(entry) + "\n")
-                      self._json({"id": check_run_id}, 201)
-                  else:
-                      self._json({"message": "not found"}, 404)
-
-              def log_message(self, fmt, *args):
-                  pass
-
-
-          HTTPServer(("127.0.0.1", ${toString fakeGithubPort}), Handler).serve_forever()
-        '';
-      in
-      {
-        imports = [ self.nixosModules.nixbot ];
-
-        services.nixbot = {
-          enable = true;
-          domain = "localhost";
-          nginx.enable = false;
-          github = {
-            enable = true;
-            appId = 123;
-            apiUrl = "http://127.0.0.1:${toString fakeGithubPort}";
-            appSecretKeyFile = "/var/lib/secrets/github-app-key.pem";
-            webhookSecretFile = pkgs.writeText "webhook-secret" "test-webhook-secret";
-          };
-        };
-
-        nix.settings.experimental-features = [
-          "nix-command"
-          "flakes"
-        ];
-
-        environment.systemPackages = [
-          pkgs.git
-          pkgs.curl
-          pkgs.jq
-        ];
-
-        systemd.services.fake-github = {
-          wantedBy = [ "multi-user.target" ];
-          before = [ "nixbot.service" ];
-          requiredBy = [ "nixbot.service" ];
-          serviceConfig = {
-            ExecStart = "${fakeGithub}/bin/fake-github";
-            StateDirectory = "fake-github";
-          };
-        };
-
-        systemd.services.setup-test-repo = {
-          wantedBy = [ "multi-user.target" ];
-          before = [ "nixbot.service" ];
-          requiredBy = [ "nixbot.service" ];
-          path = [
-            pkgs.git
-            pkgs.openssl
-          ];
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-          };
-          script = ''
-            mkdir -p /var/lib/secrets
-            openssl genrsa -out /var/lib/secrets/github-app-key.pem 2048
-            chmod 644 /var/lib/secrets/github-app-key.pem
-
-            rm -rf /var/lib/test-repo /tmp/test-flake
-            ${setupTestFlake}
-            git clone --bare /tmp/test-flake /var/lib/test-repo
-            chmod -R a+rX /var/lib/test-repo
-          '';
-        };
-      };
+    github = import ./github-node.nix { flakeText = _pkgs: testFlake; };
 
     # Gitea mode against a real Gitea: discovery registers the webhook,
     # a push delivers it, and nixbot posts commit statuses back.
@@ -283,10 +146,7 @@ in
   };
 
   testScript = ''
-    import hashlib
-    import hmac
-    import json
-    import shlex
+    ${builtins.readFile ./github-helpers.py}
 
     start_all()
 
@@ -309,32 +169,10 @@ in
         retry(github_project_discovered, timeout_seconds=120)
 
     with subtest("github: webhook push triggers eval, build, and statuses"):
-        sha = github.succeed("git -C /var/lib/test-repo rev-parse master").strip()
-        body = json.dumps({
-            "ref": "refs/heads/master",
-            "after": sha,
-            "repository": {"id": 1, "default_branch": "master"},
-            "head_commit": {"message": "initial commit"},
-        }).encode()
-        sig = hmac.new(b"test-webhook-secret", body, hashlib.sha256).hexdigest()
-        github.succeed(
-            "curl --fail -s -X POST http://127.0.0.1:8010/webhooks/github "
-            "-H 'Content-Type: application/json' "
-            "-H 'X-GitHub-Event: push' "
-            "-H 'X-GitHub-Delivery: test-delivery-1' "
-            f"-H 'X-Hub-Signature-256: sha256={sig}' "
-            f"-d {shlex.quote(body.decode())}"
-        )
+        push_webhook(github)
 
         def github_checks_posted(_ignore):
-            out = github.execute("cat /var/lib/fake-github/check_runs.jsonl")[1]
-            check_runs = [json.loads(line) for line in out.splitlines() if line]
-            print(check_runs)
-            done = {
-                cr["name"]: cr.get("conclusion")
-                for cr in check_runs
-                if cr.get("status") == "completed"
-            }
+            done = completed_check_runs(github)
             return (
                 done.get("nixbot/nix-eval") == "success"
                 and done.get("nixbot/nix-build") == "success"

--- a/docs/WORKLOAD_IDENTITY.md
+++ b/docs/WORKLOAD_IDENTITY.md
@@ -1,0 +1,116 @@
+# Workload identity for effects
+
+nixbot can act as an OIDC issuer that mints short-lived ID tokens for running
+effects. Relying parties (OpenBao/Vault, AWS/GCP/Azure federation,
+[niks3](https://github.com/Mic92/niks3), ...) verify the tokens against nixbot's
+JWKS and grant access based on the claims, so effects need no static deploy
+secrets in `effects.perRepoSecretFiles`.
+
+Enabled by default (`services.nixbot.workloadIdentity`); an effect only receives
+tokens for audiences it declares.
+
+## Declaring audiences
+
+Set `idTokenAudiences` on the effect derivation (an argument of this repo's
+effects-lib `mkEffect`, or a plain env attribute containing a JSON list):
+
+```nix
+effects-lib.mkEffect {
+  name = "deploy";
+  idTokenAudiences = [ "https://vault.example.com" ];
+  inputs = [ pkgs.openbao pkgs.openssh ];
+  effectScript = ''
+    export VAULT_ADDR=https://vault.example.com
+
+    # Authenticate to Vault with the nixbot-issued identity token.
+    vault write -field=token auth/jwt/login \
+      role=deploy jwt="$(nixbot-id-token https://vault.example.com)" > ~/.vault-token
+
+    # Trade it for a short-lived SSH certificate and deploy with it:
+    # no deploy key is stored in CI.
+    ssh-keygen -t ed25519 -N "" -f ./id_deploy
+    vault write -field=signed_key ssh/sign/deploy \
+      public_key=@./id_deploy.pub valid_principals=deploy > ./id_deploy-cert.pub
+
+    export NIX_SSHOPTS="-i ./id_deploy -o CertificateFile=./id_deploy-cert.pub"
+    nixos-rebuild switch --flake .#web01 \
+      --target-host deploy@web01.example.com \
+      --use-remote-sudo
+  '';
+}
+```
+
+The matching Vault SSH CA setup is:
+
+```
+vault secrets enable ssh
+vault write ssh/config/ca generate_signing_key=true
+vault write ssh/roles/deploy \
+  key_type=ca allow_user_certificates=true \
+  allowed_users=deploy default_user=deploy ttl=10m
+```
+
+Inside the sandbox, `nixbot-id-token <audience>` prints a fresh ID token
+(default lifetime 300 s). `nixbot-id-token <audience> --json` prints the raw
+`{"token": ..., "expires_at": ...}` response, which is the format niks3's
+`token-script` credential expects. Requests for audiences not listed in
+`idTokenAudiences` are rejected. The env variables it uses
+(`NIXBOT_ID_TOKEN_REQUEST_URL`, `NIXBOT_ID_TOKEN_REQUEST_TOKEN`) are only
+present for effects that declare at least one audience.
+
+Note the opt-in scopes tokens per effect, not per person: anyone who can get an
+effect with `idTokenAudiences` to run in the repository can obtain its tokens.
+Restrict relying-party policies with the claims below (in particular
+`sub`/`ref`), and remember effects only run for pushes and pull requests
+according to the repository's effects gating.
+
+## Claims
+
+Common claims: `iss` (the nixbot URL), `aud` (one requested audience per token),
+`sub`, `event`, `forge`, `repository`, `repository_owner`, `effect`, plus
+`iat`/`nbf`/`exp`/`jti`.
+
+| event        | `sub`                                                 | extra claims                               |
+| ------------ | ----------------------------------------------------- | ------------------------------------------ |
+| push         | `repo:<forge>:<owner>/<repo>:ref:refs/heads/<branch>` | `ref`, `sha`, `build_id`                   |
+| pull_request | `repo:<forge>:<owner>/<repo>:pull_request`            | `pr_number`, `base_ref`, `sha`, `build_id` |
+| schedule     | `repo:<forge>:<owner>/<repo>:schedule:<name>`         | `schedule`                                 |
+
+Pull-request tokens carry no `ref` claim: branch-based conditions (e.g. "only
+refs/heads/main may deploy") therefore never match a PR run.
+
+## Relying-party configuration
+
+Discovery and JWKS documents are served unauthenticated at
+`<url>/.well-known/openid-configuration` and `<url>/.well-known/jwks.json`.
+
+Example niks3 provider:
+
+```toml
+[upload-oidc-providers.nixbot]
+issuer = "https://ci.example.com"
+audience = "https://cache.example.com"
+bound_subject = "repo:github:acme/*:ref:refs/heads/main"
+```
+
+Example Vault/OpenBao JWT role for the deploy effect above (only pushes to main
+of acme/widgets can log in; PR-triggered effects carry no `ref` claim and never
+match):
+
+```
+vault write auth/jwt/config oidc_discovery_url=https://ci.example.com
+vault write auth/jwt/role/deploy \
+  role_type=jwt user_claim=sub \
+  bound_audiences=https://vault.example.com \
+  bound_subject=repo:github:acme/widgets:ref:refs/heads/main \
+  token_policies=ssh-deploy token_ttl=5m
+```
+
+## Keys
+
+Tokens are RS256-signed. Without `workloadIdentity.signingKeyFile`, nixbot
+generates the key in its state directory and rotates it every `keyRotationDays`
+(default 30); the previous key stays in the JWKS so in-flight tokens keep
+verifying. An operator-provided key is used as-is and never rotated — rotate it
+by replacing the file and restarting nixbot, which invalidates tokens signed
+with the old key.

--- a/formatter/treefmt.nix
+++ b/formatter/treefmt.nix
@@ -69,6 +69,7 @@
       ];
       extraPythonPackages = [
         pkgs.python3.pkgs.pydantic
+        pkgs.python3.pkgs.joserfc
         pkgs.python3.pkgs.pytest
         pkgs.python3.pkgs.pytest-benchmark
         pkgs.python3.pkgs.httpx

--- a/herculesCI/effects-lib.nix
+++ b/herculesCI/effects-lib.nix
@@ -2,6 +2,14 @@
 # Avoids pulling hercules-ci-effects (and its transitive flake-parts input)
 # into every consumer of this flake.
 { pkgs }:
+let
+  # Fetches a workload-identity ID token from nixbot inside the effect
+  # sandbox, see docs/WORKLOAD_IDENTITY.md. --json prints the raw
+  # {token, expires_at} response (niks3's ScriptToken format).
+  idTokenScript = pkgs.writers.writePython3Bin "nixbot-id-token" { } (
+    builtins.readFile ./nixbot-id-token.py
+  );
+in
 {
   mkEffect =
     {
@@ -13,6 +21,9 @@
       # Pushable repository checkout at /build/checkout ($NIXBOT_EFFECT_CHECKOUT),
       # see docs/EFFECTS.md.
       checkout ? false,
+      # Audiences this effect may request workload-identity ID tokens
+      # for via `nixbot-id-token <audience>`, see docs/WORKLOAD_IDENTITY.md.
+      idTokenAudiences ? [ ],
       # Scheduling metadata read via `nixbot-effects list`: attribute paths
       # of effects that must succeed first, job name first
       # (e.g. [ [ "default" "deploy-staging" ] ]), and a named lock
@@ -32,11 +43,13 @@
       isEffect = true;
       __nixbot_effect_checkout = checkout;
       secretsMap = builtins.toJSON secretsMap;
+      idTokenAudiences = builtins.toJSON idTokenAudiences;
       nativeBuildInputs = [
         pkgs.cacert
         pkgs.curl
         pkgs.jq
       ]
+      ++ (if idTokenAudiences != [ ] then [ idTokenScript ] else [ ])
       ++ inputs;
       phases = [
         "initPhase"

--- a/herculesCI/nixbot-id-token.py
+++ b/herculesCI/nixbot-id-token.py
@@ -1,0 +1,43 @@
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Request a workload-identity ID token from nixbot"
+    )
+    parser.add_argument("audience")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print the raw {token, expires_at} response",
+    )
+    args = parser.parse_args()
+    url = os.environ.get("NIXBOT_ID_TOKEN_REQUEST_URL")
+    token = os.environ.get("NIXBOT_ID_TOKEN_REQUEST_TOKEN")
+    if not url or not token:
+        sys.exit(
+            "nixbot-id-token: no ID token endpoint available; "
+            "declare the audience in the effect's idTokenAudiences"
+        )
+    request = urllib.request.Request(
+        url,
+        data=json.dumps({"audience": args.audience}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read().decode()
+    except urllib.error.HTTPError as e:
+        sys.exit(f"nixbot-id-token: {e}: {e.read().decode(errors='replace')}")
+    print(body if args.json else json.loads(body)["token"])
+
+
+main()

--- a/nixbot/nixbot/bootstrap.py
+++ b/nixbot/nixbot/bootstrap.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 import asyncpg
@@ -73,6 +74,7 @@ from .webhooks import (
     create_webhook_router,
 )
 from .work_queue import WorkQueue
+from .workload_identity import load_issuer
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -308,8 +310,25 @@ async def build_service(config: Config) -> tuple[CIService, FastAPI]:
         orchestrator.reporter = RetryingReporter(reporter, service)
 
     # Web application.
+    identity_issuer = None
+    if config.workload_identity.enable:
+        identity_issuer = load_issuer(
+            config.state_dir,
+            config.url,
+            signing_key_file=resolve_credential_path(
+                config.workload_identity.signing_key_file
+            ),
+            token_ttl=config.workload_identity.token_ttl,
+            key_rotation_interval=timedelta(
+                days=config.workload_identity.key_rotation_days
+            ),
+        )
     app = create_app(
-        pool, config.state_dir, orchestrator.log_registry, orchestrator.task_tokens
+        pool,
+        config.state_dir,
+        orchestrator.log_registry,
+        orchestrator.task_tokens,
+        identity_issuer=identity_issuer,
     )
     ctx = app.state.web_context
     authz = AuthzConfig(

--- a/nixbot/nixbot/config.py
+++ b/nixbot/nixbot/config.py
@@ -202,6 +202,21 @@ class OIDCConfig(BaseModel):
         return read_secret_file(self.client_secret_file)
 
 
+class WorkloadIdentityConfig(BaseModel):
+    """nixbot as OIDC issuer for effect workload identity
+    (docs/WORKLOAD_IDENTITY.md)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enable: bool = True
+    # Operator-provided PEM RSA private key; auto-generated and rotated
+    # in the state dir when unset.
+    signing_key_file: Path | None = None
+    token_ttl: int = 300
+    # Rotation interval for the auto-generated key, in days.
+    key_rotation_days: int = 30
+
+
 class PostBuildStep(BaseModel):
     name: str
     environment: Mapping[str, str | Interpolate]
@@ -327,6 +342,9 @@ class Config(BaseModel):
     github: GitHubConfig | None = None
     pull_based: PullBasedConfig | None = None
     oidc: OIDCConfig | None = None
+    workload_identity: WorkloadIdentityConfig = Field(
+        default_factory=WorkloadIdentityConfig
+    )
     outputs_path: Path | None = None
     post_build_steps: list[PostBuildStep] = []
     failed_build_report_limit: int = (

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 from contextlib import asynccontextmanager
+from functools import partial
 from typing import TYPE_CHECKING
 
 from nixbot_effects import EffectError
@@ -30,6 +31,7 @@ from .effects import (
 )
 from .events import effects_event_for_build
 from .executor import failure_excerpt
+from .workload_identity import identity_from_event
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -227,7 +229,9 @@ async def run_effect_item(
         # The checkout ref (build commit) differs from the report ref
         # (see effects_event_for_build).
         event = effects_event_for_build(worktree_event.repo, build)
-        task_token = o.task_tokens.issue(build.project_id)
+        task_token = o.task_tokens.issue(
+            build.project_id, identity_from_event(event, name, build.id)
+        )
         try:
             async with effect_checkout(
                 o.repos, info, worktree_path, event.commit_sha, credentials
@@ -242,6 +246,11 @@ async def run_effect_item(
                     task_token=task_token,
                 )
                 ctx.effect_checkout = checkout
+                # Audiences come from the effect derivation, evaluated by
+                # run_effect just before its sandbox starts.
+                ctx.bind_id_token_audiences = partial(
+                    o.task_tokens.bind_audiences, task_token
+                )
                 await _run_one_effect(o, event, ctx, build, name)
             await post_effects_summary(o, event, build)
         finally:

--- a/nixbot/nixbot/effects_state.py
+++ b/nixbot/nixbot/effects_state.py
@@ -12,6 +12,7 @@ actual effects (not discovery) carry an EffectIdentity there.
 
 from __future__ import annotations
 
+import dataclasses
 import secrets
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -53,6 +54,16 @@ class TaskTokens:
 
     def claim_for(self, token: str) -> TaskClaim | None:
         return self._tokens.get(token)
+
+    def bind_audiences(self, token: str, audiences: list[str]) -> None:
+        """Audiences the effect declared via idTokenAudiences, known only
+        once its derivation is evaluated (just before the sandbox starts)."""
+        claim = self._tokens.get(token)
+        if claim is None or claim.identity is None:
+            return
+        claim.identity = dataclasses.replace(
+            claim.identity, allowed_audiences=tuple(audiences)
+        )
 
 
 def state_file_path(state_dir: Path, project_id: int, name: str) -> Path:

--- a/nixbot/nixbot/effects_state.py
+++ b/nixbot/nixbot/effects_state.py
@@ -1,20 +1,35 @@
-"""Hercules state API for effects.
+"""Per-run task tokens and the Hercules state API for effects.
 
 Effects persist small files between runs (`getStateFile`/
 `putStateFile` in hercules-ci-effects: nixops state, ssh known
 hosts). The agent proxies these to hercules-ci. We serve them from
 the state directory, scoped per project, authorized by a per-run
 bearer token that the service mints for each effect invocation.
+
+The same token authenticates the workload-identity endpoint; runs of
+actual effects (not discovery) carry an EffectIdentity there.
 """
 
 from __future__ import annotations
 
 import secrets
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from .workload_identity import EffectIdentity
+
+
+@dataclass
+class TaskClaim:
+    project_id: int
+    # None for discovery-phase runs: they must not mint ID tokens.
+    identity: EffectIdentity | None = None
+    # ID tokens minted so far, for the per-run rate limit.
+    id_tokens_issued: int = 0
 
 
 class TaskTokens:
@@ -22,17 +37,21 @@ class TaskTokens:
     is up, so restart-safety is not needed."""
 
     def __init__(self) -> None:
-        self._tokens: dict[str, int] = {}
+        self._tokens: dict[str, TaskClaim] = {}
 
-    def issue(self, project_id: int) -> str:
+    def issue(self, project_id: int, identity: EffectIdentity | None = None) -> str:
         token = secrets.token_urlsafe(32)
-        self._tokens[token] = project_id
+        self._tokens[token] = TaskClaim(project_id=project_id, identity=identity)
         return token
 
     def revoke(self, token: str) -> None:
         self._tokens.pop(token, None)
 
     def project_for(self, token: str) -> int | None:
+        claim = self._tokens.get(token)
+        return claim.project_id if claim is not None else None
+
+    def claim_for(self, token: str) -> TaskClaim | None:
         return self._tokens.get(token)
 
 

--- a/nixbot/nixbot/schedule_runner.py
+++ b/nixbot/nixbot/schedule_runner.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import re
 import time
+from functools import partial
 from typing import TYPE_CHECKING
 
 from .effects import EffectsContext, effects_context, run_scheduled_effect
@@ -20,6 +21,7 @@ from .schedules import (
     ScheduledEffectsStore,
     discover_schedules,
 )
+from .workload_identity import EffectIdentity
 
 if TYPE_CHECKING:
     from .events import RepoInfo
@@ -137,7 +139,17 @@ async def _run_scheduled_inner(
         base_commit=info.default_branch,
         credentials=credentials,
     )
-    task_token = s.orchestrator.task_tokens.issue(due.project_id)
+    task_token = s.orchestrator.task_tokens.issue(
+        due.project_id,
+        EffectIdentity(
+            forge=info.forge,
+            owner=info.owner,
+            repo=info.repo,
+            event="schedule",
+            effect=due.effect,
+            schedule=due.schedule_name,
+        ),
+    )
     log_dir = s.config.state_dir / "logs" / "scheduled"
     log_dir.mkdir(parents=True, exist_ok=True)
     log = LogWriter(
@@ -161,6 +173,9 @@ async def _run_scheduled_inner(
                 task_token=task_token,
             )
             ctx.effect_checkout = checkout
+            ctx.bind_id_token_audiences = partial(
+                s.orchestrator.task_tokens.bind_audiences, task_token
+            )
             return await run_scheduled_effect(
                 ctx, due.schedule_name, due.effect, log.write
             )

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -17,6 +17,8 @@ import pytest
 import zstandard
 from fastapi import Request
 from fastapi.responses import JSONResponse
+from joserfc import jwt
+from joserfc.jwk import KeySet
 
 from nixbot.auth import User
 from nixbot.build_scheduler import AttributeStatus
@@ -48,6 +50,8 @@ from nixbot.web.templating import (
     pr_url,
     timeago,
 )
+from nixbot.web.workload_routes import create_workload_identity_router
+from nixbot.workload_identity import EffectIdentity, load_issuer
 
 from .e2e.support import seed
 from .support import (
@@ -1635,6 +1639,57 @@ def test_effects_state_api(client: WebHarness, tmp_path: Path) -> None:
     client.loop.run_until_complete(run())
     # Scoped under the project directory, name percent-encoded.
     assert (tmp_path / "effects-state" / "7" / "known-hosts").exists()
+
+
+def test_workload_identity_api(client: WebHarness, tmp_path: Path) -> None:
+    issuer = load_issuer(tmp_path, "http://ci.example")
+    tokens = TaskTokens()
+    client.app.include_router(create_workload_identity_router(issuer, tokens))
+    identity = EffectIdentity(
+        forge="github",
+        owner="acme",
+        repo="widgets",
+        event="push",
+        effect="default.deploy",
+        branch="main",
+        allowed_audiences=("https://cache.example.com",),
+    )
+    run_token = tokens.issue(7, identity)
+    discovery_token = tokens.issue(7)
+    url = "/api/v1/id-token"
+    body = {"audience": "https://cache.example.com"}
+
+    async def run() -> None:
+        doc = await client.http.get("/.well-known/openid-configuration")
+        assert doc.json()["issuer"] == "http://ci.example"
+        jwks = await client.http.get("/.well-known/jwks.json")
+        assert jwks.json()["keys"]
+
+        # Only a valid task token of an effect run may mint tokens.
+        assert (await client.http.post(url, json=body)).status_code == 401
+        bad = {"Authorization": "Bearer nope"}
+        assert (await client.http.post(url, json=body, headers=bad)).status_code == 401
+        disc = {"Authorization": f"Bearer {discovery_token}"}
+        assert (await client.http.post(url, json=body, headers=disc)).status_code == 403
+
+        auth = {"Authorization": f"Bearer {run_token}"}
+        # Only audiences the effect declared via idTokenAudiences.
+        wrong = {"audience": "https://other.example.com"}
+        assert (
+            await client.http.post(url, json=wrong, headers=auth)
+        ).status_code == 403
+
+        resp = await client.http.post(url, json=body, headers=auth)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["expires_at"]
+        key_set = KeySet.import_key_set(jwks.json())
+        claims = jwt.decode(data["token"], key_set, algorithms=["RS256"]).claims
+        assert claims["sub"] == "repo:github:acme/widgets:ref:refs/heads/main"
+        assert claims["aud"] == "https://cache.example.com"
+        assert claims["iss"] == "http://ci.example"
+
+    client.loop.run_until_complete(run())
 
 
 def test_logout_revokes_session_cookie(postgres_dsn: str) -> None:

--- a/nixbot/nixbot/tests/test_workload_identity.py
+++ b/nixbot/nixbot/tests/test_workload_identity.py
@@ -1,0 +1,152 @@
+"""Issuer core for effect workload identity: key handling, discovery
+documents, and claim construction. Endpoint behaviour is covered in
+test_web.py."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from joserfc import jwt
+from joserfc.jwk import KeySet, RSAKey
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from nixbot.workload_identity import (
+    EffectIdentity,
+    IdentityIssuer,
+    load_issuer,
+)
+
+ISSUER_URL = "https://nixbot.example.com"
+
+
+def push_identity(**overrides: object) -> EffectIdentity:
+    fields: dict = {
+        "forge": "github",
+        "owner": "acme",
+        "repo": "widgets",
+        "event": "push",
+        "effect": "default.deploy",
+        "build_id": 42,
+        "sha": "0" * 40,
+        "branch": "main",
+        "allowed_audiences": ("https://cache.example.com",),
+    }
+    fields.update(overrides)
+    return EffectIdentity(**fields)
+
+
+def make_issuer(tmp_path: Path) -> IdentityIssuer:
+    return load_issuer(tmp_path, ISSUER_URL)
+
+
+def decode(issuer: IdentityIssuer, token: str) -> dict:
+    key_set = KeySet.import_key_set(issuer.jwks())
+    return jwt.decode(token, key_set, algorithms=["RS256"]).claims
+
+
+# --- keys ---------------------------------------------------------------
+
+
+def test_key_generated_and_persisted(tmp_path: Path) -> None:
+    a = load_issuer(tmp_path, ISSUER_URL)
+    b = load_issuer(tmp_path, ISSUER_URL)
+    assert (tmp_path / "workload-identity-key.pem").exists()
+    assert a.jwks() == b.jwks()
+    assert len(a.jwks()["keys"]) == 1
+    assert a.jwks()["keys"][0]["kid"]
+
+
+def test_key_rotation_keeps_previous_in_jwks(tmp_path: Path) -> None:
+    old = load_issuer(tmp_path, ISSUER_URL)
+    old_kid = old.jwks()["keys"][0]["kid"]
+    # Age the key file beyond the rotation interval.
+    key_file = tmp_path / "workload-identity-key.pem"
+    past = datetime.now(tz=UTC) - timedelta(days=40)
+    os.utime(key_file, (past.timestamp(), past.timestamp()))
+
+    rotated = load_issuer(tmp_path, ISSUER_URL)
+    kids = [k["kid"] for k in rotated.jwks()["keys"]]
+    assert old_kid in kids
+    assert len(kids) == 2  # noqa: PLR2004
+    assert kids[0] != old_kid  # new key signs
+    # Tokens signed by the old issuer still verify against the new JWKS.
+    issued = old.mint(push_identity(), "https://cache.example.com")
+    key_set = KeySet.import_key_set(rotated.jwks())
+    assert jwt.decode(issued.token, key_set, algorithms=["RS256"]).claims
+
+
+def test_operator_provided_key_is_not_rotated(tmp_path: Path) -> None:
+    pem = RSAKey.generate_key(2048).as_pem(private=True)
+    key_file = tmp_path / "provided.pem"
+    key_file.write_bytes(pem)
+    past = datetime.now(tz=UTC) - timedelta(days=400)
+    os.utime(key_file, (past.timestamp(), past.timestamp()))
+    issuer = load_issuer(tmp_path, ISSUER_URL, signing_key_file=key_file)
+    assert len(issuer.jwks()["keys"]) == 1
+    assert not (tmp_path / "workload-identity-key.pem").exists()
+
+
+# --- discovery ----------------------------------------------------------
+
+
+def test_discovery_document(tmp_path: Path) -> None:
+    doc = make_issuer(tmp_path).discovery_document()
+    assert doc["issuer"] == ISSUER_URL
+    assert doc["jwks_uri"] == f"{ISSUER_URL}/.well-known/jwks.json"
+    assert "RS256" in doc["id_token_signing_alg_values_supported"]
+    assert "sub" in doc["claims_supported"]
+
+
+# --- claims -------------------------------------------------------------
+
+
+def test_push_claims(tmp_path: Path) -> None:
+    issuer = make_issuer(tmp_path)
+    issued = issuer.mint(push_identity(), "https://cache.example.com")
+    claims = decode(issuer, issued.token)
+    assert claims["iss"] == ISSUER_URL
+    assert claims["aud"] == "https://cache.example.com"
+    assert claims["sub"] == "repo:github:acme/widgets:ref:refs/heads/main"
+    assert claims["ref"] == "refs/heads/main"
+    assert claims["event"] == "push"
+    assert claims["repository"] == "acme/widgets"
+    assert claims["repository_owner"] == "acme"
+    assert claims["forge"] == "github"
+    assert claims["effect"] == "default.deploy"
+    assert claims["build_id"] == 42  # noqa: PLR2004
+    assert claims["sha"] == "0" * 40
+    assert claims["exp"] > claims["iat"]
+    assert claims["nbf"] < claims["iat"]
+    assert claims["jti"]
+    assert issued.expires_at.tzinfo is not None
+
+
+def test_pull_request_claims_have_no_ref(tmp_path: Path) -> None:
+    issuer = make_issuer(tmp_path)
+    identity = push_identity(
+        event="pull_request", pr_number=7, base_ref="refs/heads/main", branch="main"
+    )
+    claims = decode(issuer, issuer.mint(identity, "aud").token)
+    assert claims["sub"] == "repo:github:acme/widgets:pull_request"
+    assert claims["event"] == "pull_request"
+    assert claims["pr_number"] == 7  # noqa: PLR2004
+    assert claims["base_ref"] == "refs/heads/main"
+    assert "ref" not in claims
+
+
+def test_schedule_claims(tmp_path: Path) -> None:
+    issuer = make_issuer(tmp_path)
+    identity = push_identity(
+        event="schedule", schedule="flake-update", branch=None, sha=None, build_id=None
+    )
+    claims = decode(issuer, issuer.mint(identity, "aud").token)
+    assert claims["sub"] == "repo:github:acme/widgets:schedule:flake-update"
+    assert claims["event"] == "schedule"
+    assert claims["schedule"] == "flake-update"
+    assert "ref" not in claims
+    assert "sha" not in claims
+    assert "build_id" not in claims

--- a/nixbot/nixbot/tests/test_workload_identity.py
+++ b/nixbot/nixbot/tests/test_workload_identity.py
@@ -14,9 +14,12 @@ from joserfc.jwk import KeySet, RSAKey
 if TYPE_CHECKING:
     from pathlib import Path
 
+from nixbot.effects_state import TaskTokens
+from nixbot.events import ChangeEvent, RepoInfo
 from nixbot.workload_identity import (
     EffectIdentity,
     IdentityIssuer,
+    identity_from_event,
     load_issuer,
 )
 
@@ -136,6 +139,59 @@ def test_pull_request_claims_have_no_ref(tmp_path: Path) -> None:
     assert claims["pr_number"] == 7  # noqa: PLR2004
     assert claims["base_ref"] == "refs/heads/main"
     assert "ref" not in claims
+
+
+# --- run identity -------------------------------------------------------
+
+
+def change_event(pr_number: int | None = None) -> ChangeEvent:
+    repo = RepoInfo(
+        id=1,
+        key="github/acme/widgets",
+        name="acme/widgets",
+        owner="acme",
+        repo="widgets",
+        forge="github",
+        clone_url="https://github.com/acme/widgets.git",
+        default_branch="main",
+    )
+    return ChangeEvent(
+        repo=repo, branch="main", commit_sha="a" * 40, pr_number=pr_number
+    )
+
+
+def test_identity_from_push_event() -> None:
+    identity = identity_from_event(change_event(), "default.deploy", 42)
+    assert identity.sub == "repo:github:acme/widgets:ref:refs/heads/main"
+    assert identity.event == "push"
+    assert identity.sha == "a" * 40
+    assert identity.allowed_audiences == ()
+
+
+def test_identity_from_pull_request_event() -> None:
+    # ChangeEvent.branch of a PR is the base branch: it must appear as
+    # base_ref, never as ref/branch.
+    identity = identity_from_event(change_event(pr_number=7), "default.deploy", 42)
+    assert identity.sub == "repo:github:acme/widgets:pull_request"
+    assert identity.branch is None
+    assert identity.base_ref == "refs/heads/main"
+    assert identity.pr_number == 7  # noqa: PLR2004
+
+
+def test_task_tokens_bind_audiences() -> None:
+    tokens = TaskTokens()
+    discovery_token = tokens.issue(1)
+    tokens.bind_audiences(discovery_token, ["aud"])
+    claim = tokens.claim_for(discovery_token)
+    assert claim is not None
+    assert claim.identity is None  # discovery runs never gain an identity
+
+    run_token = tokens.issue(1, identity_from_event(change_event(), "e", 1))
+    tokens.bind_audiences(run_token, ["https://cache.example.com"])
+    claim = tokens.claim_for(run_token)
+    assert claim is not None
+    assert claim.identity is not None
+    assert claim.identity.allowed_audiences == ("https://cache.example.com",)
 
 
 def test_schedule_claims(tmp_path: Path) -> None:

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -51,6 +51,7 @@ from .queries import PAGE_SIZE, BuildFilters, WebQueries
 from .routing import register_owner_convertor
 from .state_routes import create_state_router
 from .templating import STATIC_DIR, CachedStaticFiles, make_env
+from .workload_routes import create_workload_identity_router
 
 if TYPE_CHECKING:
     from ..api_tokens import ApiTokenStore  # noqa: TID252
@@ -61,6 +62,7 @@ if TYPE_CHECKING:
         TokenVault,
     )
     from ..visibility import VisibilityService  # noqa: TID252
+    from ..workload_identity import IdentityIssuer  # noqa: TID252
 
 if TYPE_CHECKING:
     import asyncpg
@@ -691,6 +693,7 @@ def create_app(
     state_dir: Path | None = None,
     log_registry: LogRegistry | None = None,
     task_tokens: TaskTokens | None = None,
+    identity_issuer: IdentityIssuer | None = None,
 ) -> FastAPI:
     broker = EventBroker(pool)
 
@@ -735,6 +738,12 @@ def create_app(
         app.include_router(
             create_state_router(state_dir, task_tokens or TaskTokens()),
             include_in_schema=False,
+        )
+    if identity_issuer is not None:
+        app.include_router(
+            create_workload_identity_router(
+                identity_issuer, task_tokens or TaskTokens()
+            )
         )
     app.include_router(create_api_router(ctx))
     # Last: the legacy catch-alls must not shadow real routes.

--- a/nixbot/nixbot/web/workload_routes.py
+++ b/nixbot/nixbot/web/workload_routes.py
@@ -1,0 +1,76 @@
+"""Workload-identity endpoints: OIDC discovery, JWKS, and the
+per-effect ID token endpoint (see workload_identity.py)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from nixbot.effects_state import TaskClaim, TaskTokens
+    from nixbot.workload_identity import IdentityIssuer
+
+logger = logging.getLogger(__name__)
+
+# Cap per effect run: an effect has no legitimate reason to mint more,
+# even when re-requesting throughout a long deploy.
+MAX_ID_TOKENS_PER_RUN = 100
+
+
+class IdTokenRequest(BaseModel):
+    audience: str
+
+
+def create_workload_identity_router(
+    issuer: IdentityIssuer, tokens: TaskTokens
+) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/.well-known/openid-configuration", include_in_schema=False)
+    async def discovery() -> dict:
+        return issuer.discovery_document()
+
+    @router.get("/.well-known/jwks.json", include_in_schema=False)
+    async def jwks() -> dict:
+        return issuer.jwks()
+
+    def _claim(request: Request) -> TaskClaim:
+        auth = request.headers.get("authorization", "")
+        scheme, _, token = auth.partition(" ")
+        claim = tokens.claim_for(token) if scheme.lower() == "bearer" else None
+        if claim is None:
+            raise HTTPException(status_code=401, detail="invalid task token")
+        return claim
+
+    @router.post("/api/v1/id-token")
+    async def id_token(request: Request, body: IdTokenRequest) -> dict:
+        claim = _claim(request)
+        identity = claim.identity
+        if identity is None:
+            raise HTTPException(
+                status_code=403, detail="this run cannot request identity tokens"
+            )
+        if body.audience not in identity.allowed_audiences:
+            raise HTTPException(
+                status_code=403,
+                detail="audience not declared in the effect's idTokenAudiences",
+            )
+        if claim.id_tokens_issued >= MAX_ID_TOKENS_PER_RUN:
+            raise HTTPException(status_code=429, detail="id token limit reached")
+        claim.id_tokens_issued += 1
+        issued = issuer.mint(identity, body.audience)
+        logger.info(
+            "issued id token",
+            extra={
+                "build_id": identity.build_id,
+                "effect": identity.effect,
+                "repository": identity.repository,
+                "audience": body.audience,
+            },
+        )
+        return {"token": issued.token, "expires_at": issued.expires_at.isoformat()}
+
+    return router

--- a/nixbot/nixbot/web/workload_routes.py
+++ b/nixbot/nixbot/web/workload_routes.py
@@ -35,7 +35,7 @@ def create_workload_identity_router(
 
     @router.get("/.well-known/jwks.json", include_in_schema=False)
     async def jwks() -> dict:
-        return issuer.jwks()
+        return dict(issuer.jwks())
 
     def _claim(request: Request) -> TaskClaim:
         auth = request.headers.get("authorization", "")

--- a/nixbot/nixbot/workload_identity.py
+++ b/nixbot/nixbot/workload_identity.py
@@ -1,0 +1,227 @@
+"""OIDC issuer for effect workload identity.
+
+nixbot mints short-lived RS256 ID tokens for running effects, so they
+can authenticate to relying parties (Vault, AWS, niks3, ...) without
+static deploy secrets. Key handling, the discovery documents, and
+claim construction live here; the HTTP endpoints are in
+web/workload_routes.py and the per-run authorization (which effect may
+request which audience) in effects_state.TaskTokens.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from joserfc import jwt
+from joserfc.jwk import RSAKey
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Relying parties commonly allow only small skew; nbf is backdated so a
+# slightly-behind verifier clock does not reject fresh tokens.
+CLOCK_SKEW = 60
+
+KEY_FILENAME = "workload-identity-key.pem"
+PREVIOUS_KEY_FILENAME = "workload-identity-key.previous.pem"
+
+DEFAULT_TOKEN_TTL = 300
+DEFAULT_ROTATION_INTERVAL = timedelta(days=30)
+
+RSA_KEY_SIZE = 2048
+
+
+@dataclass(frozen=True)
+class EffectIdentity:
+    """What one effect run is, as attested in its ID tokens."""
+
+    forge: str
+    owner: str
+    repo: str
+    # "push" | "pull_request" | "schedule"
+    event: str
+    # Dotted effect name, e.g. "default.deploy".
+    effect: str
+    build_id: int | None = None
+    sha: str | None = None
+    branch: str | None = None
+    pr_number: int | None = None
+    base_ref: str | None = None
+    schedule: str | None = None
+    # Audiences the effect declared via idTokenAudiences. Enforced by
+    # the token endpoint, not by mint().
+    allowed_audiences: tuple[str, ...] = ()
+
+    @property
+    def repository(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+    @property
+    def sub(self) -> str:
+        prefix = f"repo:{self.forge}:{self.repository}"
+        match self.event:
+            case "pull_request":
+                return f"{prefix}:pull_request"
+            case "schedule":
+                return f"{prefix}:schedule:{self.schedule}"
+            case _:
+                return f"{prefix}:ref:refs/heads/{self.branch}"
+
+    def claims(self) -> dict[str, Any]:
+        claims: dict[str, Any] = {
+            "sub": self.sub,
+            "event": self.event,
+            "forge": self.forge,
+            "repository": self.repository,
+            "repository_owner": self.owner,
+            "effect": self.effect,
+        }
+        if self.build_id is not None:
+            claims["build_id"] = self.build_id
+        if self.sha is not None:
+            claims["sha"] = self.sha
+        match self.event:
+            case "push":
+                claims["ref"] = f"refs/heads/{self.branch}"
+            case "pull_request":
+                # No "ref": nixbot stores the PR's *base* branch, which
+                # must not satisfy branch-based relying-party conditions.
+                claims["pr_number"] = self.pr_number
+                if self.base_ref is not None:
+                    claims["base_ref"] = self.base_ref
+            case "schedule":
+                claims["schedule"] = self.schedule
+        return claims
+
+
+@dataclass(frozen=True)
+class IssuedToken:
+    token: str
+    expires_at: datetime
+
+
+class IdentityIssuer:
+    """Signs ID tokens with the current key; retired keys stay in the
+    JWKS so in-flight tokens keep verifying."""
+
+    def __init__(
+        self,
+        issuer_url: str,
+        keys: list[RSAKey],
+        token_ttl: int = DEFAULT_TOKEN_TTL,
+    ) -> None:
+        self.issuer_url = issuer_url.rstrip("/")
+        self._keys = keys
+        self.token_ttl = token_ttl
+
+    @property
+    def _signing_key(self) -> RSAKey:
+        return self._keys[0]
+
+    def jwks(self) -> dict[str, Any]:
+        return {
+            "keys": [key.as_dict(private=False) for key in self._keys],
+        }
+
+    def discovery_document(self) -> dict[str, Any]:
+        return {
+            "issuer": self.issuer_url,
+            "jwks_uri": f"{self.issuer_url}/.well-known/jwks.json",
+            "id_token_signing_alg_values_supported": ["RS256"],
+            "response_types_supported": ["id_token"],
+            "subject_types_supported": ["public"],
+            "claims_supported": [
+                "sub",
+                "aud",
+                "exp",
+                "iat",
+                "iss",
+                "jti",
+                "nbf",
+                "event",
+                "forge",
+                "repository",
+                "repository_owner",
+                "ref",
+                "base_ref",
+                "sha",
+                "pr_number",
+                "schedule",
+                "effect",
+                "build_id",
+            ],
+        }
+
+    def mint(self, identity: EffectIdentity, audience: str) -> IssuedToken:
+        now = int(time.time())
+        expires_at = datetime.fromtimestamp(now + self.token_ttl, tz=UTC)
+        claims = {
+            "iss": self.issuer_url,
+            "aud": audience,
+            "iat": now,
+            "nbf": now - CLOCK_SKEW,
+            "exp": now + self.token_ttl,
+            "jti": secrets.token_urlsafe(16),
+            **identity.claims(),
+        }
+        header = {"alg": "RS256", "kid": self._signing_key.kid, "typ": "JWT"}
+        token = jwt.encode(header, claims, self._signing_key)
+        return IssuedToken(token=token, expires_at=expires_at)
+
+
+def _load_key(pem: bytes) -> RSAKey:
+    key = RSAKey.import_key(pem)
+    key.ensure_kid()
+    return key
+
+
+def _generate_key(path: Path) -> RSAKey:
+    key = RSAKey.generate_key(RSA_KEY_SIZE)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_bytes(key.as_pem(private=True))
+    tmp.chmod(0o600)
+    tmp.rename(path)
+    key.ensure_kid()
+    return key
+
+
+def load_issuer(
+    state_dir: Path,
+    issuer_url: str,
+    *,
+    signing_key_file: Path | None = None,
+    token_ttl: int = DEFAULT_TOKEN_TTL,
+    key_rotation_interval: timedelta = DEFAULT_ROTATION_INTERVAL,
+) -> IdentityIssuer:
+    """The issuer with its current key, generating or rotating the
+    auto-managed key as needed. An operator-provided key is used as-is
+    and never rotated."""
+    if signing_key_file is not None:
+        return IdentityIssuer(
+            issuer_url, [_load_key(signing_key_file.read_bytes())], token_ttl
+        )
+
+    key_file = state_dir / KEY_FILENAME
+    previous_file = state_dir / PREVIOUS_KEY_FILENAME
+    keys: list[RSAKey] = []
+    if key_file.exists():
+        age = datetime.now(tz=UTC) - datetime.fromtimestamp(
+            key_file.stat().st_mtime, tz=UTC
+        )
+        if age > key_rotation_interval:
+            # Rotate: the old key moves to .previous so tokens signed
+            # before the rotation keep verifying until they expire.
+            key_file.replace(previous_file)
+            keys = [_generate_key(key_file), _load_key(previous_file.read_bytes())]
+        else:
+            keys = [_load_key(key_file.read_bytes())]
+            if previous_file.exists():
+                keys.append(_load_key(previous_file.read_bytes()))
+    else:
+        keys = [_generate_key(key_file)]
+    return IdentityIssuer(issuer_url, keys, token_ttl)

--- a/nixbot/nixbot/workload_identity.py
+++ b/nixbot/nixbot/workload_identity.py
@@ -10,6 +10,7 @@ request which audience) in effects_state.TaskTokens.
 
 from __future__ import annotations
 
+import dataclasses
 import secrets
 import time
 from dataclasses import dataclass
@@ -17,10 +18,12 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from joserfc import jwt
-from joserfc.jwk import RSAKey
+from joserfc.jwk import KeySetSerialization, RSAKey
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from .events import ChangeEvent
 
 # Relying parties commonly allow only small skew; nbf is backdated so a
 # slightly-behind verifier clock does not reject fresh tokens.
@@ -98,6 +101,34 @@ class EffectIdentity:
         return claims
 
 
+def identity_from_event(
+    event: ChangeEvent, effect: str, build_id: int
+) -> EffectIdentity:
+    """The identity of one push- or PR-triggered effect run. Audiences
+    are bound later, once the effect derivation is evaluated."""
+    repo = event.repo
+    identity = EffectIdentity(
+        forge=repo.forge,
+        owner=repo.owner,
+        repo=repo.repo,
+        event="push",
+        effect=effect,
+        build_id=build_id,
+        sha=event.commit_sha,
+        branch=event.branch,
+    )
+    if event.pr_number is None:
+        return identity
+    return dataclasses.replace(
+        identity,
+        event="pull_request",
+        pr_number=event.pr_number,
+        branch=None,
+        # ChangeEvent.branch of a PR is the base branch.
+        base_ref=f"refs/heads/{event.branch}",
+    )
+
+
 @dataclass(frozen=True)
 class IssuedToken:
     token: str
@@ -122,7 +153,7 @@ class IdentityIssuer:
     def _signing_key(self) -> RSAKey:
         return self._keys[0]
 
-    def jwks(self) -> dict[str, Any]:
+    def jwks(self) -> KeySetSerialization:
         return {
             "keys": [key.as_dict(private=False) for key in self._keys],
         }

--- a/nixbot/pyproject.toml
+++ b/nixbot/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "asyncpg",
   "jinja2",
   "httpx",
+  "joserfc",
   "zstandard",
   "python-multipart",
   "nixbot-effects"

--- a/nixbot_cli/skill/SKILL.md
+++ b/nixbot_cli/skill/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: nixbot-cli
+description: Inspect and control nixbot CI builds with nbo. Use to find the build for a branch/PR, watch it, list failed attributes, fetch failure logs, restart or cancel builds.
+---
+
+Server: `NIXBOT_URL` or `~/.config/nixbot/hosts.toml`. In a checkout, repo and
+build number are inferred from `origin`/`HEAD`, override with
+`-R [forge/]owner/name` and an explicit build number.
+
+```bash
+nbo build list --branch main
+nbo build view 412                           # status + failed attributes
+nbo build watch 412 [--attr treefmt]         # exit 1 on failure
+nbo log 412                                  # failure summary with log tails
+nbo log 412 checks.x86_64-linux.foo --tail 200   # or --follow
+nbo build restart 412 --attr treefmt         # token: NIXBOT_TOKEN / hosts.toml
+nbo build cancel 412
+nbo effects list | run default.deploy        # local, no token
+```
+
+Attribute args accept unambiguous substrings; `--json [fields]` for
+machine-readable output. `nbo auth status` shows server/token. HTTP API docs at
+`/llms.txt`.

--- a/nixbot_effects/nixbot_effects/options.py
+++ b/nixbot_effects/nixbot_effects/options.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .proc import LogWrite
 
 
@@ -30,6 +32,10 @@ class EffectsOptions:
     task_token: str | None = None
     # Hercules state API + project metadata.
     api_base_url: str | None = None
+    # Called with the audiences the effect declares via idTokenAudiences,
+    # once its derivation is evaluated. The daemon uses it to authorize
+    # the run's task token for the id-token endpoint.
+    bind_id_token_audiences: Callable[[list[str]], None] | None = None
     project_id: str | None = None
     project_path: str | None = None
     # Sandbox configuration.

--- a/nixbot_effects/nixbot_effects/run.py
+++ b/nixbot_effects/nixbot_effects/run.py
@@ -23,6 +23,7 @@ from .proc import stream_command
 from .sandbox import (
     effect_checkout_mount,
     env_args,
+    id_token_audiences,
     pass_as_file_env,
     select_mounts,
     select_secrets,
@@ -124,6 +125,12 @@ async def _run_in_sandbox(
     secrets = dict(select_secrets(drv, opts.secrets or {}, opts))
     bind_mounts = select_mounts(drv, opts)
     env, task_token = task_env(drv_env, opts)
+    audiences = id_token_audiences(drv_env)
+    if audiences and opts.api_base_url and opts.task_token:
+        if opts.bind_id_token_audiences is not None:
+            opts.bind_id_token_audiences(audiences)
+        env["NIXBOT_ID_TOKEN_REQUEST_URL"] = f"{opts.api_base_url}/api/v1/id-token"
+        env["NIXBOT_ID_TOKEN_REQUEST_TOKEN"] = opts.task_token
     uid, gid = virtual_ids(drv_env)
     bwrap = shutil.which("bwrap")
     if bwrap is None:

--- a/nixbot_effects/nixbot_effects/sandbox.py
+++ b/nixbot_effects/nixbot_effects/sandbox.py
@@ -75,6 +75,31 @@ def select_secrets(
     return gather_secrets(secrets_map, secrets, secret_context(opts), opts.git_token)
 
 
+# Audiences the effect may request ID tokens for (JSON list), set by
+# mkEffect's idTokenAudiences argument. Effects without it cannot mint
+# workload-identity tokens.
+ID_TOKEN_AUDIENCES_ATTR = "idTokenAudiences"  # noqa: S105 (attribute name, not a secret)
+
+
+def id_token_audiences(drv_env: dict[str, str]) -> list[str]:
+    """The declared idTokenAudiences of an effect derivation."""
+    raw = drv_env.get(ID_TOKEN_AUDIENCES_ATTR)
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        msg = f"could not parse {ID_TOKEN_AUDIENCES_ATTR} in the derivation: {e}"
+        raise EffectError(msg) from e
+    if not isinstance(parsed, list) or not all(isinstance(a, str) for a in parsed):
+        msg = (
+            f"{ID_TOKEN_AUDIENCES_ATTR} in the derivation must be a JSON "
+            "list of audience strings"
+        )
+        raise EffectError(msg)
+    return parsed
+
+
 # Effect derivations opt into the runner-prepared repository clone by
 # setting this environment attribute to true.
 EFFECT_CHECKOUT_ATTR = "__nixbot_effect_checkout"

--- a/nixbot_effects/nixbot_effects/tests/test_secrets.py
+++ b/nixbot_effects/nixbot_effects/tests/test_secrets.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 from nixbot_effects import EffectError
 from nixbot_effects.options import EffectsOptions
 from nixbot_effects.sandbox import (
+    id_token_audiences,
     pass_as_file_env,
     sandbox_env,
     select_mounts,
@@ -74,6 +75,16 @@ def test_parse_secrets_map() -> None:
     assert parse_secrets_map({"secretsMap": "{}"}) == {}
     with pytest.raises(SecretsError):
         parse_secrets_map({"secretsMap": json.dumps({"x": {"type": "wat"}})})
+
+
+def test_id_token_audiences() -> None:
+    assert id_token_audiences({}) == []
+    assert id_token_audiences(
+        {"idTokenAudiences": json.dumps(["sts.amazonaws.com"])}
+    ) == ["sts.amazonaws.com"]
+    for bad in ("not json", json.dumps("aud"), json.dumps([1])):
+        with pytest.raises(EffectError, match="idTokenAudiences"):
+            id_token_audiences({"idTokenAudiences": bad})
 
 
 def _opts() -> EffectsOptions:

--- a/nixosModules/nixbot.nix
+++ b/nixosModules/nixbot.nix
@@ -124,6 +124,13 @@ let
             mapping = cfg.oidc.mapping;
             client_secret_file = "oidc-client-secret";
           };
+      workload_identity = {
+        enable = cfg.workloadIdentity.enable;
+        signing_key_file =
+          if cfg.workloadIdentity.signingKeyFile != null then "workload-identity-key" else null;
+        token_ttl = cfg.workloadIdentity.tokenTtl;
+        key_rotation_days = cfg.workloadIdentity.keyRotationDays;
+      };
       outputs_path = cfg.outputsPath;
       post_build_steps = map (step: {
         name = step.name;
@@ -601,6 +608,41 @@ in
       };
     };
 
+    workloadIdentity = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Serve OIDC discovery/JWKS documents and mint short-lived ID
+          tokens for effects that declare idTokenAudiences, so they can
+          authenticate to relying parties (Vault, AWS, niks3, ...)
+          without static secrets. See docs/WORKLOAD_IDENTITY.md.
+        '';
+      };
+
+      signingKeyFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          RSA private key (PEM) used to sign ID tokens. When unset, a
+          key is generated in the state directory and rotated
+          automatically.
+        '';
+      };
+
+      tokenTtl = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 300;
+        description = "Lifetime of issued ID tokens in seconds.";
+      };
+
+      keyRotationDays = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 30;
+        description = "Rotation interval of the auto-generated signing key.";
+      };
+    };
+
     pullBased = {
       repositories = lib.mkOption {
         default = { };
@@ -983,6 +1025,9 @@ in
             cfg.gitlab.enable && cfg.gitlab.sshPrivateKeyFile != null
           ) "gitlab-ssh-key:${cfg.gitlab.sshPrivateKeyFile}"
           ++ lib.optional cfg.oidc.enable "oidc-client-secret:${cfg.oidc.clientSecretFile}"
+          ++ lib.optional (
+            cfg.workloadIdentity.signingKeyFile != null
+          ) "workload-identity-key:${cfg.workloadIdentity.signingKeyFile}"
           ++ lib.optional (
             !cfg.database.createLocally && cfg.database.urlFile != null
           ) "db-url:${cfg.database.urlFile}"

--- a/packages/nixbot-cli.nix
+++ b/packages/nixbot-cli.nix
@@ -26,6 +26,13 @@ buildPythonPackage {
     "--prefix PATH : ${lib.makeBinPath [ bubblewrap ]}"
   ];
 
+  # Ship the agent skill definition alongside the CLI so tools like
+  # mics-skills' home-manager modules can symlink it from the package.
+  postInstall = ''
+    mkdir -p $out/share/skills
+    cp -r ${./../nixbot_cli/skill} $out/share/skills/nixbot-cli
+  '';
+
   # The CLI tests live in the server's suite (nixbot.passthru.tests.pytest)
   # because they run against the real web app.
 

--- a/packages/nixbot.nix
+++ b/packages/nixbot.nix
@@ -15,6 +15,7 @@
   asyncpg,
   jinja2,
   httpx,
+  joserfc,
   zstandard,
   python-multipart,
   postgresql,
@@ -44,6 +45,7 @@ buildPythonPackage (finalAttrs: {
     asyncpg
     jinja2
     httpx
+    joserfc
     zstandard
     python-multipart
     nixbot-effects


### PR DESCRIPTION
CI pipelines on GitHub/GitLab/Forgejo provide OIDC identities that allow authenticating against external systems without hard-coded secrets.

This feature now allows the same for CI effects: nixbot acts as an OIDC issuer and mints short-lived ID tokens for effects that opt in via `idTokenAudiences`. See docs/WORKLOAD_IDENTITY.md for claims, key handling and relying-party setup.

## Example: deploy over SSH without a stored deploy key

The effect trades its ID token for a short-lived SSH certificate from OpenBao/Vault's SSH CA and deploys with it. No deploy key lives in CI, and only main-branch effects of this repo can get a certificate.

```nix
effects-lib.mkEffect {
  name = "deploy";
  idTokenAudiences = [ "https://vault.example.com" ];
  inputs = [ pkgs.openbao pkgs.openssh ];
  effectScript = ''
    export VAULT_ADDR=https://vault.example.com

    # Authenticate to Vault with the nixbot-issued identity token.
    vault write -field=token auth/jwt/login \
      role=deploy jwt="$(nixbot-id-token https://vault.example.com)" > ~/.vault-token

    # Get a short-lived SSH certificate for the deploy user.
    ssh-keygen -t ed25519 -N "" -f ./id_deploy
    vault write -field=signed_key ssh/sign/deploy \
      public_key=@./id_deploy.pub valid_principals=deploy > ./id_deploy-cert.pub

    export NIX_SSHOPTS="-i ./id_deploy -o CertificateFile=./id_deploy-cert.pub"
    nixos-rebuild switch --flake .#web01 \
      --target-host deploy@web01.example.com \
      --use-remote-sudo
  '';
}
```

`nixbot-id-token <audience>` prints the signed JWT; `--json` prints the raw endpoint response:

```json
{"token":"eyJhbGciOiJSUzI1NiIsImtpZCI6...","expires_at":"2026-07-29T06:25:41+00:00"}
```

Vault side: trust nixbot as JWT issuer and pin the role to this repo's main branch, so PR-triggered effects (which carry no `ref` claim) can never obtain a certificate.

```
vault write auth/jwt/config oidc_discovery_url=https://ci.example.com
vault write auth/jwt/role/deploy \
  role_type=jwt user_claim=sub \
  bound_audiences=https://vault.example.com \
  bound_subject=repo:github:acme/infra:ref:refs/heads/main \
  token_policies=ssh-deploy token_ttl=5m

vault secrets enable ssh
vault write ssh/config/ca generate_signing_key=true
vault write ssh/roles/deploy \
  key_type=ca allow_user_certificates=true \
  allowed_users=deploy default_user=deploy ttl=10m
```
