### PR TITLE
web: serve per-derivation raw logs while the attribute is running

### DIFF
--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -1231,6 +1231,36 @@ def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
     assert "event: done" in stream
 
 
+def test_drv_raw_serves_running_attribute(client: WebHarness, tmp_path: Path) -> None:
+    """The per-derivation raw link works during the build, served from the live capture."""
+    ctx = client.ctx
+    ctx.state_dir = tmp_path
+    registry = client.app.state.log_registry
+
+    async def run() -> None:
+        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 3")
+        writer = LogWriter(path=tmp_path / "logs" / "live" / "x86_64-linux.ok.zst")
+        cap = StructuredCapture(clock=lambda: 1.0)
+        writer.capture = cap
+        cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")
+        cap.log_line(1, "CC main.o")
+        cap.phase(1, "build")
+        cap.log_line(1, "\x1b[31mCC failed\x1b[0m")
+        registry.register(build_id, "x86_64-linux.ok", writer)
+        try:
+            base = "/repos/github/acme/widget/builds/3/logs/x86_64-linux.ok"
+            raw = await client.http.get(f"{base}/drv/1/raw")
+            assert raw.status_code == 200
+            assert "CC main.o" in raw.text
+            assert "Running phase: build" in raw.text
+            assert "\x1b" not in raw.text  # ANSI stripped
+            assert (await client.http.get(f"{base}/drv/99/raw")).status_code == 404
+        finally:
+            registry.unregister(build_id, "x86_64-linux.ok")
+
+    client.loop.run_until_complete(run())
+
+
 def test_log_sse_stream_caps_history_backlog(
     client: WebHarness, tmp_path: Path
 ) -> None:

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -214,6 +214,21 @@ def render_log_lines(text: str) -> str:
     return "".join(lines)
 
 
+def _reinject_phases(lines: list[str], ph: list[list]) -> list[str]:
+    """Mirrors LogContainerReader.lines_with_phases for capture lines."""
+    if not ph:
+        return lines
+    at: dict[int, list[str]] = {}
+    for name, line in ph:
+        at.setdefault(line, []).append(name)
+    out: list[str] = []
+    for n in range(len(lines) + 1):
+        out.extend(f"Running phase: {name}" for name in at.get(n, []))
+        if n < len(lines):
+            out.append(lines[n])
+    return out
+
+
 def phase_sep(name: str) -> str:
     """Inline phase divider; CSS pins it as the current-phase header."""
     safe = html.escape(name)
@@ -879,12 +894,19 @@ class _LogRoutes:
         attr: str,
         idx: int,
     ) -> PlainTextResponse:
-        """One derivation's log as plain text (ANSI stripped)."""
-        _, _, path = await self._resolve(request, forge, owner, name, number, attr)
-        reader = await _load_container(path)
-        if reader is None or not (0 <= idx < len(reader)):
-            raise HTTPException(status_code=404)
-        lines = await asyncio.to_thread(reader.lines_with_phases, idx)
+        """One derivation's log as plain text (ANSI stripped). Served from the live capture until the container exists."""
+        _, build, path = await self._resolve(request, forge, owner, name, number, attr)
+        capture = self._capture(build, attr)
+        if capture is not None:
+            entry = next((e for e in capture.state() if e["idx"] == idx), None)
+            if entry is None:
+                raise HTTPException(status_code=404)
+            lines = _reinject_phases(entry["lines"], entry["ph"])
+        else:
+            reader = await _load_container(path)
+            if reader is None or not (0 <= idx < len(reader)):
+                raise HTTPException(status_code=404)
+            lines = await asyncio.to_thread(reader.lines_with_phases, idx)
         return PlainTextResponse(strip_ansi("\n".join(lines)))
 
     async def build_search(  # noqa: PLR0913


### PR DESCRIPTION

The /drv/{idx}/raw endpoint only read the .nbl1 container, which is
written when the attribute finishes. Following a raw link during a
build therefore returned 404 even though the drv viewer page already
falls back to the live capture. Serve raw text from the capture too,
with phase markers reinjected to match the finished output.
