### PR TITLE
web: wrap log line content in a single flex item

### DIFF
--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -206,7 +206,8 @@ def render_log_lines(text: str) -> str:
         rendered, style = _ansi_convert(line, style)
         lines.append(
             f'<span class="logline" id="L{i}">'
-            f'<a class="lineno" href="#L{i}">{i}</a>{rendered}</span>'
+            f'<a class="lineno" href="#L{i}">{i}</a>'
+            f'<span class="logtext">{rendered}</span></span>'
         )
     # .logline is display:block. A joining "\n" inside <pre> would
     # render as an extra blank line.
@@ -249,7 +250,8 @@ def render_rows(
         rendered, style = _ansi_convert(line, style)
         out.append(
             f'<span class="logline" id="d{idx}-L{n}">'
-            f'<a class="lineno" href="#d{idx}-L{n}">{n}</a>{rendered}</span>'
+            f'<a class="lineno" href="#d{idx}-L{n}">{n}</a>'
+            f'<span class="logtext">{rendered}</span></span>'
         )
         n += 1
     return "".join(out), style

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -1051,8 +1051,12 @@ details.webhook-setup summary {
 	contain-intrinsic-size: auto 20px;
 	scroll-margin-top: 2rem;
 }
-/* Space the gutter with margin, not flex gap: ANSI colors split a line
-   into several span children and gap would space them apart mid-line. */
+/* One wrapper per line: bare ANSI spans as flex items would each
+   wrap inside their own box, scrambling long lines. */
+.log-lines .logtext {
+	flex: 1;
+	min-width: 0;
+}
 .log-lines .lineno {
 	width: 5ch;
 	margin: 0 1ch 0 0;


### PR DESCRIPTION
.logline is display:flex and ANSI colors split a line into several sibling spans. Each span became its own flex item, so long journal lines wrapped inside each segment's box, scrambling the output (timestamps and INFO tags drifting mid-line). Wrap the rendered content in one .logtext span so the row has exactly two flex items (gutter + text); wrapped continuations now also indent past the line-number gutter.