### PR TITLE
cli: per-effect restart via nbo build restart --effect

### DIFF
--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -64,6 +64,11 @@ async def postgres_dsn(postgres_dsn: str) -> str:
             """,
             failed,
         )
+        await pool.execute(
+            "INSERT INTO build_effects (build_id, name, status) "
+            "VALUES ($1, 'deploy', 'failed'), ($1, 'notify', 'skipped')",
+            failed,
+        )
     return postgres_dsn
 
 
@@ -150,6 +155,24 @@ def test_build_restart_cancel(
     )
     assert [a for _, a in BACKEND.attr_restarts] == ["bad1"]
     assert run_cli(api, "build", "restart", "1", "-R", "acme/widget", "--effects") == 0
+    BACKEND.effect_restarts.clear()
+    assert (
+        run_cli(
+            api,
+            "build",
+            "restart",
+            "1",
+            "-R",
+            "acme/widget",
+            "--effect",
+            "dep",
+            "--effect",
+            "not",
+        )
+        == 0
+    )
+    assert BACKEND.effect_restarts == [(1, "deploy"), (1, "notify")]
+    assert "restarting effect deploy" in capsys.readouterr().out
     assert run_cli(api, "build", "cancel", "2", "-R", "acme/widget") == 0
     assert "cancelling build #2" in capsys.readouterr().out
     assert len(BACKEND.cancelled) == 1

--- a/nixbot/nixbot/tests/test_cli_api.py
+++ b/nixbot/nixbot/tests/test_cli_api.py
@@ -49,6 +49,11 @@ async def postgres_dsn(postgres_dsn: str) -> str:
             """,
             failed,
         )
+        await pool.execute(
+            "INSERT INTO build_effects (build_id, name, status) "
+            "VALUES ($1, 'deploy', 'failed')",
+            failed,
+        )
     return postgres_dsn
 
 
@@ -148,6 +153,11 @@ def test_control_requires_token(harness: WebHarness, api: NixbotClient) -> None:
     assert api.restart_attr(REPO, 1, "bad1")["attr"] == "bad1"
     assert api.cancel_attr(REPO, 1, "bad1")["attr"] == "bad1"
     assert api.restart_effects(REPO, 1)["action"] == "restart-effects"
+    assert api.restart_effects(REPO, 1, "deploy")["action"] == "restart-effects"
+    assert BACKEND.effect_restarts[-2:] == [(1, None), (1, "deploy")]
+    with pytest.raises(ApiError) as err:
+        api.restart_effects(REPO, 1, "nope")
+    assert err.value.status == 404
     assert len(BACKEND.restarted) == 1
     assert [a for _, a in BACKEND.attr_restarts] == ["bad1"]
     assert [a for _, a in BACKEND.attr_cancels] == ["bad1"]

--- a/nixbot/nixbot/web/api_routes.py
+++ b/nixbot/nixbot/web/api_routes.py
@@ -95,9 +95,18 @@ class Attribute(BaseModel):
     log_truncated: bool | None = None
 
 
+class Effect(BaseModel):
+    name: str
+    status: str
+    error: str | None
+    started_at: datetime | None
+    finished_at: datetime | None
+
+
 class BuildDetail(BaseModel):
     build: Build
     attributes: list[Attribute]
+    effects: list[Effect]
 
 
 class AttributeDelta(BaseModel):
@@ -225,12 +234,14 @@ def create_api_router(ctx: WebContext) -> APIRouter:
     async def get_build(
         request: Request, forge: str, owner: str, name: str, number: int
     ) -> dict[str, Any]:
-        """Build plus all of its attributes."""
+        """Build plus all of its attributes and effects."""
         build = await _build_or_404(ctx, request, forge, owner, name, number)
         attributes = await ctx.queries.attributes(build["id"])
+        effects = await ctx.queries.effects(build["id"])
         return {
             "build": clean_row(build),
             "attributes": [clean_row(a) for a in attributes],
+            "effects": [clean_row(e) for e in effects],
         }
 
     @router.get(

--- a/nixbot_cli/nixbot_cli/api.py
+++ b/nixbot_cli/nixbot_cli/api.py
@@ -176,8 +176,14 @@ class NixbotClient:
             "POST", f"/api/repos/{repo}/builds/{number}/attrs/{attr}/cancel"
         )
 
