### PR TITLE
herculesCI: keep the per-system layout for checks

### DIFF
--- a/herculesCI/default.nix
+++ b/herculesCI/default.nix
@@ -12,7 +12,6 @@ in
 { primaryRepo, ... }:
 {
   onPush.default.outputs = {
-    checks = self.checks.${system};
     effects.deploy = hci-effects.runIf (primaryRepo.branch or null == "main") (
       hci-effects.mkEffect {
         effectScript = ''


### PR DESCRIPTION
Job names now match the flake's checks.<system>.<name> paths instead of the flattened default.checks.<name>.