### PR TITLE
web: allow proxy users to create tokens

### DIFF
--- a/nixbot/nixbot/tests/test_auth.py
+++ b/nixbot/nixbot/tests/test_auth.py
@@ -560,7 +560,7 @@ async def test_oauth_callback_filters_session_groups() -> None:
 
 
 async def test_proxy_auth_header() -> None:
-    """The proxy auth header authenticates request and interactive users."""
+    """The proxy auth header authenticates users through request_user."""
     app = FastAPI()
     signer = SessionSigner([b"k" * 32])
     ctx = WebContext(pool=AsyncMock(), signer=signer)
@@ -575,13 +575,6 @@ async def test_proxy_auth_header() -> None:
             return JSONResponse({"user": None})
         return JSONResponse({"user": user.qualified})
 
-    @app.get("/interactive")
-    async def interactive(request: Request) -> JSONResponse:
-        user = await ctx.interactive_user(request)
-        if user is None:
-            return JSONResponse({"user": None})
-        return JSONResponse({"user": user.qualified})
-
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -592,9 +585,6 @@ async def test_proxy_auth_header() -> None:
 
         # With the header, the user is authenticated as proxy:alice.
         resp = await client.get("/me", headers={"X-Remote-User": "alice"})
-        assert resp.status_code == 200
-        assert resp.json()["user"] == "proxy:alice"
-        resp = await client.get("/interactive", headers={"X-Remote-User": "alice"})
         assert resp.status_code == 200
         assert resp.json()["user"] == "proxy:alice"
 
@@ -613,12 +603,6 @@ async def test_proxy_auth_header() -> None:
         cookie = signer.session_for(User(provider="github", username="bob"))
         client.cookies.set(SESSION_COOKIE, cookie)
         resp = await client.get("/me", headers={"X-Remote-User": "alice"})
-        client.cookies.clear()
-        assert resp.status_code == 200
-        assert resp.json()["user"] == "github:bob"
-
-        client.cookies.set(SESSION_COOKIE, cookie)
-        resp = await client.get("/interactive", headers={"X-Remote-User": "alice"})
         client.cookies.clear()
         assert resp.status_code == 200
         assert resp.json()["user"] == "github:bob"

--- a/nixbot/nixbot/tests/test_auth.py
+++ b/nixbot/nixbot/tests/test_auth.py
@@ -560,7 +560,7 @@ async def test_oauth_callback_filters_session_groups() -> None:
 
 
 async def test_proxy_auth_header() -> None:
-    """The proxy auth header authenticates users through _request_user."""
+    """The proxy auth header authenticates request and interactive users."""
     app = FastAPI()
     signer = SessionSigner([b"k" * 32])
     ctx = WebContext(pool=AsyncMock(), signer=signer)
@@ -575,6 +575,13 @@ async def test_proxy_auth_header() -> None:
             return JSONResponse({"user": None})
         return JSONResponse({"user": user.qualified})
 
+    @app.get("/interactive")
+    async def interactive(request: Request) -> JSONResponse:
+        user = await ctx.interactive_user(request)
+        if user is None:
+            return JSONResponse({"user": None})
+        return JSONResponse({"user": user.qualified})
+
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -585,6 +592,9 @@ async def test_proxy_auth_header() -> None:
 
         # With the header, the user is authenticated as proxy:alice.
         resp = await client.get("/me", headers={"X-Remote-User": "alice"})
+        assert resp.status_code == 200
+        assert resp.json()["user"] == "proxy:alice"
+        resp = await client.get("/interactive", headers={"X-Remote-User": "alice"})
         assert resp.status_code == 200
         assert resp.json()["user"] == "proxy:alice"
 
@@ -603,6 +613,12 @@ async def test_proxy_auth_header() -> None:
         cookie = signer.session_for(User(provider="github", username="bob"))
         client.cookies.set(SESSION_COOKIE, cookie)
         resp = await client.get("/me", headers={"X-Remote-User": "alice"})
