### PR TITLE
Switch to newest nix-eval-jobs and bump nixpkgs

### DIFF
--- a/checks/nixbot-gitlab.nix
+++ b/checks/nixbot-gitlab.nix
@@ -96,6 +96,7 @@
           pkgs.coreutils
           pkgs.bash
           pkgs.util-linux
+          pkgs.systemd
         ];
         serviceConfig = {
           Type = "oneshot";
@@ -107,24 +108,17 @@
           set -x
           timeout 900 bash -c 'until curl -fs http://gitlab/users/sign_in > /dev/null; do sleep 5; done'
 
-          BEARER=$(curl -fs -X POST -H 'Content-Type: application/json' \
-            -d '{"grant_type":"password","username":"root","password":"notproduction"}' \
-            http://gitlab/oauth/token | jq -r .access_token)
-          AUTH="Authorization: Bearer $BEARER"
+          TOKEN=nixbot-test-token-of-20-chars
+          runuser -u gitlab -- /run/current-system/sw/bin/gitlab-rails runner "
+            ApplicationSetting.current.update!(allow_local_requests_from_web_hooks_and_services: true)
+            Rails.cache.clear
+            token = User.find_by_username('root').personal_access_tokens.create!(
+              name: 'nixbot', scopes: [:api], expires_at: 7.days.from_now)
+            token.set_token('$TOKEN')
+            token.save!
+          "
+          systemctl restart gitlab-sidekiq.service
 
-          # GitLab refuses webhooks to local addresses by default. The
-          # setting is Rails-cached for a minute and earlier requests
-          # already cached the default, so drop the cache afterwards.
-          curl -fs -X PUT -H "$AUTH" \
-            "http://gitlab/api/v4/application/settings?allow_local_requests_from_web_hooks_and_services=true" > /dev/null
-          runuser -u gitlab -- /run/current-system/sw/bin/gitlab-rails runner 'Rails.cache.clear'
-
-          # nixbot authenticates with a PAT (PRIVATE-TOKEN), not OAuth.
-          # expires_at is mandatory-bounded (max 400 days); a week outlives the test.
-          TOKEN=$(curl -fs -X POST -H "$AUTH" -H 'Content-Type: application/json' \
-            -d "{\"name\":\"nixbot\",\"scopes\":[\"api\"],\"expires_at\":\"$(date -d '+7 days' +%F)\"}" \
-            http://gitlab/api/v4/users/1/personal_access_tokens | jq -r .token)
-          test -n "$TOKEN" && test "$TOKEN" != null
           mkdir -p /var/lib/secrets
           echo "$TOKEN" > /var/lib/secrets/gitlab-token
           chmod 644 /var/lib/secrets/gitlab-token

--- a/devShells/default.nix
+++ b/devShells/default.nix
@@ -9,6 +9,7 @@ let
   # (postgres + nixbot).
   devProcessCompose = pkgs.python3.pkgs.callPackage ../packages/process-compose.nix {
     nixbot = self.packages.${system}.nixbot;
+    inherit (self.packages.${system}) nix-eval-jobs;
   };
   # sqlc wrapped with the nix-pinned codegen plugin (same version as
   # the sqlc-generated flake check); works offline.
@@ -21,7 +22,7 @@ in
       pkgs.mypy
       pkgs.ruff
       pkgs.postgresql
-      pkgs.nix-eval-jobs
+      self.packages.${system}.nix-eval-jobs
       # SQL codegen: `sqlc generate` regenerates nixbot/nixbot/db_gen
       # from sqlc.yaml.
       sqlc

--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,10 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780751787,
-        "narHash": "sha256-nWR7F46SyrLvN8Ot39XJDpVCswekGakXlOD4KsTYKW0=",
+        "lastModified": 1786301960,
+        "narHash": "sha256-EC1Vjo2Htw0urpDTWryYwQvxd+1AlnuXZ4opRK27o1Y=",
         "ref": "nixos-unstable-small",
-        "rev": "00fa9a692bafc08a86061886f888b843bf7fbdb0",
+        "rev": "1d383cbb23927d10d1b67d1cef2b653024ebc171",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"

--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -458,7 +458,7 @@ async def _read_stderr_tail(
     buf = bytearray()
     pending = bytearray()
 
-    async def keep(raw_line: bytes) -> bool:
+    async def keep(raw_line: bytes | bytearray) -> bool:
         text = strip_ansi(raw_line.decode(errors="replace")).strip()
         if _is_stderr_noise(text):
             return False
@@ -480,7 +480,7 @@ async def _read_stderr_tail(
                 buf += line + b"\n"
         if len(buf) > 2 * limit:
             del buf[:-limit]
-    if pending and await keep(bytes(pending)):
+    if pending and await keep(pending):
         buf += pending
     return bytes(buf[-limit:])
 

--- a/nixbot/nixbot/schedule_runner.py
+++ b/nixbot/nixbot/schedule_runner.py
@@ -30,12 +30,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def scheduled_worktree_id(due: DueEffect, run_id: int) -> str:
-    """Per-run worktree id: concurrent effects (or a run outlasting the
-    next due fire) must not share a checkout. Schedule/effect names are
-    repo-controlled, so sanitize against path traversal."""
+def scheduled_worktree_id(due: DueEffect) -> str:
+    """Worktree id for one scheduled effect run.
+    Schedule/effect names are repo-controlled,
+    so sanitize against path traversal."""
     safe = re.sub(r"[^A-Za-z0-9_-]+", "_", f"{due.schedule_name}-{due.effect}")
-    return f"scheduled-{due.project_id}-{safe}-{run_id}"
+    return f"scheduled-{due.project_id}-{safe}"
 
 
 async def scheduled_effects_loop(s: CIService) -> None:
@@ -135,7 +135,7 @@ async def _run_scheduled_inner(
     )
     worktree = await s.orchestrator.repos.checkout_for_build(
         info.key,
-        scheduled_worktree_id(due, run_id),
+        scheduled_worktree_id(due),
         base_commit=info.default_branch,
         credentials=credentials,
     )

--- a/nixbot/nixbot/tests/test_service.py
+++ b/nixbot/nixbot/tests/test_service.py
@@ -107,7 +107,7 @@ def test_scheduled_worktree_id_distinct_per_effect() -> None:
     when = ScheduleWhen()
     a = DueEffect(project_id=1, schedule_name="s", effect="deploy", when=when)
     b = DueEffect(project_id=1, schedule_name="s", effect="notify", when=when)
-    assert scheduled_worktree_id(a, 1) != scheduled_worktree_id(b, 1)
+    assert scheduled_worktree_id(a) != scheduled_worktree_id(b)
 
 
 def test_scheduled_worktree_id_sanitizes_traversal() -> None:
@@ -117,7 +117,7 @@ def test_scheduled_worktree_id_sanitizes_traversal() -> None:
         effect="x/../../y",
         when=ScheduleWhen(),
     )
-    wid = scheduled_worktree_id(due, 1)
+    wid = scheduled_worktree_id(due)
     assert "/" not in wid
     assert ".." not in wid
 

--- a/nixbot/nixbot/web/templates/_macros.html
+++ b/nixbot/nixbot/web/templates/_macros.html
@@ -81,35 +81,35 @@
             <span class="card-name">{{ d.name }}</span>
             {# .meta-status is what the live JS rewrites. The links stay. #}
             <span class="meta"><span class="meta-status">{{ meta }}</span>
-            {% if live or d.n > 0 %}
-              · <a href="{{ base }}/drv/{{ d.idx }}/view"
+              {% if live or d.n > 0 %}
+                · <a href="{{ base }}/drv/{{ d.idx }}/view"
     class="raw"
     onclick="event.stopPropagation()">open&nbsp;↗</a>
-            {% endif %}
-            {% if not live and d.n > 0 %}
-              · <a href="{{ base }}/drv/{{ d.idx }}/raw"
+              {% endif %}
+              {% if not live and d.n > 0 %}
+                · <a href="{{ base }}/drv/{{ d.idx }}/raw"
     class="raw"
     onclick="event.stopPropagation()">raw&nbsp;↗</a>
-            {% endif %}
+              {% endif %}
+            </span>
           </span>
-        </span>
-      </summary>
-      <div class="card-body">
-        {% if d.n == 0 and d.status != "running" %}
-          <p class="log-empty">no output</p>
-        {% else %}
-          <div class="log-lines" aria-busy="true"></div>
-        {% endif %}
-      </div>
-    </details>
-  {%- endmacro %}
-  {% macro error_row(error, colspan=3) -%}
-    <tr>
-      <td colspan="{{ colspan }}">
-        <details class="error">
-          <summary>{{ error | plain | excerpt(160) }}</summary>
-          <pre class="error">{{ error | ansi }}</pre>
-        </details>
-      </td>
-    </tr>
-  {%- endmacro %}
+        </summary>
+        <div class="card-body">
+          {% if d.n == 0 and d.status != "running" %}
+            <p class="log-empty">no output</p>
+          {% else %}
+            <div class="log-lines" aria-busy="true"></div>
+          {% endif %}
+        </div>
+      </details>
+    {%- endmacro %}
+    {% macro error_row(error, colspan=3) -%}
+      <tr>
+        <td colspan="{{ colspan }}">
+          <details class="error">
+            <summary>{{ error | plain | excerpt(160) }}</summary>
+            <pre class="error">{{ error | ansi }}</pre>
+          </details>
+        </td>
+      </tr>
+    {%- endmacro %}

--- a/nixbot/nixbot/web/templates/attribute_history.html
+++ b/nixbot/nixbot/web/templates/attribute_history.html
@@ -3,40 +3,39 @@
 {% block title %}
   {{ attr }} history
 {% endblock title %}
-{%
-block body %}
-<main id="main">
-  <section class="content">
-    <h2>
-      <code>{{ attr }}</code>
-      <small>in <a href="{{ repo_path(project) }}">{{ repo_name(project.owner, project.name) }}</a></small>
-    </h2>
-    <div class="table-scroll">
-      <table class="builds">
-        <tr>
-          <th scope="col">build</th>
-          <th scope="col">branch</th>
-          <th scope="col">status</th>
-          <th scope="col">commit</th>
-          <th scope="col">when</th>
-        </tr>
-        {% for h in history %}
+{% block body %}
+  <main id="main">
+    <section class="content">
+      <h2>
+        <code>{{ attr }}</code>
+        <small>in <a href="{{ repo_path(project) }}">{{ repo_name(project.owner, project.name) }}</a></small>
+      </h2>
+      <div class="table-scroll">
+        <table class="builds">
           <tr>
-            <td>
-              <a href="{{ build_path(project, h.build_number) }}">#{{ h.build_number }}</a>
-            </td>
-            <td>{{ h.branch }}</td>
-            <td>{{ status_pill(h.status) }}</td>
-            <td>{{ commit_link(project, h.commit_sha) }}</td>
-            <td>{{ ago(h.build_created_at) }}</td>
+            <th scope="col">build</th>
+            <th scope="col">branch</th>
+            <th scope="col">status</th>
+            <th scope="col">commit</th>
+            <th scope="col">when</th>
           </tr>
-        {% else %}
-          <tr>
-            <td colspan="5" class="empty-state">no history</td>
-          </tr>
-        {% endfor %}
-      </table>
-    </div>
-  </section>
-</main>
+          {% for h in history %}
+            <tr>
+              <td>
+                <a href="{{ build_path(project, h.build_number) }}">#{{ h.build_number }}</a>
+              </td>
+              <td>{{ h.branch }}</td>
+              <td>{{ status_pill(h.status) }}</td>
+              <td>{{ commit_link(project, h.commit_sha) }}</td>
+              <td>{{ ago(h.build_created_at) }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="5" class="empty-state">no history</td>
+            </tr>
+          {% endfor %}
+        </table>
+      </div>
+    </section>
+  </main>
 {% endblock body %}

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -106,9 +106,7 @@
                     <span class="meta browse-hint"></span>
                   </span>
                 </summary>
-                <div id="succeeded-list">
-                  {% for d in ok %}{{ drv_card(d, base) }}{% endfor %}
-                </div>
+                <div id="succeeded-list">{% for d in ok %}{{ drv_card(d, base) }}{% endfor %}</div>
               </details>
             {% endif %}
           {% endif %}

--- a/nixbot/pyproject.toml
+++ b/nixbot/pyproject.toml
@@ -58,6 +58,10 @@ force-exclude = true
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
+  # no copyright headers in this repo
+  "CPY",
+  # duplicate of PLR0913, handled per site
+  "PLR0917",
   # pydocstyle
   "D",
   # todo comments

--- a/nixbot_cli/nixbot_cli/api.py
+++ b/nixbot_cli/nixbot_cli/api.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 import httpx
 
@@ -63,7 +63,7 @@ class NixbotClient:
     def close(self) -> None:
         self.http.close()
 
-    def __enter__(self) -> NixbotClient:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *exc: object) -> None:
@@ -107,7 +107,7 @@ class NixbotClient:
 
     # --- builds --------------------------------------------------------
 
-    def builds(  # noqa: PLR0913
+    def builds(
         self,
         repo: RepoRef,
         *,
@@ -185,7 +185,7 @@ class NixbotClient:
         """Table of contents of one attribute's structured log."""
         return self._json("GET", f"/api/repos/{repo}/builds/{number}/logs/{attr}")
 
-    def log_text(  # noqa: PLR0913
+    def log_text(
         self,
         repo: RepoRef,
         number: int,

--- a/nixbot_cli/nixbot_cli/config.py
+++ b/nixbot_cli/nixbot_cli/config.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import os
 import shlex
 import subprocess
-import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+
+import tomllib
 
 
 def config_path() -> Path:
@@ -47,7 +48,7 @@ def _run_token_command(entry: dict) -> str | None:
     if not command:
         return None
     try:
-        out = subprocess.run(  # noqa: S603
+        out = subprocess.run(
             shlex.split(command), capture_output=True, text=True, check=True
         )
     except (OSError, subprocess.CalledProcessError) as err:

--- a/nixbot_cli/nixbot_cli/effects.py
+++ b/nixbot_cli/nixbot_cli/effects.py
@@ -13,6 +13,9 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 
+from nixbot_effects.eval import options_from_flake_ref
+from nixbot_effects.graph import render_tree
+
 from nixbot_effects import (
     EffectsOptions,
     list_effects,
@@ -20,8 +23,6 @@ from nixbot_effects import (
     run_effect,
     run_scheduled_effect,
 )
-from nixbot_effects.eval import options_from_flake_ref
-from nixbot_effects.graph import render_tree
 
 
 async def _log_stderr(data: bytes) -> None:

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -208,7 +208,7 @@ def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
-def print_failures(  # noqa: PLR0913
+def print_failures(
     client: NixbotClient, repo: RepoRef, number: int, status: str, finished: int
 ) -> None:
     """Result line plus a failure block with a clickable log URL per
@@ -452,7 +452,7 @@ def follow_attr(
         print(client.log_text(repo, number, attr, tail=tail), end="")
 
 
-def cmd_auth_status(client: NixbotClient, args: argparse.Namespace) -> int:  # noqa: ARG001
+def cmd_auth_status(client: NixbotClient, args: argparse.Namespace) -> int:
     settings = Settings.load()
     print(f"server: {settings.url}")
     if settings.token:
@@ -486,7 +486,7 @@ def _add_json_arg(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="nbo", description="nixbot CI client")
     sub = parser.add_subparsers(dest="command", required=True)
 

--- a/nixbot_cli/nixbot_cli/watch_tty.py
+++ b/nixbot_cli/nixbot_cli/watch_tty.py
@@ -308,9 +308,11 @@ class TtyWatch:
         elapsed = fmt_duration(time.time() - self.started_at)
         _, term_rows = self.display.size()
         lines = [
-            f" {BOLD}build #{self.number}{RESET} {status} · "
-            f"{GREEN}✓{finished - failed}{RESET} {RED}✗{failed}{RESET} "
-            f"⏵{len(running)} · {elapsed}"
+            (
+                f" {BOLD}build #{self.number}{RESET} {status} · "
+                f"{GREEN}✓{finished - failed}{RESET} {RED}✗{failed}{RESET} "
+                f"⏵{len(running)} · {elapsed}"
+            )
         ]
         budget = max(2, term_rows - 3)
         now = time.time()

--- a/nixbot_effects/nixbot_effects/tests/test_e2e_flake_ref.py
+++ b/nixbot_effects/nixbot_effects/tests/test_e2e_flake_ref.py
@@ -80,8 +80,10 @@ def _cli(*args: str) -> subprocess.CompletedProcess[str]:
         [
             sys.executable,
             "-c",
-            "import sys; sys.argv = ['nbo', 'effects'] + sys.argv[1:]; "
-            "from nixbot_cli.main import main; main()",
+            (
+                "import sys; sys.argv = ['nbo', 'effects'] + sys.argv[1:]; "
+                "from nixbot_cli.main import main; main()"
+            ),
             *args,
         ],
         check=True,

--- a/nixbot_effects/pyproject.toml
+++ b/nixbot_effects/pyproject.toml
@@ -27,6 +27,10 @@ line-length = 88
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
+  # no copyright headers in this repo
+  "CPY",
+  # duplicate of PLR0913, handled per site
+  "PLR0917",
   # pydocstyle
   "D",
   # todo comments

--- a/nixosModules/nixbot.nix
+++ b/nixosModules/nixbot.nix
@@ -948,7 +948,7 @@ in
         pkgs.bash
         pkgs.coreutils
         pkgs.bubblewrap
-        pkgs.nix-eval-jobs
+        packages.nix-eval-jobs
         config.nix.package
       ];
 

--- a/nixosModules/packages.nix
+++ b/nixosModules/packages.nix
@@ -16,9 +16,18 @@ in
       description = "Python interpreter to use for nixbot.";
     };
 
+    nix-eval-jobs = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ../packages/nix-eval-jobs.nix { };
+      defaultText = lib.literalExpression "pkgs.nix-eval-jobs";
+      description = "The nix-eval-jobs package to use.";
+    };
+
     nixbot = lib.mkOption {
       type = lib.types.package;
-      default = cfg.python.pkgs.callPackage ../packages/nixbot.nix { };
+      default = cfg.python.pkgs.callPackage ../packages/nixbot.nix {
+        inherit (cfg) nix-eval-jobs;
+      };
       defaultText = lib.literalExpression "python.pkgs.callPackage ../packages/nixbot.nix { }";
       description = "The nixbot package to use.";
     };

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -5,6 +5,7 @@ let
   scope = lib.makeScope newScope (
     self:
     {
+      nix-eval-jobs = self.callPackage ./nix-eval-jobs.nix { };
       nixbot = self.callPackage ./nixbot.nix { };
       nixbot-cli = self.callPackage ./nixbot-cli.nix { };
       docs = self.callPackage ./docs.nix { };

--- a/packages/nix-eval-jobs.nix
+++ b/packages/nix-eval-jobs.nix
@@ -1,0 +1,13 @@
+# TODO: drop when nixpkgs ships nix-eval-jobs >= 2.35.1
+{ pkgs, fetchFromGitHub }:
+pkgs.nix-eval-jobs.overrideAttrs (
+  finalAttrs: _prevAttrs: {
+    version = "2.35.1";
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "nix-eval-jobs";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-EFJnN35L7UieL8zV8qPrpqfdfzztWksY8JYuXF+mr9o=";
+    };
+  }
+)


### PR DESCRIPTION
This nix-eval-jobs checks upstream caches now using the nix-daemon, which helps with missing credentials for private upstream caches.