### PR TITLE
nix_eval: pin worktree eval to its HEAD rev

### DIFF
--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -22,6 +22,7 @@ import itertools
 import json
 import logging
 import os
+import re
 import signal
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -170,18 +171,50 @@ def build_select_expr(branch_config: BranchConfig, settings: EvalSettings) -> st
     )
 
 
+def detached_head_rev(worktree_path: Path) -> str | None:
+    """HEAD commit of a detached checkout; None on a branch or non-git dir."""
+    git = worktree_path / ".git"
+    try:
+        if git.is_file():  # linked worktree: pointer file to the gitdir
+            pointer = git.read_text().strip()
+            if not pointer.startswith("gitdir: "):
+                return None
+            gitdir = worktree_path / pointer.removeprefix("gitdir: ")
+        else:
+            gitdir = git
+        head = (gitdir / "HEAD").read_text().strip()
+    except OSError:
+        return None
+    return head if re.fullmatch(r"[0-9a-fA-F]{40,64}", head) else None
+
+
+def build_flake_ref(worktree_path: Path, branch_config: BranchConfig) -> str:
+    """Pin the worktree to its HEAD rev: locking from the plain directory
+    uses nix's workdir export, whose narHash includes checked-out
+    submodule contents, while the eval workers re-fetch the locked
+    __final input by rev (submodules as empty dirs) and fail the
+    narHash check (nix >= 2.36)."""
+    rev = detached_head_rev(worktree_path)
+    if rev is None:
+        return branch_config.flake_dir
+    url = f"git+file://{worktree_path}?rev={rev}"
+    if branch_config.flake_dir != ".":
+        url += f"&dir={branch_config.flake_dir}"
+    return url
+
+
 def build_eval_command(
-    branch_config: BranchConfig, settings: EvalSettings
+    worktree_path: Path, branch_config: BranchConfig, settings: EvalSettings
 ) -> list[str]:
     """The plain nix-eval-jobs invocation (without sandbox wrapping)."""
+    flake = build_flake_ref(worktree_path, branch_config)
     if branch_config.legacy_eval:
         # Deprecated buildbot-nix behaviour: no herculesCI traversal,
         # no build modifiers, unprefixed attribute names.
         logger.warning("legacy_eval is deprecated and will be removed")
-        flake = f"{branch_config.flake_dir}#{branch_config.attribute}"
+        flake = f"{flake}#{branch_config.attribute}"
         select_args = []
     else:
-        flake = branch_config.flake_dir
         select_args = [
             "--select",
             build_select_expr(branch_config, settings),
@@ -428,7 +461,7 @@ def build_full_command(
         cmd += build_systemd_scope_command(settings)
     if settings.sandbox:
         cmd += build_sandbox_command(worktree_path, settings)
-    cmd += build_eval_command(branch_config, settings)
+    cmd += build_eval_command(worktree_path, branch_config, settings)
     return cmd
 
 

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -31,6 +31,8 @@ from nixbot.nix_eval import (
 )
 from nixbot.repo_config import BranchConfig
 
+from .support import git, init_upstream
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -41,7 +43,7 @@ def test_eval_command(tmp_path: Path) -> None:
     settings = EvalSettings(
         gc_roots_dir=tmp_path / "gcroots", worker_count=4, max_memory_size_mib=1024
     )
-    cmd = build_eval_command(BranchConfig(), settings)
+    cmd = build_eval_command(tmp_path, BranchConfig(), settings)
     assert cmd[0] == "nix-eval-jobs"
     assert "--workers" in cmd
     assert cmd[cmd.index("--workers") + 1] == "4"
@@ -62,6 +64,7 @@ def test_eval_command(tmp_path: Path) -> None:
 
     settings.show_trace = True
     cmd = build_eval_command(
+        tmp_path,
         BranchConfig(flake_dir="sub", lock_file="alt.lock", attribute="hydraJobs"),
         settings,
     )
@@ -71,13 +74,36 @@ def test_eval_command(tmp_path: Path) -> None:
     assert cmd[cmd.index("--reference-lock-file") + 1] == "alt.lock"
 
     # A dotted attribute selects the nested path, like `--flake .#a.b` did.
-    cmd = build_eval_command(BranchConfig(attribute="hydraJobs.ci"), settings)
+    cmd = build_eval_command(tmp_path, BranchConfig(attribute="hydraJobs.ci"), settings)
     assert json.dumps(json.dumps(["hydraJobs", "ci"])) in cmd[cmd.index("--select") + 1]
+
+
+def test_eval_command_pins_worktree_rev(tmp_path: Path) -> None:
+    repo = init_upstream(tmp_path / "wt")
+    settings = EvalSettings(gc_roots_dir=tmp_path / "gcroots")
+
+    cmd = build_eval_command(repo, BranchConfig(), settings)
+    assert cmd[cmd.index("--flake") + 1] == "."
+
+    rev = git(repo, "rev-parse", "HEAD")
+    git(repo, "checkout", "-q", "--detach")
+
+    cmd = build_eval_command(repo, BranchConfig(), settings)
+    assert cmd[cmd.index("--flake") + 1] == f"git+file://{repo}?rev={rev}"
+
+    cmd = build_eval_command(repo, BranchConfig(flake_dir="sub"), settings)
+    assert cmd[cmd.index("--flake") + 1] == f"git+file://{repo}?rev={rev}&dir=sub"
+
+    cmd = build_eval_command(
+        repo, BranchConfig(attribute="hydraJobs", legacy_eval=True), settings
+    )
+    assert cmd[cmd.index("--flake") + 1] == f"git+file://{repo}?rev={rev}#hydraJobs"
 
 
 def test_eval_command_legacy_eval(tmp_path: Path) -> None:
     settings = EvalSettings(gc_roots_dir=tmp_path / "gcroots")
     cmd = build_eval_command(
+        tmp_path,
         BranchConfig(flake_dir="sub", attribute="hydraJobs", legacy_eval=True),
         settings,
     )


### PR DESCRIPTION
Since nix 2.36 pre-releases, every build of a repo with submodules
fails to evaluate. When nix-eval-jobs is handed the worktree as a
plain directory, nix locks the flake by checksumming the files on
disk, which include the checked-out submodule contents. The eval
workers then re-fetch the locked input from git history by commit ID,
where submodules are only empty placeholder directories. The two
checksums differ and the __final lock check fails:

  error: mismatch in field 'narHash' of input
  '{..."narHash":"sha256-bx4L...","rev":"43b725f7..."}', got
  '{..."narHash":"sha256-8EHv...","rev":"43b725f7..."}'

Pass git+file://<worktree>?rev=<HEAD> instead, so both steps use the
git-history view and the checksums agree. Build worktrees are always
detached, so HEAD is a plain file containing the commit hash and can
be read without spawning git.