+        client.cookies.clear()
+        assert resp.status_code == 200
+        assert resp.json()["user"] == "github:bob"
+
+        client.cookies.set(SESSION_COOKIE, cookie)
+        resp = await client.get("/interactive", headers={"X-Remote-User": "alice"})
         client.cookies.clear()
         assert resp.status_code == 200
         assert resp.json()["user"] == "github:bob"

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -526,6 +526,50 @@ def test_token_creation_with_expiry(harness: WebHarness) -> None:
     assert create({"name": "bad", "expires_days": "999999999999"}).status_code == 400
 
 
+def test_proxy_user_can_manage_api_tokens(harness: WebHarness) -> None:
+    ctx = harness.ctx
+    store = ctx.token_store
+    assert store is not None
+    old_proxy_auth_header = ctx.proxy_auth_header
+    ctx.proxy_auth_header = "X-Remote-User"
+    proxy_user = User(provider="proxy", username="alice@example.com")
+    headers = {"X-Remote-User": proxy_user.username}
+    try:
+        settings = harness.get("/settings", headers=headers)
+        assert settings.status_code == 200
+        assert proxy_user.qualified in settings.text
+
+        created = harness.post(
+            "/settings/tokens",
+            data={"name": "proxy-client"},
+            headers=headers,
+        )
+        assert created.status_code == 200
+        tokens = harness.run(store.list_for(proxy_user))
+        token = next(t for t in tokens if t.name == "proxy-client")
+
+        revoked = harness.post(f"/settings/tokens/{token.id}/revoke", headers=headers)
+        assert revoked.status_code == 303
+        assert all(t.id != token.id for t in harness.run(store.list_for(proxy_user)))
+    finally:
+        ctx.proxy_auth_header = old_proxy_auth_header
+
+
+def test_bearer_token_cannot_manage_api_tokens(harness: WebHarness) -> None:
+    store = harness.ctx.token_store
+    assert store is not None
+    token = harness.run(store.create(ALICE, "no-token-chaining"))
+    headers = {"Authorization": f"Bearer {token}"}
+
+    assert harness.get("/settings", headers=headers).status_code == 403
+    assert (
+        harness.post(
+            "/settings/tokens", data={"name": "chained"}, headers=headers
+        ).status_code
+        == 403
+    )
+
+
 def test_api_token_controls_build(harness: WebHarness) -> None:
     ctx = harness.ctx
     store = ApiTokenStore(ctx.pool)

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -127,7 +127,27 @@ class WebContext:
         controllable = await self.controllable_repo_ids(request)
         return controllable is None or build["project_id"] in controllable
 
-    async def current_user(self, request: Request) -> User | None:
+    async def interactive_user(self, request: Request) -> User | None:
+        """User authenticated by a browser-oriented login mechanism:
+        session cookie or trusted reverse-proxy header.
+
+        Unlike request_user(), this deliberately excludes personal API
+        tokens.  Token-management routes use it so an existing bearer token
+        cannot mint or revoke other tokens, while deployments using trusted
+        reverse-proxy authentication can still manage tokens in the UI.
+        """
+        # Session cookies win over the proxy header so forge/OIDC identities
+        # keep their authz rules.
+        user = await self._session_user(request)
+        if user is not None:
+            return user
+        if self.proxy_auth_header is not None:
+            remote_user = request.headers.get(self.proxy_auth_header, "").strip()
+            if remote_user:
+                return User(provider="proxy", username=remote_user)
+        return None
+
+    async def _session_user(self, request: Request) -> User | None:
         if self.signer is None:
             return None
         token = request.cookies.get(SESSION_COOKIE)
@@ -144,25 +164,6 @@ class WebContext:
         ):
             return None
         return user
