### PR TITLE
nix_eval: limit traversal to configured build systems

### DIFF
--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -187,6 +187,7 @@ def _eval_settings(
         # sandboxed evaluator needs to read it.
         extra_ro_paths=[o.repos.clone_path(event.repo.key)],
         hercules_args=hercules_args,
+        eval_systems=o.config.eval_systems,
     )
 
 

--- a/nixbot/nixbot/config.py
+++ b/nixbot/nixbot/config.py
@@ -306,6 +306,7 @@ class Config(BaseModel):
     db_url: str | None = None
     db_url_file: Path | None = None
     build_systems: list[str]
+    eval_systems: list[str] = []
     url: str
 
     # Webhook URL may differ from the UI URL (e.g. split ingress).

--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -91,6 +91,9 @@ class EvalSettings:
     # herculesCI arguments (primaryRepo, rev, branch, ...) passed to the
     # flake's herculesCI output when it is a function.
     hercules_args: dict[str, Any] = field(default_factory=dict)
+    # Instance systems are the fallback when the repository does not set
+    # herculesCI.ciSystems. Empty preserves evaluation of every flake system.
+    eval_systems: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -117,7 +120,8 @@ let
     "x86_64-linux" "aarch64-linux" "i686-linux" "armv7l-linux"
     "riscv64-linux" "powerpc64le-linux" "x86_64-darwin" "aarch64-darwin"
   ];
-  ciSystems = hci.ciSystems or null;
+  configuredSystems = builtins.fromJSON {eval_systems_json};
+  ciSystems = hci.ciSystems or configuredSystems;
   keepName = name: ciSystems == null || !(builtins.elem name knownSystems)
     || builtins.elem name ciSystems;
   isDrv = v: (v.type or null) == "derivation";
@@ -166,6 +170,7 @@ drv: {
 def build_select_expr(branch_config: BranchConfig, settings: EvalSettings) -> str:
     return SELECT_TEMPLATE.format(
         args_json=json.dumps(json.dumps(settings.hercules_args)),
+        eval_systems_json=json.dumps(json.dumps(settings.eval_systems or None)),
         # The attribute may be a dotted path (e.g. "hydraJobs.ci").
         attr_path_json=json.dumps(json.dumps(branch_config.attribute.split("."))),
     )

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -316,6 +316,7 @@ async def test_eval_runner_hercules_ci_jobs(tmp_path: Path) -> None:
             "rev": "abcdef1234567",
             "shortRev": "abcdef1",
         },
+        eval_systems=["aarch64-linux"],
     )
     result = await EvalRunner().run(flake, BranchConfig(), settings)
     attrs = {job.attr: job.name for job in result.jobs}  # type: ignore[union-attr]
@@ -324,6 +325,60 @@ async def test_eval_runner_hercules_ci_jobs(tmp_path: Path) -> None:
         "default.checks.x86_64-linux.ok": "ok-abcdef1",
         "docs.site": "site",
     }
+
+
+@pytest.mark.skipif(
+    shutil.which("nix-eval-jobs") is None or shutil.which("nix") is None,
+    reason="nix-eval-jobs not available",
+)
+@pytest.mark.parametrize(
+    ("eval_systems", "expected_attrs"),
+    [
+        (
+            [],
+            [
+                "default.checks.aarch64-linux.foreign",
+                "default.checks.x86_64-linux.native",
+            ],
+        ),
+        (["x86_64-linux"], ["default.checks.x86_64-linux.native"]),
+    ],
+)
+async def test_eval_runner_filters_configured_eval_systems(
+    tmp_path: Path, eval_systems: list[str], expected_attrs: list[str]
+) -> None:
+    flake = tmp_path / "repo"
+    flake.mkdir()
+    (flake / "flake.nix").write_text(
+        """
+        {
+          outputs = { self }: {
+            checks.x86_64-linux.native = derivation {
+              name = "native";
+              system = "x86_64-linux";
+              builder = "/bin/sh";
+              args = [ "-c" "echo native > $out" ];
+            };
+            checks.aarch64-linux.foreign = derivation {
+              name = "foreign";
+              system = "aarch64-linux";
+              builder = "/bin/sh";
+              args = [ "-c" "echo foreign > $out" ];
+            };
+          };
+        }
+        """
+    )
+    settings = EvalSettings(
+        gc_roots_dir=tmp_path / "gcroots",
+        sandbox=False,
+        systemd_scope=False,
+        eval_systems=eval_systems,
+    )
+
+    result = await EvalRunner().run(flake, BranchConfig(), settings)
+
+    assert [job.attr for job in result.jobs] == expected_attrs
 
 
 async def test_stderr_noise_filtered_and_warnings_reach_callback(

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -1011,6 +1011,7 @@ async def test_eval_settings_wired(
     sha = add_commit(upstream, "setw")
     eval_runner = FakeEvalRunner([mk_job("a")])
     orchestrator, _, project = await make_env(eval_runner, FakeExecutor(), "setw")
+    orchestrator.config.eval_systems = ["aarch64-linux"]
     netrc = tmp_path / "netrc"
     netrc.write_text("")
     await orchestrator.handle_change_event(
@@ -1026,6 +1027,7 @@ async def test_eval_settings_wired(
         orchestrator.config.eval_max_memory_size, 1234
     )
     assert settings.netrc_file == netrc
+    assert settings.eval_systems == ["aarch64-linux"]
 
 
 async def test_eval_netrc_withheld_from_pr_with_instance_wide_creds(

--- a/nixosModules/nixbot.nix
+++ b/nixosModules/nixbot.nix
@@ -34,6 +34,7 @@ let
   serviceConfig = (pkgs.formats.json { }).generate "nixbot-config.json" (
     {
       build_systems = cfg.buildSystems;
+      eval_systems = cfg.evalSystems;
       url = baseUrl;
       webhook_base_url = cfg.webhookBaseUrl;
       state_dir = "/var/lib/nixbot";
@@ -248,6 +249,12 @@ in
       default = [ pkgs.stdenv.hostPlatform.system ];
       defaultText = lib.literalExpression "[ pkgs.stdenv.hostPlatform.system ]";
       description = "Systems to build (others come via nix remote builders).";
+    };
+
+    evalSystems = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Systems to evaluate; an empty list evaluates every system exposed by the flake.";
     };
 
     buildConcurrency = lib.mkOption {


### PR DESCRIPTION
Limit evaluation traversal to the instance build systems when a repository does not declare herculesCI.ciSystems, because Linux-only runners otherwise evaluate every known platform and can remain in cache-status evaluation long after all buildable attributes finish. Explicit repository ciSystems settings still take precedence. Verified with the nix-eval and pipeline test suites and a deployment where the previously stuck build evaluated only x86_64-linux checks and completed successfully.