### PR TITLE
web: allow rerunning individual effects

### DIFF
--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -19,6 +19,7 @@ __all__: collections.abc.Sequence[str] = (
     "commit_built",
     "count_unfinished_attributes",
     "delete_attributes_by_name",
+    "delete_effects_by_name",
     "drop_removed_effects",
     "effect_status",
     "fail_interrupted_effects",
@@ -157,6 +158,11 @@ DELETE FROM build_attributes WHERE build_id = $1
 AND attr = ANY($2::text[])
 """
 
+DELETE_EFFECTS_BY_NAME: typing.Final[str] = """-- name: DeleteEffectsByName :exec
+DELETE FROM build_effects WHERE build_id = $1
+AND name = ANY($2::text[])
+"""
+
 DROP_REMOVED_EFFECTS: typing.Final[str] = """-- name: DropRemovedEffects :exec
 DELETE FROM build_effects WHERE build_id = $1
 AND NOT (name = ANY($2::text[]))
@@ -224,7 +230,9 @@ WITH flag AS (
 )
 UPDATE build_effects SET status = 'pending', error = NULL,
     finished_at = NULL, log_size = 0,
-    log_truncated = FALSE WHERE build_id = $1
+    log_truncated = FALSE
+WHERE build_id = $1
+  AND ($2::text[] IS NULL OR name = ANY($2::text[]))
 """
 
 RESET_EVAL_FOR_REEVAL: typing.Final[str] = """-- name: ResetEvalForReeval :exec
@@ -350,6 +358,10 @@ async def delete_attributes_by_name(conn: ConnectionLike, *, build_id: int, attr
     await conn.execute(DELETE_ATTRIBUTES_BY_NAME, build_id, attrs)
 
 
+async def delete_effects_by_name(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str]) -> None:
+    await conn.execute(DELETE_EFFECTS_BY_NAME, build_id, names)
+
+
 async def drop_removed_effects(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str]) -> None:
     await conn.execute(DROP_REMOVED_EFFECTS, build_id, names)
 
@@ -388,8 +400,8 @@ async def reset_build_for_restart(conn: ConnectionLike, *, attr: str | None, bui
     await conn.execute(RESET_BUILD_FOR_RESTART, attr, build_id)
 
 
-async def reset_effects_state(conn: ConnectionLike, *, build_id: int) -> None:
-    await conn.execute(RESET_EFFECTS_STATE, build_id)
+async def reset_effects_state(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str] | None) -> None:
+    await conn.execute(RESET_EFFECTS_STATE, build_id, names)
 
 
 async def reset_eval_for_reeval(conn: ConnectionLike, *, build_id: int) -> None:

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -52,6 +52,24 @@ async def maybe_run_effects(
     worktree_path: Path,
     credentials: FetchCredentials | None = None,
 ) -> None:
+    effects = await discover_effects(o, event, build, worktree_path, credentials)
+    if effects is None:
+        return
+    # Effects removed from the flake since the last run would
+    # otherwise linger as stale pending rows.
+    await q.drop_removed_effects(o.pool, build_id=build.id, names=list(effects))
+    await enqueue_effects(o, event, build, effects)
+
+
+async def discover_effects(
+    o: Orchestrator,
+    event: ChangeEvent,
+    build: BuildRecord,
+    worktree_path: Path,
+    credentials: FetchCredentials | None = None,
+) -> dict[str, EffectMeta] | None:
+    """Gating, the started-flag, and effect discovery. Returns None
+    when effects must not or cannot run."""
     repo = event.repo
     # Gating config comes from the default branch of the central
     # clone: the worktree is PR-controlled, so its nixbot.toml
@@ -65,7 +83,7 @@ async def maybe_run_effects(
         event.branch,
         is_pull_request=event.pr_number is not None,
     ):
-        return
+        return None
     # The started-flag guards against auto-re-running effects on crash
     # recovery (deploys are not idempotent). Record the triggering ref:
     # effect items carry only build_id and must report on this commit,
@@ -80,7 +98,7 @@ async def maybe_run_effects(
         )
         is None
     ):