-
-    async def interactive_user(self, request: Request) -> User | None:
-        """User authenticated by a browser-oriented login mechanism.
-
-        Unlike request_user(), this deliberately excludes personal API
-        tokens.  Token-management routes use it so an existing bearer token
-        cannot mint or revoke other tokens, while deployments using trusted
-        reverse-proxy authentication can still manage tokens in the UI.
-        """
-        # Session cookies win over the proxy header so forge/OIDC identities
-        # keep their authz rules.
-        user = await self.current_user(request)
-        if user is not None:
-            return user
-        if self.proxy_auth_header is not None:
-            remote_user = request.headers.get(self.proxy_auth_header, "").strip()
-            if remote_user:
-                return User(provider="proxy", username=remote_user)
-        return None
 
     async def request_user(self, request: Request) -> User | None:
         """Session cookie, personal API token (Authorization: Bearer),

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -145,6 +145,25 @@ class WebContext:
             return None
         return user
 
+    async def interactive_user(self, request: Request) -> User | None:
+        """User authenticated by a browser-oriented login mechanism.
+
+        Unlike request_user(), this deliberately excludes personal API
+        tokens.  Token-management routes use it so an existing bearer token
+        cannot mint or revoke other tokens, while deployments using trusted
+        reverse-proxy authentication can still manage tokens in the UI.
+        """
+        # Session cookies win over the proxy header so forge/OIDC identities
+        # keep their authz rules.
+        user = await self.current_user(request)
+        if user is not None:
+            return user
+        if self.proxy_auth_header is not None:
+            remote_user = request.headers.get(self.proxy_auth_header, "").strip()
+            if remote_user:
+                return User(provider="proxy", username=remote_user)
+        return None
+
     async def request_user(self, request: Request) -> User | None:
         """Session cookie, personal API token (Authorization: Bearer),
         or reverse-proxy auth header. Cached per request: routes ask
@@ -160,16 +179,7 @@ class WebContext:
             return await self.token_store.authenticate(
                 auth_header.removeprefix("Bearer ")
             )
-        # Session cookie wins over the proxy header so forge/OIDC
-        # identities keep their authz rules.
-        user = await self.current_user(request)
-        if user is not None:
-            return user
-        if self.proxy_auth_header is not None:
-            remote_user = request.headers.get(self.proxy_auth_header, "").strip()
-            if remote_user:
-                return User(provider="proxy", username=remote_user)
-        return None
+        return await self.interactive_user(request)
 
     async def render(
         self, template: str, request: Request | None = None, **context: Any

--- a/nixbot/nixbot/web/token_routes.py
+++ b/nixbot/nixbot/web/token_routes.py
@@ -41,7 +41,7 @@ def create_token_router(
 
     @router.get("/settings", response_class=HTMLResponse)
     async def settings_page(request: Request) -> HTMLResponse:
-        user = await ctx.current_user(request)
+        user = await ctx.interactive_user(request)
         if user is None:
             raise HTTPException(status_code=403, detail="login required")
         return await ctx.render(
@@ -59,7 +59,7 @@ def create_token_router(
     ) -> HTMLResponse:
         if not same_origin(request, own_url):
             raise HTTPException(status_code=403, detail="cross-origin request")
-        user = await ctx.current_user(request)
+        user = await ctx.interactive_user(request)
         if user is None:
             raise HTTPException(status_code=403, detail="login required")
         token = await store.create(user, name or "unnamed", _parse_expiry(expires_days))
@@ -75,7 +75,7 @@ def create_token_router(
     async def revoke_token(request: Request, token_id: int) -> RedirectResponse:
         if not same_origin(request, own_url):
             raise HTTPException(status_code=403, detail="cross-origin request")
-        user = await ctx.current_user(request)
+        user = await ctx.interactive_user(request)
         if user is None:
             raise HTTPException(status_code=403, detail="login required")
         if not await store.revoke(user, token_id):


### PR DESCRIPTION
I moved my nixbot instance from github oauth to proxy auth and I found I was unable to access the /settings page to create API token. This PR fixes that issue by having the settings page check for an "interactive" user which is defined as a "regular" auth or proxy auth'ed user. 