### PR TITLE
web: surface expired forge access as a page-level banner

### DIFF
--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -465,6 +465,45 @@ class _StubVisibility:
         self.seen_users.append(user)
         return self.visible
 
+    async def toggleable_repo_ids(
+        self,
+        user: object,  # noqa: ARG002
+        token: object = None,  # noqa: ARG002
+    ) -> list[int]:
+        return []
+
+    async def controllable_repo_ids(
+        self,
+        user: object,  # noqa: ARG002
+        token: object = None,  # noqa: ARG002
+    ) -> list[int]:
+        return []
+
+
+def test_expired_forge_token_shows_relogin_banner(client: WebHarness) -> None:
+    """When the forge token is gone but the session cookie is still
+    valid, private repos silently disappear. The page must call this
+    out prominently with a re-login link, not only inside the account
+    menu (issue #105)."""
+    ctx = client.ctx
+    ctx.visibility = cast("VisibilityService", _StubVisibility([]))
+    ctx.forge_tokens = ForgeTokenStore(ctx.pool)
+    try:
+        page = client.get("/", user=User(provider="github", username="alice"))
+        assert page.status_code == 200
+        assert 'class="banner banner-warning"' in page.text
+        assert 'href="/login/github"' in page.text
+
+        # With a live forge token the banner must not show.
+        page = client.get(
+            "/", user=User(provider="github", username="alice"), token="tok"
+        )
+        assert 'class="banner banner-warning"' not in page.text
+    finally:
+        ctx.visibility = None
+        ctx.forge_tokens = None
+        client.run(ctx.pool.execute("DELETE FROM forge_tokens"))
+
 
 def test_legacy_redirect_hides_invisible_projects(client: WebHarness) -> None:
     """Redirect-vs-404 must not let anonymous users probe private

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -477,6 +477,24 @@ details.menu summary:hover {
 details.menu .menu-label {
 	font-size: 0.9rem;
 }
+.banner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: 0.6rem;
+	margin: 0.8rem auto 0;
+	max-width: calc(90rem - 2.5rem);
+	padding: 0.6rem 1rem;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	background: var(--card);
+}
+
+.banner-warning {
+	border-left: 4px solid var(--warn);
+}
+
 .menu-panel {
 	position: absolute;
 	right: 0;

--- a/nixbot/nixbot/web/templates/base.html
+++ b/nixbot/nixbot/web/templates/base.html
@@ -43,9 +43,6 @@
           <div class="menu-panel">
             {% if user %}
               <span class="muted">{{ user.qualified }}</span>
-              {% if forge_token_expired %}
-                <span class="muted">forge access expired — log in again to see private repos</span>
-              {% endif %}
               <a href="/settings">settings</a>
               <form action="/logout" method="post">
                 <button>logout</button>
@@ -74,6 +71,19 @@
         </details>
       {% endif %}
     </header>
+    {% if forge_token_expired %}
+      {% set provider_keys = login_providers | map(attribute="key") | list %}
+      {% set relogin_key = "oidc" if user.provider.startswith("oidc") else user.provider %}
+      {% if relogin_key not in provider_keys and provider_keys %}
+        {% set relogin_key = provider_keys[0] %}
+      {% endif %}
+      <div class="banner banner-warning" role="alert">
+        <span>Your forge access has expired — private repositories and controls are hidden.</span>
+        {% if relogin_key %}
+          <a class="login-btn" href="/login/{{ relogin_key }}">Log in again</a>
+        {% endif %}
+      </div>
+    {% endif %}
     {% block body %}
     {% endblock body %}
     <footer class="site-footer muted">


### PR DESCRIPTION

The forge token can expire long before the 30-day session cookie
does. Private repositories then silently disappear while the header
still shows the user as logged in; the only hint was a muted note
hidden inside the account dropdown, which is easy to miss.

Show a prominent warning banner below the header instead, with a
"Log in again" button that points at the user's original login
provider so one click restores private-repo visibility.

Fixes #105