-    def restart_effects(self, repo: RepoRef, number: int) -> dict:
-        return self._json("POST", f"/api/repos/{repo}/builds/{number}/effects/restart")
+    def restart_effects(
+        self, repo: RepoRef, number: int, name: str | None = None
+    ) -> dict:
+        """Re-run every effect of the build, or a single one by name."""
+        params = {"name": name} if name is not None else None
+        return self._json(
+            "POST", f"/api/repos/{repo}/builds/{number}/effects/restart", params
+        )
 
     # --- logs ----------------------------------------------------------
 

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -340,6 +340,11 @@ def cmd_build_restart(client: NixbotClient, args: argparse.Namespace) -> int:
     if args.effects:
         client.restart_effects(repo, number)
         print(f"restarting effects of build #{number}")
+    elif args.effect:
+        detail = client.build(repo, number)
+        for effect in [_match_effect(detail["effects"], sel) for sel in args.effect]:
+            client.restart_effects(repo, number, effect)
+            print(f"restarting effect {effect} of build #{number}")
     elif args.attr:
         attr = resolve_attr(client, repo, number, args.attr)
         client.restart_attr(repo, number, attr)
@@ -361,6 +366,21 @@ def cmd_build_cancel(client: NixbotClient, args: argparse.Namespace) -> int:
         client.cancel_build(repo, number)
         print(f"cancelling build #{number}")
     return EXIT_OK
+
+
+def _match_effect(effects: list[dict], selector: str) -> str:
+    """Effect name by exact match or unambiguous substring."""
+    names = [e["name"] for e in effects]
+    if selector in names:
+        return selector
+    matches = [n for n in names if selector in n]
+    if not matches:
+        msg = f"no effect matches {selector!r}"
+        raise UsageError(msg)
+    if len(matches) > 1:
+        msg = f"{selector!r} is ambiguous: {', '.join(matches)}"
+        raise UsageError(msg)
+    return matches[0]
 
 
 def _match_attr(attrs: list[dict], selector: str) -> dict:
@@ -551,12 +571,18 @@ running ones. Piped or in CI it prints one line per finished attribute.""",
   nbo build restart                 rebuild the current commit's build
   nbo build restart 412             rebuild everything of build #412
   nbo build restart 412 --attr nixos-eve   one attribute only (substring is enough)
-  nbo build restart 412 --effects   re-run the effects""",
+  nbo build restart 412 --effects   re-run the effects
+  nbo build restart 412 --effect deploy   one effect only""",
     )
     b_restart.add_argument("number", type=int, nargs="?")
     _add_repo_arg(b_restart)
     b_restart.add_argument("--attr", help="restart only this attribute")
     b_restart.add_argument("--effects", action="store_true", help="restart the effects")
+    b_restart.add_argument(
+        "--effect",
+        action="append",
+        help="restart only this effect (repeatable)",
+    )
     b_restart.set_defaults(func=cmd_build_restart)
 
     b_cancel = build.add_parser("cancel", help="cancel a build or attribute")

--- a/nixbot_cli/skill/SKILL.md
+++ b/nixbot_cli/skill/SKILL.md
@@ -14,10 +14,11 @@ nbo build watch 412 [--attr treefmt]         # exit 1 on failure
 nbo log 412                                  # failure summary with log tails
 nbo log 412 checks.x86_64-linux.foo --tail 200   # or --follow
 nbo build restart 412 --attr treefmt         # token: NIXBOT_TOKEN / hosts.toml
+nbo build restart 412 --effects|--effect deploy  # all or one (repeatable)
 nbo build cancel 412
 nbo effects list | run default.deploy        # local, no token
 ```
 
-Attribute args accept unambiguous substrings; `--json [fields]` for
+Attribute and effect args accept unambiguous substrings; `--json [fields]` for
 machine-readable output. `nbo auth status` shows server/token. HTTP API docs at
 `/llms.txt`.


### PR DESCRIPTION

The web UI gained per-effect reruns. Expose the same through the CLI:
--effect NAME resolves like --attr (exact or unambiguous substring)
and is repeatable. The build detail API now includes the effects list
so the client can resolve names without a extra endpoint.