-        return
+        return None
     task_token = o.task_tokens.issue(build.project_id)
     ctx = effects_context(
         o.config,
@@ -99,13 +117,10 @@ async def maybe_run_effects(
         # OSError: nix/git missing from PATH. Effects are best-effort
         # and must not fail the (already reported) build.
         logger.exception("effects discovery failed", extra={"build_id": build.id})
-        return
+        return None
     finally:
         o.task_tokens.revoke(task_token)
-    # Effects removed from the flake since the last run would
-    # otherwise linger as stale pending rows.
-    await q.drop_removed_effects(o.pool, build_id=build.id, names=list(effects))
-    await _enqueue_effects(o, event, build, effects)
+    return effects
 
 
 def _dedup_key(build: BuildRecord, name: str, meta: EffectMeta) -> str:
@@ -118,7 +133,7 @@ def _dedup_key(build: BuildRecord, name: str, meta: EffectMeta) -> str:
     return f"build-{build.id}-effect-{name}"
 
 
-async def _enqueue_effects(
+async def enqueue_effects(
     o: Orchestrator,
     event: ChangeEvent,
     build: BuildRecord,

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -47,6 +47,7 @@ from .executor import (
     LogWriter,
     attribute_log_path,
     build_log_dir,
+    effect_log_path,
     log_path_for_key,
 )
 from .gitrepo import MergeConflictError, pr_refspec
@@ -155,9 +156,16 @@ class Orchestrator:
                 missing_ok=True
             )
 
-    def reset_effect_logs(self, build_id: int) -> None:
-        """Drop all effect log files when a build's effects are reset."""
-        shutil.rmtree(self._log_dir(build_id) / "effects", ignore_errors=True)
+    def reset_effect_logs(self, build_id: int, names: list[str] | None = None) -> None:
+        """Drop effect log files when a build's effects are reset.
+        `names` limits the cleanup to those effects."""
+        if names is None:
+            shutil.rmtree(self._log_dir(build_id) / "effects", ignore_errors=True)
+            return
+        for name in names:
+            effect_log_path(self.config.state_dir, build_id, name).unlink(
+                missing_ok=True
+            )
 
     def gcroots_dir(self, build: BuildRecord) -> Path:
         return self.config.state_dir / "eval-gcroots" / str(build.id)
@@ -394,10 +402,11 @@ class Orchestrator:
         info: RepoInfo,
         build: BuildRecord,
         credentials: FetchCredentials | None = None,
+        only: str | None = None,
     ) -> None:
         """Effects-only restart: fresh worktree at the recorded commit,
-        attributes untouched."""
-        await rerun_exec.rerun_effects(self, info, build, credentials)
+        attributes untouched. `only` narrows the rerun to one effect."""
+        await rerun_exec.rerun_effects(self, info, build, credentials, only)
 
     async def maybe_run_effects(
         self,

--- a/nixbot/nixbot/queries/maintenance.sql
+++ b/nixbot/nixbot/queries/maintenance.sql
@@ -45,13 +45,22 @@ WHERE builds.id = sqlc.arg(build_id)::bigint;
 -- name: ResetEffectsState :exec
 -- Drop the started-flag and reset the effect rows atomically (a
 -- crash between the two writes must not leave re-runnable effects
--- behind a still-set flag).
+-- behind a still-set flag). A NULL names resets every row. Otherwise
+-- only the named effects are reset.
 WITH flag AS (
     UPDATE builds SET effects_started = FALSE WHERE id = sqlc.arg(build_id)
 )
 UPDATE build_effects SET status = 'pending', error = NULL,
     finished_at = NULL, log_size = 0,
-    log_truncated = FALSE WHERE build_id = sqlc.arg(build_id);
+    log_truncated = FALSE
+WHERE build_id = sqlc.arg(build_id)
+  AND (sqlc.narg(names)::text[] IS NULL OR name = ANY(sqlc.narg(names)::text[]));
+
+-- name: DeleteEffectsByName :exec
+-- Removes rows of effects that a rerun selected but discovery no
+-- longer found in the flake. They would stay pending forever.
+DELETE FROM build_effects WHERE build_id = $1
+AND name = ANY(sqlc.arg(names)::text[]);
 
 -- name: CountUnfinishedAttributes :one
 SELECT count(*) AS count FROM build_attributes

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -8,16 +8,20 @@ imported directly since it has no runtime dependency on this module.
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
-from . import build_run, db
+from . import build_run, db, effects_run
 from .canceller import branch_key
 from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
 from .events import ChangeEvent, EvalReport, event_for_build
 from .gitrepo import pr_refspec
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -134,30 +138,80 @@ async def rerun_pending_attributes(
         o.cancel_events.pop(build.id, None)
 
 
+async def _rerun_names(
+    o: Orchestrator, build: BuildRecord, only: str
+) -> list[str] | None:
+    """The effect plus its transitively skipped dependents. A skipped
+    row must not stay skipped after a green rerun. Returns None when
+    `only` is not a row of this build."""
+    rows = await builds_q.effects_for_build(o.pool, build_id=build.id)
+    if all(r.name != only for r in rows):
+        return None
+    names = {only}
+    changed = True
+    while changed:
+        changed = False
+        for r in rows:
+            deps = set(json.loads(r.deps)) if r.deps else set()
+            if r.status == "skipped" and r.name not in names and deps & names:
+                names.add(r.name)
+                changed = True
+    return sorted(names)
+
+
 async def rerun_effects(
     o: Orchestrator,
     info: RepoInfo,
     build: BuildRecord,
     credentials: FetchCredentials | None = None,
+    only: str | None = None,
 ) -> None:
     """Effects-only restart: fresh worktree at the recorded commit,
-    attributes untouched."""
+    attributes untouched. `only` narrows the rerun to one effect and
+    its skipped dependents."""
     if build.id in o.cancel_events:
         # A concurrent rerun (or double click) would deploy twice.
         return
     o.cancel_events[build.id] = asyncio.Event()
     try:
+        names: list[str] | None = None
+        if only is not None:
+            names = await _rerun_names(o, build, only)
+            if names is None:
+                logger.warning(
+                    "rerun of unknown effect ignored",
+                    extra={"build_id": build.id, "effect": only},
+                )
+                return
         # Reset under the claim: resetting earlier (e.g. in the
         # service) could clobber a rerun already in flight. Drop the
         # previous run's logs here too, so pending rows show no stale
         # output.
-        await q.reset_effects_state(o.pool, build_id=build.id)
-        o.reset_effect_logs(build.id)
+        await q.reset_effects_state(o.pool, build_id=build.id, names=names)
+        o.reset_effect_logs(build.id, names)
         async with rerun_worktree(o, info, build, "effects", credentials) as (
             event,
             worktree_path,
         ):
-            await o.maybe_run_effects(event, build, worktree_path, credentials)
+            if names is None:
+                await o.maybe_run_effects(event, build, worktree_path, credentials)
+            else:
+                effects = await effects_run.discover_effects(
+                    o, event, build, worktree_path, credentials
+                )
+                if effects is not None:
+                    # Selected effects that discovery no longer found
+                    # would stay pending forever.
+                    if missing := sorted(set(names) - effects.keys()):
+                        await q.delete_effects_by_name(
+                            o.pool, build_id=build.id, names=missing
+                        )
+                    await effects_run.enqueue_effects(
+                        o,
+                        event,
+                        build,
+                        {n: m for n, m in effects.items() if n in names},
+                    )
             await o.refresh_schedules(event)
         # The enqueued effect items share this build's key and only
         # become claimable once this item finishes.

--- a/nixbot/nixbot/restart_dispatch.py
+++ b/nixbot/nixbot/restart_dispatch.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 UNWIND_RETRY_SECONDS = 0.5
 
 
-async def restart_effects(s: CIService, build_id: int) -> None:
+async def restart_effects(s: CIService, build_id: int, name: str | None = None) -> None:
     if build_id in s.orchestrator.cancel_events:
         return  # build (or an effects rerun) still running
     build = await builds_q.get_build(s.orchestrator.pool, id_=build_id)
@@ -45,7 +45,7 @@ async def restart_effects(s: CIService, build_id: int) -> None:
         return
     info = repo_info(project)
     credentials = await s.credentials_provider(info.forge).get(info.clone_url)
-    await s.orchestrator.rerun_effects(info, build, credentials)
+    await s.orchestrator.rerun_effects(info, build, credentials, only=name)
 
 
 async def rerun(s: CIService, build_id: int) -> bool:

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -379,8 +379,11 @@ class CIService:
             await self.orchestrator.reporter.build_restarted(event, build, attr)
         await self.enqueue_work("rerun", f"build-{build_id}", {"build_id": build_id})
 
-    async def restart_effects(self, build_id: int) -> None:
-        await self.enqueue_work("effects", f"build-{build_id}", {"build_id": build_id})
+    async def restart_effects(self, build_id: int, name: str | None = None) -> None:
+        # Per-build dedup key: single-effect and full reruns serialize.
+        await self.enqueue_work(
+            "effects", f"build-{build_id}", {"build_id": build_id, "name": name}
+        )
 
     async def run_scheduled_now(
         self, project_id: int, schedule_name: str, effect: str, when_spec: str
@@ -461,7 +464,9 @@ class CIService:
                 # Previous run still unwinding. Retry, don't drop.
                 await self.enqueue_work("rerun", item.dedup_key, payload)
         elif item.kind == "effects":
-            await restart_dispatch.restart_effects(self, payload["build_id"])
+            await restart_dispatch.restart_effects(
+                self, payload["build_id"], payload.get("name")
+            )
         elif item.kind == "effect":
             await self._run_effect_item(payload["build_id"], payload["name"])
         elif item.kind == "report":

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -62,7 +62,7 @@ MALLORY = User(provider="gitea", username="alice")  # same name, wrong forge
 class FakeBackend:
     restarted: list[int] = field(default_factory=list)
     attr_restarts: list[tuple[int, str]] = field(default_factory=list)
-    effect_restarts: list[int] = field(default_factory=list)
+    effect_restarts: list[tuple[int, str | None]] = field(default_factory=list)
     cancelled: list[int] = field(default_factory=list)
     attr_cancels: list[tuple[int, str]] = field(default_factory=list)
     scheduled_runs: list[tuple[int, str, str, str]] = field(default_factory=list)
@@ -75,8 +75,8 @@ class FakeBackend:
     async def restart_attribute(self, build_id: int, attr: str) -> None:
         self.attr_restarts.append((build_id, attr))
 
-    async def restart_effects(self, build_id: int) -> None:
-        self.effect_restarts.append(build_id)
+    async def restart_effects(self, build_id: int, name: str | None = None) -> None:
+        self.effect_restarts.append((build_id, name))
 
     async def cancel_build(self, build_id: int) -> None:
         self.cancelled.append(build_id)
@@ -128,6 +128,11 @@ async def seed(dsn: str) -> None:
               ($1, 'bad2', 'x', 'dependency_failed'),
               ($1, 'pkgs/o k?#100%', 'x', 'succeeded')
             """,
+            build_id,
+        )
+        await pool.execute(
+            "INSERT INTO build_effects (build_id, name, status) "
+            "VALUES ($1, 'deploy', 'failed')",
             build_id,
         )
         # Queue for the mass-cancel tests: two pending, one running.
@@ -1078,7 +1083,17 @@ def test_effects_restart_route(harness: WebHarness) -> None:
     url = "/repos/github/acme/widget/builds/1/effects/restart"
     assert harness.post(url).status_code == 403
     assert harness.post(url, ROOT).status_code == 303
-    assert BACKEND.effect_restarts == [1]
+    assert BACKEND.effect_restarts == [(1, None)]
+
+
+def test_single_effect_restart_route(harness: WebHarness) -> None:
+    BACKEND.effect_restarts.clear()
+    url = "/repos/github/acme/widget/builds/1/effects/restart"
+    assert harness.post(f"{url}?name=deploy", ROOT).status_code == 303
+    assert BACKEND.effect_restarts == [(1, "deploy")]
+    # Unknown effect is a 404, not an enqueue.
+    assert harness.post(f"{url}?name=nope", ROOT).status_code == 404
+    assert len(BACKEND.effect_restarts) == 1
 
 
 def test_webhook_panel_is_forge_aware(harness: WebHarness) -> None:
@@ -1148,3 +1163,8 @@ def test_api_attr_and_effects_control(harness: WebHarness) -> None:
     assert response.status_code == 200
     assert response.json() == {"number": 1, "action": "restart-effects"}
     assert len(BACKEND.effect_restarts) == 1
+
+    response = harness.post(f"{base}/effects/restart?name=deploy", ROOT)
+    assert response.status_code == 200
+    assert BACKEND.effect_restarts[-1] == (1, "deploy")
+    assert harness.post(f"{base}/effects/restart?name=nope", ROOT).status_code == 404

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -1166,6 +1166,84 @@ async def test_rerun_effects_runs_effects_again(
     assert attrs_before == attrs_after
 
 
+async def test_rerun_single_effect(
+    pool: asyncpg.Pool,
+    make_env: EnvFactory,
+    upstream: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rerunning one effect resets that effect and the dependents
+    skipped because of it. Every other effect keeps its result."""
+    add_commit(upstream, "single")
+    fail_deploy = True
+    ran: list[str] = []
+
+    async def run(ctx: object, name: str, log_write: object = None) -> bool:
+        ran.append(name)
+        return not (name == "deploy" and fail_deploy)
+
+    patch_effects(
+        monkeypatch,
+        run_effect=run,
+        effects={
+            "deploy": EffectMeta(),
+            "notify": EffectMeta(after=("deploy",)),
+            "other": EffectMeta(),
+        },
+    )
+    orchestrator, _, project = await make_env(
+        FakeEvalRunner([mk_job("a")]), FakeExecutor()
+    )
+    build = await orchestrator.handle_change_event(
+        ChangeEvent(
+            repo=project, branch="main", commit_sha=git(upstream, "rev-parse", "HEAD")
+        )
+    )
+    assert build is not None
+    await drain_effect_items(orchestrator, project, pool)
+    assert sorted(ran) == ["deploy", "other"]  # notify skipped
+    statuses = {
+        r["name"]: r["status"]
+        for r in await pool.fetch(
+            "SELECT name, status FROM build_effects WHERE build_id = $1", build.id
+        )
+    }
+    assert statuses == {
+        "deploy": "failed",
+        "notify": "skipped",
+        "other": "succeeded",
+    }
+    other_finished = await pool.fetchval(
+        "SELECT finished_at FROM build_effects WHERE build_id = $1 AND name = 'other'",
+        build.id,
+    )
+
+    fail_deploy = False
+    ran.clear()
+    await orchestrator.rerun_effects(project, build, only="deploy")
+    await drain_effect_items(orchestrator, project, pool)
+    assert sorted(ran) == ["deploy", "notify"]  # "other" untouched
+    statuses = {
+        r["name"]: r["status"]
+        for r in await pool.fetch(
+            "SELECT name, status FROM build_effects WHERE build_id = $1", build.id
+        )
+    }
+    assert statuses == {
+        "deploy": "succeeded",
+        "notify": "succeeded",
+        "other": "succeeded",
+    }
+    assert (
+        await pool.fetchval(
+            "SELECT finished_at FROM build_effects "
+            "WHERE build_id = $1 AND name = 'other'",
+            build.id,
+        )
+        == other_finished
+    )
+
+
 async def test_recovery_rerun_runs_effects(
     pool: asyncpg.Pool, run_effect_build: EffectBuildRunner, upstream: Path
 ) -> None:

--- a/nixbot/nixbot/web/control_routes.py
+++ b/nixbot/nixbot/web/control_routes.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Annotated, Protocol
 from urllib.parse import quote
 
-from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi import APIRouter, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import BaseModel
 
@@ -35,7 +35,7 @@ class ControlBackend(Protocol):
 
     async def restart_attribute(self, build_id: int, attr: str) -> None: ...
 
-    async def restart_effects(self, build_id: int) -> None: ...
+    async def restart_effects(self, build_id: int, name: str | None = None) -> None: ...
 
     async def cancel_build(self, build_id: int) -> None: ...
 
@@ -138,12 +138,26 @@ class _ControlRoutes:
         await self.backend.restart_attribute(build["id"], attr)
         return _back_to_attr(forge, owner, name, number, attr)
 
-    async def restart_effects(
-        self, request: Request, forge: str, owner: str, name: str, number: int
+    async def restart_effects(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        effect: str | None = Query(None, alias="name"),
     ) -> RedirectResponse:
         build = await self._authorize(request, forge, owner, name, number)
-        await self.backend.restart_effects(build["id"])
+        await self._check_effect(build["id"], effect)
+        await self.backend.restart_effects(build["id"], effect)
         return _back(forge, owner, name, number)
+
+    async def _check_effect(self, build_id: int, effect: str | None) -> None:
+        if effect is not None and (
+            await maint_gen.effect_status(self.ctx.pool, build_id=build_id, name=effect)
+            is None
+        ):
+            raise HTTPException(status_code=404, detail="unknown effect")
 
     async def cancel_attribute(  # noqa: PLR0913
         self,
@@ -245,13 +259,20 @@ class _ControlRoutes:
         await self.backend.cancel_attribute(build["id"], attr)
         return {"number": number, "attr": attr, "action": "cancel"}
 
-    async def api_restart_effects(
-        self, request: Request, forge: str, owner: str, name: str, number: int
+    async def api_restart_effects(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        effect: str | None = Query(None, alias="name"),
     ) -> dict:
-        """Re-run the build's effects. Authz: admins, the PR author, or
-        repo writers."""
+        """Re-run the build's effects, or a single one via ?name=.
+        Authz: admins, the PR author, or repo writers."""
         build = await self._authorize(request, forge, owner, name, number)
-        await self.backend.restart_effects(build["id"])
+        await self._check_effect(build["id"], effect)
+        await self.backend.restart_effects(build["id"], effect)
         return {"number": number, "action": "restart-effects"}
 
     async def api_set_enabled(

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -197,6 +197,13 @@ td.attr-duration {
 	color: var(--muted);
 	font-variant-numeric: tabular-nums;
 }
+td.attr-restart {
+	white-space: nowrap;
+}
+button.icon-button {
+	padding: 0 0.4rem;
+	line-height: 1.4;
+}
 .dot {
 	display: inline-block;
 	width: 0.6rem;

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -141,6 +141,7 @@
               <th scope="col">status</th>
               <th scope="col">effect</th>
               <th scope="col">duration</th>
+              <th scope="col">restart</th>
             </tr>
           </thead>
           {% for e in effects %}
@@ -154,6 +155,16 @@
                 {% endif %}
               </td>
               <td class="attr-duration">{{ e | duration }}</td>
+              <td class="attr-restart">
+                {% if can_control and build.status == "succeeded" and e.status not in ("pending", "running") %}
+                  <form method="post"
+                        action="{{ build_path(project, build.number) }}/effects/restart?name={{ e.name | urlencode }}">
+                    <button class="icon-button"
+                            title="restart {{ e.name }}"
+                            aria-label="restart effect {{ e.name }}"><span aria-hidden="true">↻</span></button>
+                  </form>
+                {% endif %}
+              </td>
             </tr>
             {% if e.error %}{{ error_row(e.error) }}{% endif %}
           {% endfor %}

--- a/packages/nix-eval-jobs.nix
+++ b/packages/nix-eval-jobs.nix
@@ -1,13 +1,17 @@
 # TODO: drop when nixpkgs ships nix-eval-jobs >= 2.35.1
 { pkgs, fetchFromGitHub }:
-pkgs.nix-eval-jobs.overrideAttrs (
-  finalAttrs: _prevAttrs: {
-    version = "2.35.1";
-    src = fetchFromGitHub {
-      owner = "NixOS";
-      repo = "nix-eval-jobs";
-      tag = "v${finalAttrs.version}";
-      hash = "sha256-EFJnN35L7UieL8zV8qPrpqfdfzztWksY8JYuXF+mr9o=";
-    };
-  }
-)
+(pkgs.nix-eval-jobs.override {
+  # nix-eval-jobs 2.35.x requires Nix >= 2.35 (tryEnterPrivateMountNamespace)
+  nixComponents = pkgs.nixVersions.nixComponents_2_35;
+}).overrideAttrs
+  (
+    finalAttrs: _prevAttrs: {
+      version = "2.35.1";
+      src = fetchFromGitHub {
+        owner = "NixOS";
+        repo = "nix-eval-jobs";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-EFJnN35L7UieL8zV8qPrpqfdfzztWksY8JYuXF+mr9o=";
+      };
+    }
+  )


### PR DESCRIPTION

Only the whole effects section could be rerun, so retrying one flaky
deploy meant re-running every effect of the build. Add a per-row
restart button and a ?name= parameter on the effects/restart routes.

A single-effect rerun resets that effect plus dependents that were
skipped because of it, and leaves every other result untouched.
Effect discovery is split into discover_effects/enqueue_effects so
the rerun path can filter between the two.

Closes #115
