### PR TITLE
nixbot: expose structured PR diff to flake evaluation

### DIFF
--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -164,7 +164,7 @@ def _eval_settings(
         netrc_file = credentials.netrc_file
     # Arguments hercules-ci-agent passes to the flake's herculesCI
     # function; tag is unknown here (builds are branch/PR driven).
-    primary_repo = {
+    primary_repo: dict[str, Any] = {
         "name": event.repo.repo,
         "owner": event.repo.owner,
         "branch": event.branch,
@@ -175,6 +175,27 @@ def _eval_settings(
         "remoteHttpUrl": event.repo.clone_url,
         "forgeType": event.repo.forge,
     }
+    if event.pr_number is not None and event.pr_diff is not None:
+        diff = event.pr_diff
+        primary_repo["pullRequest"] = {
+            "number": event.pr_number,
+            "baseRev": diff.base_rev,
+            "mergedRev": diff.merged_rev,
+            "diff": {
+                "complete": diff.complete,
+                "fileCount": diff.file_count,
+                "reason": diff.reason,
+                "files": [
+                    {
+                        "status": changed.status,
+                        "path": changed.path,
+                        "previousPath": changed.previous_path,
+                        "score": changed.score,
+                    }
+                    for changed in diff.files
+                ],
+            },
+        }
     hercules_args = {"primaryRepo": primary_repo, **primary_repo}
     return EvalSettings(
         gc_roots_dir=o.gcroots_dir(build),

--- a/nixbot/nixbot/events.py
+++ b/nixbot/nixbot/events.py
@@ -8,7 +8,7 @@ build pipeline.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -33,6 +33,43 @@ class RepoInfo:
 
 
 @dataclass(frozen=True)
+class ChangedFile:
+    """One base-to-merged-tree path change for a pull request."""
+
+    status: Literal[
+        "added",
+        "modified",
+        "deleted",
+        "renamed",
+        "copied",
+        "type_changed",
+        "unmerged",
+        "unknown",
+        "broken_pairing",
+    ]
+    path: str
+    previous_path: str | None = None
+    score: int | None = None
+
+
+@dataclass(frozen=True)
+class PullRequestDiff:
+    """Pure PR diff metadata exposed to the flake evaluator.
+
+    complete=False is an explicit instruction to use the consumer's full
+    fallback. It bounds evaluator arguments and fails closed for path encodings
+    that cannot be represented losslessly in JSON/Nix strings.
+    """
+
+    base_rev: str
+    merged_rev: str
+    complete: bool
+    file_count: int
+    files: tuple[ChangedFile, ...] = ()
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
 class ChangeEvent:
     """A push or pull-request event from a forge or poller."""
 
@@ -43,6 +80,7 @@ class ChangeEvent:
     pr_number: int | None = None
     pr_author: str | None = None
     base_sha: str | None = None
+    pr_diff: PullRequestDiff | None = None
     commit_message: str = ""
 
 

--- a/nixbot/nixbot/gitrepo.py
+++ b/nixbot/nixbot/gitrepo.py
@@ -31,6 +31,7 @@ from typing import Protocol
 from urllib.parse import urlsplit
 
 from .environ import passthrough_env
+from .events import ChangedFile, PullRequestDiff
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,10 @@ PR_REF_MAX_AGE = 90 * 86400
 # Crash-leaked plain files next to worktrees (e.g. effects side-files)
 # are swept once clearly older than any running build.
 ORPHAN_FILE_MAX_AGE = 86400
+# Keep the JSON embedded in nix-eval-jobs' --select argument comfortably below
+# platform argv limits. Consumers must run their full fallback when incomplete.
+MAX_PR_DIFF_FILES = 4096
+MAX_PR_DIFF_PATH_BYTES = 128 * 1024
 
 
 def pr_refspec(forge: str, pr_number: int) -> str:
@@ -191,12 +196,101 @@ def _worktree_paths(porcelain_output: str) -> set[Path]:
     }
 
 
+_DIFF_STATUS = {
+    "A": "added",
+    "M": "modified",
+    "D": "deleted",
+    "R": "renamed",
+    "C": "copied",
+    "T": "type_changed",
+    "U": "unmerged",
+    "X": "unknown",
+    "B": "broken_pairing",
+}
+
+
+def _parse_pull_request_diff(
+    base_rev: str, merged_rev: str, output: bytes
+) -> PullRequestDiff:
+    fields = output.removesuffix(b"\0").split(b"\0") if output else []
+    changes: list[ChangedFile] = []
+    path_bytes = 0
+    index = 0
+    try:
+        while index < len(fields):
+            token = fields[index].decode("ascii")
+            index += 1
+            code = token[:1]
+            if code not in _DIFF_STATUS or index >= len(fields):
+                return PullRequestDiff(
+                    base_rev=base_rev,
+                    merged_rev=merged_rev,
+                    complete=False,
+                    file_count=len(changes),
+                    reason="unrepresentable_or_malformed_path",
+                )
+            first_raw = fields[index]
+            index += 1
+            path_bytes += len(first_raw)
+            first = first_raw.decode("utf-8")
+            previous_path = None
+            path = first
+            score = int(token[1:]) if token[1:].isdigit() else None
+            if code in ("R", "C"):
+                if index >= len(fields):
+                    return PullRequestDiff(
+                        base_rev=base_rev,
+                        merged_rev=merged_rev,
+                        complete=False,
+                        file_count=len(changes),
+                        reason="unrepresentable_or_malformed_path",
+                    )
+                second_raw = fields[index]
+                index += 1
+                path_bytes += len(second_raw)
+                previous_path = first
+                path = second_raw.decode("utf-8")
+            changes.append(
+                ChangedFile(
+                    status=_DIFF_STATUS[code],  # type: ignore[arg-type]
+                    path=path,
+                    previous_path=previous_path,
+                    score=score,
+                )
+            )
+    except UnicodeDecodeError:
+        return PullRequestDiff(
+            base_rev=base_rev,
+            merged_rev=merged_rev,
+            complete=False,
+            file_count=len(changes),
+            reason="unrepresentable_or_malformed_path",
+        )
+    if len(changes) > MAX_PR_DIFF_FILES or path_bytes > MAX_PR_DIFF_PATH_BYTES:
+        return PullRequestDiff(
+            base_rev=base_rev,
+            merged_rev=merged_rev,
+            complete=False,
+            file_count=len(changes),
+            reason="diff_too_large",
+        )
+    return PullRequestDiff(
+        base_rev=base_rev,
+        merged_rev=merged_rev,
+        complete=True,
+        file_count=len(changes),
+        files=tuple(changes),
+    )
+
+
 @dataclass
 class Worktree:
     """A per-build checkout backed by a project's central clone."""
 
     path: Path
     clone_path: Path
+    # Immutable commit checked out before an optional PR merge.
+    base_revision: str | None = None
 
     async def rev_parse(self, rev: str) -> str:
         return (await run_git(["rev-parse", rev], cwd=self.path)).strip()
@@ -207,6 +301,42 @@ class Worktree:
 
     async def commit_message(self, rev: str = "HEAD") -> str:
         return await run_git(["log", "-1", "--format=%B", rev], cwd=self.path)
+
+    async def pull_request_diff(self) -> PullRequestDiff | None:
+        """Structured base-to-merged-tree diff for a PR worktree.
+
+        NUL-delimited output handles whitespace, quotes, tabs, and newlines in
+        filenames without shell parsing. Invalid UTF-8 cannot round-trip through
+        JSON/Nix strings, so it produces an explicit incomplete manifest.
+        """
+        if self.base_revision is None:
+            return None
+        merged_rev = await self.rev_parse("HEAD")
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            "--find-copies",
+            "--find-copies-harder",
+            self.base_revision,
+            merged_rev,
+            "--",
+            cwd=self.path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            raise GitError(
+                ["diff", self.base_revision, merged_rev],
+                proc.returncode or -1,
+                stderr.decode(errors="replace"),
+            )
+        return _parse_pull_request_diff(self.base_revision, merged_rev, stdout)
 
     async def merge(
         self, head_sha: str, credentials: FetchCredentials | None = None
@@ -468,6 +598,7 @@ class RepoManager:
             project_key, worktree_id, base_commit, credentials
         )
         try:
+            worktree.base_revision = await worktree.rev_parse("HEAD")
             if head_commit is not None and head_commit != base_commit:
                 await worktree.merge(head_commit, credentials)
             # .gitmodules is PR-controlled: with the primary repo's

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -15,7 +15,7 @@ import logging
 import shutil
 import uuid
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Protocol
 
 from . import (
@@ -240,6 +240,14 @@ class Orchestrator:
             return build
 
         try:
+            if event.pr_number is not None and event.base_sha is not None:
+                pr_diff = await worktree.pull_request_diff()
+                if pr_diff is not None:
+                    event = replace(
+                        event,
+                        base_sha=pr_diff.base_rev,
+                        pr_diff=pr_diff,
+                    )
             tree_hash = await worktree.tree_hash()
             build, created = await db.get_or_create_build(
                 self.pool,

--- a/nixbot/nixbot/tests/test_gitrepo.py
+++ b/nixbot/nixbot/tests/test_gitrepo.py
@@ -17,6 +17,7 @@ from nixbot.gitrepo import (
     MergeConflictError,
     RepoManager,
     StaticCredentialsProvider,
+    _parse_pull_request_diff,
     run_git,
 )
 
@@ -94,6 +95,59 @@ async def test_pr_merge_and_tree_hash_dedup(
     tree2 = await wt2.tree_hash()
     await manager.remove_worktree(wt2)
     assert tree1 == tree2
+
+
+async def test_pr_diff_represents_paths_and_change_kinds(
+    manager: RepoManager, upstream: Path
+) -> None:
+    for name, content in {
+        "modified.txt": "before\n",
+        "deleted.txt": "delete me\n",
+        "old name.txt": "rename me\n",
+        "copy-source.txt": "copy me\n",
+    }.items():
+        (upstream / name).write_text(content)
+    git(upstream, "add", ".")
+    git(upstream, "commit", "-m", "diff base")
+    base = git(upstream, "rev-parse", "HEAD")
+
+    git(upstream, "checkout", "-b", "pr-diff")
+    (upstream / "modified.txt").write_text("after\n")
+    (upstream / "deleted.txt").unlink()
+    (upstream / "old name.txt").rename(upstream / "renamed name.txt")
+    shutil.copyfile(upstream / "copy-source.txt", upstream / "copied name.txt")
+    unusual = 'space tab\tquote" newline\n.txt'
+    (upstream / unusual).write_text("odd\n")
+    git(upstream, "add", "-A")
+    git(upstream, "commit", "-m", "mixed changes")
+    head = git(upstream, "rev-parse", "HEAD")
+    git(upstream, "checkout", "main")
+    await fetch(manager, upstream)
+
+    wt = await manager.checkout_for_build(
+        KEY, "diff", base_commit=base, head_commit=head
+    )
+    diff = await wt.pull_request_diff()
+    assert diff is not None
+    assert diff.complete
+    assert diff.base_rev == base
+    assert diff.merged_rev == await wt.rev_parse("HEAD")
+    by_path = {change.path: change for change in diff.files}
+    assert by_path["modified.txt"].status == "modified"
+    assert by_path["deleted.txt"].status == "deleted"
+    assert by_path["renamed name.txt"].status == "renamed"
+    assert by_path["renamed name.txt"].previous_path == "old name.txt"
+    assert by_path["copied name.txt"].status == "copied"
+    assert by_path["copied name.txt"].previous_path == "copy-source.txt"
+    assert by_path[unusual].status == "added"
+    await manager.remove_worktree(wt)
+
+
+def test_pr_diff_falls_back_for_unrepresentable_path() -> None:
+    diff = _parse_pull_request_diff("base", "merged", b"M\0bad-\xff\0")
+    assert not diff.complete
+    assert diff.reason == "unrepresentable_or_malformed_path"
+    assert diff.files == ()
 
 
 async def test_merge_conflict_raises(manager: RepoManager, upstream: Path) -> None:

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -21,6 +21,7 @@ from nixbot.memory import (
     calculate_eval_workers,
     get_memory_info,
 )
+from nixbot.models import NixEvalJobSuccess
 from nixbot.nix_eval import (
     EvalError,
     EvalRunner,
@@ -298,6 +299,134 @@ async def test_eval_runner_hercules_ci_jobs(tmp_path: Path) -> None:
         "default.checks.x86_64-linux.ok": "ok-abcdef1",
         "docs.site": "site",
     }
+
+
+@pytest.mark.skipif(
+    shutil.which("nix-eval-jobs") is None or shutil.which("nix") is None,
+    reason="nix-eval-jobs not available",
+)
+async def test_pr_diff_overlay_replaces_full_checks_without_their_closure(
+    tmp_path: Path,
+) -> None:
+    """A consumer can keep status paths while replacing every expensive
+    leaf and aggregate. Unrelated configured checks remain scheduled."""
+    flake = tmp_path / "repo"
+    flake.mkdir()
+    (flake / "flake.nix").write_text(
+        """
+        {
+          outputs = { self }:
+            let
+              fullInput = derivation {
+                name = "full-test-input";
+                system = "x86_64-linux";
+                builder = "/bin/sh";
+                args = [ "-c" "echo full > $out" ];
+              };
+              fullShard = derivation {
+                name = "full-web-unit-1";
+                system = "x86_64-linux";
+                builder = "/bin/sh";
+                args = [ "-c" "cat ${fullInput} > $out" ];
+              };
+              fullAggregate = derivation {
+                name = "full-web-unit";
+                system = "x86_64-linux";
+                builder = "/bin/sh";
+                args = [ "-c" "test -e ${fullShard}; touch $out" ];
+              };
+            in {
+              checks.x86_64-linux = {
+                web-unit-1 = fullShard;
+                web-unit = fullAggregate;
+                worker-unit = derivation {
+                  name = "worker-unit-full";
+                  system = "x86_64-linux";
+                  builder = "/bin/sh";
+                  args = [ "-c" "touch $out" ];
+                };
+              };
+              herculesCI = { primaryRepo, ... }:
+                let
+                  manifest = builtins.toFile "pr-diff.json"
+                    (builtins.toJSON primaryRepo.pullRequest.diff);
+                  selectiveShard = derivation {
+                    name = "selective-web-unit-1";
+                    system = "x86_64-linux";
+                    builder = "/bin/sh";
+                    args = [ "-c" "cp ${manifest} $out" ];
+                  };
+                in {
+                  onPush.default.outputs.checks.x86_64-linux = {
+                    web-unit-1 = selectiveShard;
+                    web-unit = derivation {
+                      name = "selective-web-unit";
+                      system = "x86_64-linux";
+                      builder = "/bin/sh";
+                      args = [ "-c" "test -e ${selectiveShard}; touch $out" ];
+                    };
+                  };
+                };
+            };
+        }
+        """
+    )
+
+    def settings(path: str) -> EvalSettings:
+        pull_request = {
+            "number": 7,
+            "baseRev": "base",
+            "mergedRev": "merged",
+            "diff": {
+                "complete": True,
+                "fileCount": 1,
+                "reason": None,
+                "files": [
+                    {
+                        "status": "modified",
+                        "path": path,
+                        "previousPath": None,
+                        "score": None,
+                    }
+                ],
+            },
+        }
+        primary_repo = {
+            "rev": "abcdef1234567",
+            "shortRev": "abcdef1",
+            "pullRequest": pull_request,
+        }
+        return EvalSettings(
+            gc_roots_dir=tmp_path / f"gcroots-{len(path)}",
+            sandbox=False,
+            systemd_scope=False,
+            hercules_args={"primaryRepo": primary_repo, **primary_repo},
+        )
+
+    first = await EvalRunner().run(flake, BranchConfig(), settings("web/a.ts"))
+    assert all(isinstance(job, NixEvalJobSuccess) for job in first.jobs)
+    jobs = {job.attr: job for job in first.jobs if isinstance(job, NixEvalJobSuccess)}
+    assert {attr: job.name for attr, job in jobs.items()} == {
+        "default.checks.x86_64-linux.web-unit": "selective-web-unit",
+        "default.checks.x86_64-linux.web-unit-1": "selective-web-unit-1",
+        "default.checks.x86_64-linux.worker-unit": "worker-unit-full",
+    }
+    for attr in (
+        "default.checks.x86_64-linux.web-unit",
+        "default.checks.x86_64-linux.web-unit-1",
+    ):
+        assert all("full-test-input" not in path for path in jobs[attr].needed_builds)
+        assert all("full-web-unit" not in path for path in jobs[attr].needed_builds)
+
+    second = await EvalRunner().run(flake, BranchConfig(), settings("web/b.ts"))
+    assert all(isinstance(job, NixEvalJobSuccess) for job in second.jobs)
+    second_jobs = {
+        job.attr: job for job in second.jobs if isinstance(job, NixEvalJobSuccess)
+    }
+    assert (
+        jobs["default.checks.x86_64-linux.web-unit-1"].drv_path
+        != second_jobs["default.checks.x86_64-linux.web-unit-1"].drv_path
+    )
 
 
 async def test_stderr_noise_filtered_and_warnings_reach_callback(

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -1026,6 +1026,87 @@ async def test_eval_settings_wired(
         orchestrator.config.eval_max_memory_size, 1234
     )
     assert settings.netrc_file == netrc
+    assert "pullRequest" not in settings.hercules_args["primaryRepo"]
+
+
+async def test_pr_diff_is_exposed_in_hercules_args(
+    make_env: EnvFactory, upstream: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def no_prefetch(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(build_run_mod, "_prefetch_inputs", no_prefetch)
+    (upstream / "a-source.nix").write_text("{ changed = false; }\n")
+    git(upstream, "add", "a-source.nix")
+    git(upstream, "commit", "-m", "base source")
+    base = git(upstream, "rev-parse", "HEAD")
+    git(upstream, "checkout", "-b", "pr-diff-args")
+    unusual = 'odd tab\tquote" newline\n.nix'
+    (upstream / unusual).write_text("{}\n")
+    (upstream / "a-source.nix").write_text("{ changed = true; }\n")
+    git(upstream, "add", "-A")
+    git(upstream, "commit", "-m", "diffargs")
+    head = git(upstream, "rev-parse", "HEAD")
+    git(upstream, "update-ref", "refs/pull/12/head", head)
+    git(upstream, "checkout", "main")
+    git(upstream, "branch", "-D", "pr-diff-args")
+
+    eval_runner = FakeEvalRunner([mk_job("a")])
+    orchestrator, _, project = await make_env(eval_runner, FakeExecutor(), "diffargs")
+    await orchestrator.handle_change_event(
+        ChangeEvent(
+            repo=project,
+            branch="main",
+            commit_sha=head,
+            pr_number=12,
+            base_sha=base,
+        )
+    )
+    settings = eval_runner.last_settings
+    assert settings is not None
+    pr = settings.hercules_args["primaryRepo"]["pullRequest"]
+    assert pr["number"] == 12
+    assert pr["baseRev"] == base
+    assert pr["mergedRev"] != head
+    assert pr["diff"] == {
+        "complete": True,
+        "fileCount": 2,
+        "reason": None,
+        "files": [
+            {
+                "status": "modified",
+                "path": "a-source.nix",
+                "previousPath": None,
+                "score": None,
+            },
+            {
+                "status": "added",
+                "path": unusual,
+                "previousPath": None,
+                "score": None,
+            },
+        ],
+    }
+    # The compatibility aliases receive the same optional structure.
+    assert settings.hercules_args["pullRequest"] == pr
+
+    # A missing base must not be misrepresented as an empty head-to-head diff.
+    # Omitting the metadata makes consumers take their full fallback.
+    missing_base_runner = FakeEvalRunner([mk_job("a")])
+    missing_base_orchestrator, _, missing_base_project = await make_env(
+        missing_base_runner, FakeExecutor(), "missing-base"
+    )
+    await missing_base_orchestrator.handle_change_event(
+        ChangeEvent(
+            repo=missing_base_project,
+            branch="main",
+            commit_sha=head,
+            pr_number=13,
+        )
+    )
+    missing_base_settings = missing_base_runner.last_settings
+    assert missing_base_settings is not None
+    assert "pullRequest" not in missing_base_settings.hercules_args["primaryRepo"]
 
 
 async def test_eval_netrc_withheld_from_pr_with_instance_wide_creds(


### PR DESCRIPTION
## Summary

Expose optional, structured base-to-merged-tree PR diff metadata through the existing Hercules arguments.

For PR builds with a usable base, primaryRepo.pullRequest now contains:

- PR number
- immutable base revision
- merged revision
- a structured diff with status, path, previous path, and similarity score

Non-PR builds and PR builds without a base keep the existing argument shape, making the extension backward compatible.

## Motivation

Nix derivations receive store sources without the evaluator worktree Git directory. Flakes therefore cannot implement correct PR-affected checks from primaryRepo.rev alone. Passing the actual diff as evaluator data lets a flake turn it into an explicit pure manifest input and overlay selective derivations at its existing check paths.

## Safety

- computes the diff after the real base checkout and no-ff merge
- uses NUL-delimited git output without shell parsing
- handles whitespace, quotes, tabs, and newlines in filenames
- represents additions, modifications, deletions, renames, copies, type changes, and exceptional Git statuses
- marks invalid UTF-8, malformed, oversized, or missing-base diffs incomplete or absent so consumers can run a full fallback
- does not add dependencies

## Scheduling proof

The evaluator test overlays selective shard and aggregate derivations at the same configured check paths. It verifies that:

- check names are preserved
- unoverridden configured checks remain scheduled
- replaced jobs do not retain the original full-test derivation closure
- changing the serialized diff changes the selective derivation path

## Validation

- focused pytest set: 47 passed
- affected orchestration test rerun after missing-base hardening: passed
- Ruff: passed
- MyPy: passed
- git diff --check: passed