### PR TITLE
RFC: drop herculesCI job traversal

### DIFF
--- a/examples/nixbot.toml
+++ b/examples/nixbot.toml
@@ -29,8 +29,3 @@
 # default-branch effects. Only enable this when you trust all contributors or
 # no secrets are configured.
 #effects_on_pull_requests = false
-
-# Deprecated: evaluate `flake_dir#attribute` directly like buildbot-nix did
-# (no herculesCI/onPush jobs, no build modifiers, unprefixed attribute names).
-# Eases migration of existing repos and will be removed in a future release.
-#legacy_eval = false

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -162,20 +162,6 @@ def _eval_settings(
     netrc_file = None
     if credentials is not None and (event.pr_number is None or credentials.repo_scoped):
         netrc_file = credentials.netrc_file
-    # Arguments hercules-ci-agent passes to the flake's herculesCI
-    # function; tag is unknown here (builds are branch/PR driven).
-    primary_repo = {
-        "name": event.repo.repo,
-        "owner": event.repo.owner,
-        "branch": event.branch,
-        "ref": f"refs/heads/{event.branch}",
-        "tag": None,
-        "rev": event.commit_sha,
-        "shortRev": event.commit_sha[:7],
-        "remoteHttpUrl": event.repo.clone_url,
-        "forgeType": event.repo.forge,
-    }
-    hercules_args = {"primaryRepo": primary_repo, **primary_repo}
     return EvalSettings(
         gc_roots_dir=o.gcroots_dir(build),
         timeout=o.config.eval_timeout,
@@ -186,8 +172,8 @@ def _eval_settings(
         # The worktree's .git points into the central clone. The
         # sandboxed evaluator needs to read it.
         extra_ro_paths=[o.repos.clone_path(event.repo.key)],
-        hercules_args=hercules_args,
         eval_systems=o.config.eval_systems,
+        legacy_attr_prefix=o.config.legacy_attr_prefix,
     )
 
 

--- a/nixbot/nixbot/config.py
+++ b/nixbot/nixbot/config.py
@@ -307,6 +307,9 @@ class Config(BaseModel):
     db_url_file: Path | None = None
     build_systems: list[str]
     eval_systems: list[str] = []
+    # Keep the historic "default." attribute prefix (and the status
+    # contexts derived from it) for deployments predating its removal.
+    legacy_attr_prefix: bool = False
     url: str
 
     # Webhook URL may differ from the UI URL (e.g. split ingress).

--- a/nixbot/nixbot/nix/apply.nix
+++ b/nixbot/nixbot/nix/apply.nix
@@ -1,0 +1,8 @@
+# nix-eval-jobs --apply function: hercules-ci build modifiers per
+# derivation, delivered as `extraValue` in the job JSON.
+drv: {
+  buildDependenciesOnly =
+    (drv.buildDependenciesOnly or false) || (drv.phases or null) == [ "noBuildPhase" ];
+  ignoreFailure = drv.ignoreFailure or false;
+  requireFailure = drv.requireFailure or false;
+}

--- a/nixbot/nixbot/nix/select.nix
+++ b/nixbot/nixbot/nix/select.nix
@@ -1,0 +1,55 @@
+# nix-eval-jobs --select function: build the configured attribute
+# (default `checks`) as job `default.<attribute>.`. Effects are
+# discovered separately by nixbot_effects.
+{
+  # The configured attribute as a path, e.g. [ "hydraJobs" "ci" ].
+  attrPath,
+  # Instance-configured systems; null builds everything.
+  evalSystems,
+  # Historic "default" job prefix for compat; null omits it.
+  jobPrefix,
+}:
+flake:
+let
+  perSystemOutputs = [
+    "checks"
+    "packages"
+    "devShells"
+    "formatter"
+  ];
+  isDrv = v: (v.type or null) == "derivation";
+  # Lazy in the attr values so a throwing attribute is reported at its
+  # own path instead of failing the whole set.
+  prune =
+    v:
+    if !builtins.isAttrs v || isDrv v then
+      v
+    else if v ? _type || !(v.recurseForDerivations or true) then
+      { }
+    else
+      builtins.mapAttrs (n: prune) v;
+  getAt =
+    set: path: builtins.foldl' (s: n: if builtins.isAttrs s && s ? ${n} then s.${n} else { }) set path;
+  setAt =
+    path: v: if path == [ ] then v else { ${builtins.head path} = setAt (builtins.tail path) v; };
+  configured0 = getAt flake.outputs attrPath;
+  # Only schema outputs have systems at the top level; hydraJobs etc.
+  # have arbitrary names there and must not be filtered.
+  configured =
+    if
+      evalSystems != null
+      && builtins.isAttrs configured0
+      && builtins.length attrPath == 1
+      && builtins.elem (builtins.head attrPath) perSystemOutputs
+    then
+      builtins.intersectAttrs (builtins.listToAttrs (
+        map (s: {
+          name = s;
+          value = { };
+        }) evalSystems
+      )) configured0
+    else
+      configured0;
+  job = setAt attrPath (prune configured);
+in
+if jobPrefix == null then job else { ${jobPrefix} = job; }

--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -154,19 +154,12 @@ def build_eval_command(
 ) -> list[str]:
     """The plain nix-eval-jobs invocation (without sandbox wrapping)."""
     flake = build_flake_ref(worktree_path, branch_config)
-    if branch_config.legacy_eval:
-        # Deprecated buildbot-nix behaviour: no herculesCI traversal,
-        # no build modifiers, unprefixed attribute names.
-        logger.warning("legacy_eval is deprecated and will be removed")
-        flake = f"{flake}#{branch_config.attribute}"
-        select_args = []
-    else:
-        select_args = [
-            "--select",
-            build_select_expr(branch_config, settings),
-            "--apply",
-            APPLY_EXPR,
-        ]
+    select_args = [
+        "--select",
+        build_select_expr(branch_config, settings),
+        "--apply",
+        APPLY_EXPR,
+    ]
     return [
         "nix-eval-jobs",
         # The service drives nix entirely through flakes. On hosts where

--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -26,7 +26,7 @@ import re
 import signal
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from .ansi import strip_ansi
 from .environ import passthrough_env
@@ -88,12 +88,11 @@ class EvalSettings:
     extra_ro_paths: list[Path] = field(default_factory=list)
     # Extra nix-eval-jobs arguments, e.g. --option overrides.
     extra_args: list[str] = field(default_factory=list)
-    # herculesCI arguments (primaryRepo, rev, branch, ...) passed to the
-    # flake's herculesCI output when it is a function.
-    hercules_args: dict[str, Any] = field(default_factory=dict)
-    # Instance systems are the fallback when the repository does not set
-    # herculesCI.ciSystems. Empty preserves evaluation of every flake system.
+    # Instance systems limit which per-system outputs are evaluated.
+    # Empty evaluates every system.
     eval_systems: list[str] = field(default_factory=list)
+    # See Config.legacy_attr_prefix.
+    legacy_attr_prefix: bool = False
 
 
 @dataclass
@@ -101,79 +100,19 @@ class EvalResult:
     jobs: list[NixEvalJob]
 
 
-# nix-eval-jobs --select function: the configured attribute (default
-# `checks`) is always built as `default.<attribute>.`; a `herculesCI`
-# output adds every onPush.<job>.outputs (minus `effects`) on top under
-# the attr prefix `<job>.`, following hercules-ci-agent traversal
-# (`recurseForDerivations = false` and `_type` stop recursion, ciSystems
-# filters per-system sets).
-SELECT_TEMPLATE = """
-flake:
-let
-  args = builtins.fromJSON {args_json};
-  # The configured attribute as a path, e.g. [ "hydraJobs" "ci" ].
-  attrPath = builtins.fromJSON {attr_path_json};
-  outputs = flake.outputs;
-  call = f: if builtins.isFunction f then f args else f;
-  hci = call (outputs.herculesCI or {{}});
-  knownSystems = [
-    "x86_64-linux" "aarch64-linux" "i686-linux" "armv7l-linux"
-    "riscv64-linux" "powerpc64le-linux" "x86_64-darwin" "aarch64-darwin"
-  ];
-  configuredSystems = builtins.fromJSON {eval_systems_json};
-  ciSystems = hci.ciSystems or configuredSystems;
-  keepName = name: ciSystems == null || !(builtins.elem name knownSystems)
-    || builtins.elem name ciSystems;
-  isDrv = v: (v.type or null) == "derivation";
-  # Lazy in the attr values so a throwing attribute is reported by
-  # nix-eval-jobs at its own path instead of failing the whole set.
-  # Excluded subtrees become {{}} (yield no jobs).
-  prune = builtins.mapAttrs (n: c:
-    if !keepName n then {{}}
-    else if !builtins.isAttrs c || isDrv c then c
-    else if c ? _type || !(c.recurseForDerivations or true) then {{}}
-    else prune c);
-  jobOutputs = j: builtins.removeAttrs (call (j.outputs or {{}})) [ "effects" ];
-  onPushJobs = builtins.mapAttrs (job: j: prune (jobOutputs j)) (hci.onPush or {{}});
-  getAt = set: path: builtins.foldl'
-    (s: n: if builtins.isAttrs s && s ? ${{n}} then s.${{n}} else {{}}) set path;
-  setAt = path: v: if path == [ ] then v
-    else {{ ${{builtins.head path}} = setAt (builtins.tail path) v; }};
-  configured = getAt outputs attrPath;
-  # onPush.default wins over the raw flake attribute on conflicts.
-  update = lhs: rhs: lhs // builtins.mapAttrs (n: v:
-    if lhs ? ${{n}} && builtins.isAttrs lhs.${{n}} && !isDrv lhs.${{n}}
-       && builtins.isAttrs v && !isDrv v
-    then update lhs.${{n}} v else v) rhs;
-  defaultJob = update
-    (setAt attrPath
-      (if builtins.isAttrs configured && !isDrv configured
-       then prune configured else configured))
-    (onPushJobs.default or {{}});
-in
-onPushJobs // {{ default = defaultJob; }}
-"""
-
-
-# nix-eval-jobs --apply function: hercules-ci build modifiers per
-# derivation, delivered as `extraValue` in the job JSON.
-APPLY_EXPR = """
-drv: {
-  buildDependenciesOnly = (drv.buildDependenciesOnly or false)
-    || (drv.phases or null) == [ "noBuildPhase" ];
-  ignoreFailure = drv.ignoreFailure or false;
-  requireFailure = drv.requireFailure or false;
-}
-"""
+_NIX_DIR = Path(__file__).parent / "nix"
+SELECT_FN = (_NIX_DIR / "select.nix").read_text()
+APPLY_EXPR = (_NIX_DIR / "apply.nix").read_text()
 
 
 def build_select_expr(branch_config: BranchConfig, settings: EvalSettings) -> str:
-    return SELECT_TEMPLATE.format(
-        args_json=json.dumps(json.dumps(settings.hercules_args)),
-        eval_systems_json=json.dumps(json.dumps(settings.eval_systems or None)),
+    params = {
+        "evalSystems": settings.eval_systems or None,
+        "jobPrefix": "default" if settings.legacy_attr_prefix else None,
         # The attribute may be a dotted path (e.g. "hydraJobs.ci").
-        attr_path_json=json.dumps(json.dumps(branch_config.attribute.split("."))),
-    )
+        "attrPath": branch_config.attribute.split("."),
+    }
+    return f"({SELECT_FN}) (builtins.fromJSON {json.dumps(json.dumps(params))})"
 
 
 def detached_head_rev(worktree_path: Path) -> str | None:

--- a/nixbot/nixbot/repo_config.py
+++ b/nixbot/nixbot/repo_config.py
@@ -39,9 +39,6 @@ class BranchConfig(BaseModel):
     # configured branch globs. Default branch and merge-queue
     # branches always build. None means the global config applies.
     build_branches: list[str] | None = None
-    # Deprecated: evaluate `flake_dir#attribute` directly like
-    # buildbot-nix did (no herculesCI traversal, no job prefix).
-    legacy_eval: bool = False
 
     @classmethod
     def loads(cls, text: str | None) -> Self:

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -357,7 +357,12 @@ def attr_status_context(
     prefix: str = "checks",
     context_prefix: str = "nixbot",
 ) -> str:
-    return f"{context_prefix}/nix-build {forge}:{project_name}#{prefix}.{attr}"
+    # Attrs already contain the configured attribute path unless they
+    # carry the legacy "default." job prefix; avoid doubling it.
+    name = (
+        attr if attr == prefix or attr.startswith(f"{prefix}.") else f"{prefix}.{attr}"
+    )
+    return f"{context_prefix}/nix-build {forge}:{project_name}#{name}"
 
 
 def effect_status_context(

--- a/nixbot/nixbot/tests/test_flake_prefetch.py
+++ b/nixbot/nixbot/tests/test_flake_prefetch.py
@@ -145,7 +145,7 @@ async def test_prefetch_integration(tmp_path: Path) -> None:
         gc_roots_dir=tmp_path / "eval-gcroots", sandbox=False, systemd_scope=False
     )
     result = await EvalRunner().run(repo, BranchConfig(), settings)
-    assert [j.attr for j in result.jobs] == ["default.checks.x86_64-linux.ok"]
+    assert [j.attr for j in result.jobs] == ["checks.x86_64-linux.ok"]
 
 
 @needs_nix

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -49,11 +49,10 @@ def test_eval_command(tmp_path: Path) -> None:
     assert cmd[cmd.index("--workers") + 1] == "4"
     assert cmd[cmd.index("--max-memory-size") + 1] == "1024"
     assert cmd[cmd.index("--flake") + 1] == "."
-    # The --select expression maps the flake's herculesCI onPush jobs (or
-    # the configured attribute as job "default") to the attrs to build.
+    # The --select expression maps the configured attribute to job
+    # "default".
     select = cmd[cmd.index("--select") + 1]
-    assert json.dumps(json.dumps(["checks"])) in select
-    assert "herculesCI" in select
+    assert '\\"attrPath\\": [\\"checks\\"]' in select
     # Build modifiers (buildDependenciesOnly, ...) are exported per drv.
     assert "requireFailure" in cmd[cmd.index("--apply") + 1]
     # Flakes and nix-command must be opted-in for hosts where the
@@ -70,12 +69,13 @@ def test_eval_command(tmp_path: Path) -> None:
     )
     assert "--show-trace" in cmd
     assert cmd[cmd.index("--flake") + 1] == "sub"
-    assert json.dumps(json.dumps(["hydraJobs"])) in cmd[cmd.index("--select") + 1]
+    assert '\\"attrPath\\": [\\"hydraJobs\\"]' in cmd[cmd.index("--select") + 1]
     assert cmd[cmd.index("--reference-lock-file") + 1] == "alt.lock"
 
     # A dotted attribute selects the nested path, like `--flake .#a.b` did.
     cmd = build_eval_command(tmp_path, BranchConfig(attribute="hydraJobs.ci"), settings)
-    assert json.dumps(json.dumps(["hydraJobs", "ci"])) in cmd[cmd.index("--select") + 1]
+    select = cmd[cmd.index("--select") + 1]
+    assert '\\"attrPath\\": [\\"hydraJobs\\", \\"ci\\"]' in select
 
 
 def test_eval_command_pins_worktree_rev(tmp_path: Path) -> None:
@@ -253,24 +253,25 @@ async def test_eval_runner_integration(tmp_path: Path) -> None:
     )
     assert len(result.jobs) == 1
     job = result.jobs[0]
-    assert job.attr == "default.checks.x86_64-linux.ok"  # type: ignore[union-attr]
+    assert job.attr == "checks.x86_64-linux.ok"  # type: ignore[union-attr]
     assert any("eval warning here" in line for line in seen)
 
     # Dotted attribute config selects the nested path.
     result = await EvalRunner().run(
         flake, BranchConfig(attribute="hydraJobs.ci"), settings
     )
-    assert [j.attr for j in result.jobs] == ["default.hydraJobs.ci.x86_64-linux.nested"]
+    assert [j.attr for j in result.jobs] == ["hydraJobs.ci.x86_64-linux.nested"]
 
 
 @pytest.mark.skipif(
     shutil.which("nix-eval-jobs") is None or shutil.which("nix") is None,
     reason="nix-eval-jobs not available",
 )
-async def test_eval_runner_hercules_ci_jobs(tmp_path: Path) -> None:
-    """Every onPush job is built under its job prefix in addition to the
-    checks fallback; effects and opted-out attrsets are excluded and
-    per-system attrsets are filtered by ciSystems."""
+async def test_eval_runner_ignores_hercules_ci_outputs(tmp_path: Path) -> None:
+    """Only the configured attribute is built, filtered by
+    eval_systems. herculesCI outputs (onPush jobs, ciSystems) are not
+    evaluated here; effects discovery is nixbot_effects' job.
+    """
     flake = tmp_path / "repo"
     flake.mkdir()
     (flake / "flake.nix").write_text(
@@ -283,6 +284,12 @@ async def test_eval_runner_hercules_ci_jobs(tmp_path: Path) -> None:
               builder = "/bin/sh";
               args = [ "-c" "echo extra > $out" ];
             };
+            checks.aarch64-linux.kept = derivation {
+              name = "kept";
+              system = "aarch64-linux";
+              builder = "/bin/sh";
+              args = [ "-c" "echo no > $out" ];
+            };
             herculesCI = { primaryRepo, ... }: {
               ciSystems = [ "x86_64-linux" ];
               onPush.default.outputs = {
@@ -292,11 +299,11 @@ async def test_eval_runner_hercules_ci_jobs(tmp_path: Path) -> None:
                   builder = "/bin/sh";
                   args = [ "-c" "echo ok > $out" ];
                 };
-                checks.aarch64-linux.skipped-system = derivation {
-                  name = "skipped";
+                checks.aarch64-linux.unfiltered = derivation {
+                  name = "unfiltered";
                   system = "aarch64-linux";
                   builder = "/bin/sh";
-                  args = [ "-c" "echo no > $out" ];
+                  args = [ "-c" "echo yes > $out" ];
                 };
                 effects.deploy = { isEffect = true; };
                 ignored = { recurseForDerivations = false; hidden = self; };
@@ -316,19 +323,12 @@ async def test_eval_runner_hercules_ci_jobs(tmp_path: Path) -> None:
         gc_roots_dir=tmp_path / "gcroots",
         sandbox=False,
         systemd_scope=False,
-        hercules_args={
-            "primaryRepo": {"rev": "abcdef1234567", "shortRev": "abcdef1"},
-            "rev": "abcdef1234567",
-            "shortRev": "abcdef1",
-        },
         eval_systems=["aarch64-linux"],
     )
     result = await EvalRunner().run(flake, BranchConfig(), settings)
     attrs = {job.attr: job.name for job in result.jobs}  # type: ignore[union-attr]
     assert attrs == {
-        "default.checks.x86_64-linux.extra": "extra",
-        "default.checks.x86_64-linux.ok": "ok-abcdef1",
-        "docs.site": "site",
+        "checks.aarch64-linux.kept": "kept",
     }
 
 
@@ -342,11 +342,11 @@ async def test_eval_runner_hercules_ci_jobs(tmp_path: Path) -> None:
         (
             [],
             [
-                "default.checks.aarch64-linux.foreign",
-                "default.checks.x86_64-linux.native",
+                "checks.aarch64-linux.foreign",
+                "checks.x86_64-linux.native",
             ],
         ),
-        (["x86_64-linux"], ["default.checks.x86_64-linux.native"]),
+        (["x86_64-linux"], ["checks.x86_64-linux.native"]),
     ],
 )
 async def test_eval_runner_filters_configured_eval_systems(
@@ -384,6 +384,41 @@ async def test_eval_runner_filters_configured_eval_systems(
     result = await EvalRunner().run(flake, BranchConfig(), settings)
 
     assert [job.attr for job in result.jobs] == expected_attrs
+
+
+@pytest.mark.skipif(
+    shutil.which("nix-eval-jobs") is None or shutil.which("nix") is None,
+    reason="nix-eval-jobs not available",
+)
+async def test_eval_runner_legacy_attr_prefix(tmp_path: Path) -> None:
+    """legacy_attr_prefix keeps the historic default. job prefix so
+    existing deployments retain attribute names and status contexts."""
+    flake = tmp_path / "repo"
+    flake.mkdir()
+    (flake / "flake.nix").write_text(
+        """
+        {
+          outputs = { self }: {
+            checks.x86_64-linux.native = derivation {
+              name = "native";
+              system = "x86_64-linux";
+              builder = "/bin/sh";
+              args = [ "-c" "echo native > $out" ];
+            };
+          };
+        }
+        """
+    )
+    settings = EvalSettings(
+        gc_roots_dir=tmp_path / "gcroots",
+        sandbox=False,
+        systemd_scope=False,
+        legacy_attr_prefix=True,
+    )
+
+    result = await EvalRunner().run(flake, BranchConfig(), settings)
+
+    assert [job.attr for job in result.jobs] == ["default.checks.x86_64-linux.native"]
 
 
 async def test_stderr_noise_filtered_and_warnings_reach_callback(

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -96,28 +96,6 @@ def test_eval_command_pins_worktree_rev(tmp_path: Path) -> None:
         cmd[cmd.index("--flake") + 1] == f"git+file://{repo}?ref=HEAD&rev={rev}&dir=sub"
     )
 
-    cmd = build_eval_command(
-        repo, BranchConfig(attribute="hydraJobs", legacy_eval=True), settings
-    )
-    assert (
-        cmd[cmd.index("--flake") + 1]
-        == f"git+file://{repo}?ref=HEAD&rev={rev}#hydraJobs"
-    )
-
-
-def test_eval_command_legacy_eval(tmp_path: Path) -> None:
-    settings = EvalSettings(gc_roots_dir=tmp_path / "gcroots")
-    cmd = build_eval_command(
-        tmp_path,
-        BranchConfig(flake_dir="sub", attribute="hydraJobs", legacy_eval=True),
-        settings,
-    )
-    # Deprecated compat mode: evaluate the attribute directly like
-    # buildbot-nix did, without herculesCI traversal or --apply.
-    assert cmd[cmd.index("--flake") + 1] == "sub#hydraJobs"
-    assert "--select" not in cmd
-    assert "--apply" not in cmd
-
 
 def test_sandbox_command_mounts(tmp_path: Path) -> None:
     netrc = tmp_path / "netrc"

--- a/nixbot/nixbot/tests/test_pipeline.py
+++ b/nixbot/nixbot/tests/test_pipeline.py
@@ -130,54 +130,50 @@ async def test_full_pipeline(flake: Path, tmp_path: Path) -> None:
 
     # Eval fan-out: every attribute got its own record.
     assert set(statuses) == {
-        f"default.checks.{system}.base",
-        f"default.checks.{system}.dependent",
-        f"default.checks.{system}.broken",
-        f"default.checks.{system}.brokendep",
-        f"default.checks.{system}.evalfail",
-        f"default.checks.{system}.ignoredfail",
-        f"default.checks.{system}.mustfail",
-        f"default.checks.{system}.depsonly",
+        f"checks.{system}.base",
+        f"checks.{system}.dependent",
+        f"checks.{system}.broken",
+        f"checks.{system}.brokendep",
+        f"checks.{system}.evalfail",
+        f"checks.{system}.ignoredfail",
+        f"checks.{system}.mustfail",
+        f"checks.{system}.depsonly",
     }
 
     # hercules-ci build modifiers: an ignored failure is recorded but not a
     # failure, requireFailure inverts the result, buildDependenciesOnly
     # builds only the dependency and never runs the failing script.
-    assert statuses[f"default.checks.{system}.ignoredfail"] == (
-        AttributeStatus.ignored_failure
-    )
-    assert statuses[f"default.checks.{system}.mustfail"] == AttributeStatus.succeeded
-    assert statuses[f"default.checks.{system}.depsonly"] == AttributeStatus.succeeded
+    assert statuses[f"checks.{system}.ignoredfail"] == (AttributeStatus.ignored_failure)
+    assert statuses[f"checks.{system}.mustfail"] == AttributeStatus.succeeded
+    assert statuses[f"checks.{system}.depsonly"] == AttributeStatus.succeeded
 
     # Failure aggregation: eval failure, build failure, dependency failure.
-    assert statuses[f"default.checks.{system}.evalfail"] == AttributeStatus.failed_eval
-    assert statuses[f"default.checks.{system}.broken"] == AttributeStatus.failed
-    assert statuses[f"default.checks.{system}.brokendep"] in {
+    assert statuses[f"checks.{system}.evalfail"] == AttributeStatus.failed_eval
+    assert statuses[f"checks.{system}.broken"] == AttributeStatus.failed
+    assert statuses[f"checks.{system}.brokendep"] in {
         AttributeStatus.failed,
         AttributeStatus.dependency_failed,
     }
     assert not result.success
 
     # Successful chain really built in the local store.
-    assert statuses[f"default.checks.{system}.base"] in {
+    assert statuses[f"checks.{system}.base"] in {
         AttributeStatus.succeeded,
         AttributeStatus.skipped_local,
     }
-    assert statuses[f"default.checks.{system}.dependent"] in {
+    assert statuses[f"checks.{system}.dependent"] in {
         AttributeStatus.succeeded,
         AttributeStatus.skipped_local,
     }
 
     # Real build log captured for the broken attribute.
-    if f"default.checks.{system}.broken" in executor.built:
-        log = read_log(tmp_path / f"default.checks.{system}.broken.zst")
+    if f"checks.{system}.broken" in executor.built:
+        log = read_log(tmp_path / f"checks.{system}.broken.zst")
         assert b"build error details" in log
 
     # Error text preserved for the eval failure.
     errors = {r.attr: r.error for r in result.results}
-    assert "deliberate eval failure" in (
-        errors[f"default.checks.{system}.evalfail"] or ""
-    )
+    assert "deliberate eval failure" in (errors[f"checks.{system}.evalfail"] or "")
 
 
 async def test_cached_skip_on_second_run(flake: Path, tmp_path: Path) -> None:
@@ -186,12 +182,10 @@ async def test_cached_skip_on_second_run(flake: Path, tmp_path: Path) -> None:
     result, executor = await run_pipeline(flake, tmp_path)
     system = current_system()
     statuses = {r.attr: r.status for r in result.results}
-    assert statuses[f"default.checks.{system}.base"] == AttributeStatus.skipped_local
-    assert (
-        statuses[f"default.checks.{system}.dependent"] == AttributeStatus.skipped_local
-    )
-    assert f"default.checks.{system}.base" not in executor.built
-    assert f"default.checks.{system}.dependent" not in executor.built
+    assert statuses[f"checks.{system}.base"] == AttributeStatus.skipped_local
+    assert statuses[f"checks.{system}.dependent"] == AttributeStatus.skipped_local
+    assert f"checks.{system}.base" not in executor.built
+    assert f"checks.{system}.dependent" not in executor.built
     # Skipped jobs still expose out paths for gcroots/outputs updates.
     skipped = dict(result.skipped_out_paths)
-    assert skipped[f"default.checks.{system}.base"].startswith("/nix/store/")
+    assert skipped[f"checks.{system}.base"].startswith("/nix/store/")

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -169,6 +169,17 @@ def test_context_names_default() -> None:
         attr_status_context("github", "acme/widget", "x86_64-linux.foo")
         == "nixbot/nix-build github:acme/widget#checks.x86_64-linux.foo"
     )
+    # Attrs already carrying the configured attribute path are not
+    # doubled up.
+    assert (
+        attr_status_context("github", "acme/widget", "checks.x86_64-linux.foo")
+        == "nixbot/nix-build github:acme/widget#checks.x86_64-linux.foo"
+    )
+    # The legacy default. job prefix keeps its historic context names.
+    assert (
+        attr_status_context("github", "acme/widget", "default.checks.x86_64-linux.foo")
+        == "nixbot/nix-build github:acme/widget#checks.default.checks.x86_64-linux.foo"
+    )
 
 
 async def test_context_prefix_configurable() -> None:

--- a/nixbot_effects/nixbot_effects/eval.py
+++ b/nixbot_effects/nixbot_effects/eval.py
@@ -82,6 +82,8 @@ async def effects_args(opts: EffectsOptions) -> dict[str, Any]:
     return {
         "primaryRepo": primary_repo,
         **primary_repo,
+        # HerculesCIMeta: ciSystems null = no platform default
+        "herculesCI": {"apiBaseUrl": opts.api_base_url, "ciSystems": None},
     }
 
 
@@ -101,12 +103,22 @@ async def _effects_expr(opts: EffectsOptions, body: str) -> str:
     rev = args["rev"]
     escaped_args = json.dumps(json.dumps(args))
     url = json.dumps(_flake_url(opts, rev))
+    # ciSystems normalization follows addDefaults in hercules-ci-agent's
+    # default-herculesCI-for-flake.nix.
     return f"""
       let
         flake = builtins.getFlake {url};
-        args = builtins.fromJSON {escaped_args};
-        call = f: if builtins.isFunction f then f args else f;
-        hci = call (flake.outputs.herculesCI or {{}});
+        evalArgs = builtins.fromJSON {escaped_args};
+        optionalCall = f: a: if builtins.isFunction f then f a else f;
+        hci = optionalCall (flake.outputs.herculesCI or {{}}) evalArgs;
+        args = evalArgs // {{
+          ciSystems =
+            if hci ? ciSystems
+            then builtins.listToAttrs
+              (map (s: {{ name = s; value = {{ }}; }}) hci.ciSystems)
+            else evalArgs.herculesCI.ciSystems;
+        }};
+        call = f: optionalCall f args;
       in {body}
     """
 

--- a/nixbot_effects/nixbot_effects/tests/test_ci_systems.py
+++ b/nixbot_effects/nixbot_effects/tests/test_ci_systems.py
@@ -1,0 +1,39 @@
+"""hercules-ci-agent compatibility of the herculesCI arguments."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nixbot_effects.eval import list_effects
+from nixbot_effects.options import EffectsOptions
+from nixbot_effects.tests.support import init_repo
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+FLAKE_NIX = """\
+{
+  outputs = { self, ... }: {
+    herculesCI = { herculesCI, ... }:
+      assert herculesCI ? ciSystems; {
+        ciSystems = [ "x86_64-linux" "aarch64-darwin" ];
+        onPush.default.outputs = { ciSystems, ... }:
+          assert ciSystems == { x86_64-linux = { }; aarch64-darwin = { }; }; {
+            effects.deploy = derivation {
+              name = "deploy";
+              system = builtins.currentSystem;
+              builder = "/bin/sh";
+              args = [ "-c" "echo deploy > $out" ];
+            };
+          };
+      };
+  };
+}
+"""
+
+
+async def test_ci_systems_normalized_for_outputs(tmp_path: Path) -> None:
+    repo, _rev = init_repo(tmp_path, {"flake.nix": FLAKE_NIX})
+    effects = await list_effects(EffectsOptions(path=repo))
+    assert list(effects) == ["default.deploy"]

--- a/nixosModules/nixbot.nix
+++ b/nixosModules/nixbot.nix
@@ -35,6 +35,7 @@ let
     {
       build_systems = cfg.buildSystems;
       eval_systems = cfg.evalSystems;
+      legacy_attr_prefix = cfg.legacyAttrPrefix;
       url = baseUrl;
       webhook_base_url = cfg.webhookBaseUrl;
       state_dir = "/var/lib/nixbot";
@@ -255,6 +256,16 @@ in
       type = lib.types.listOf lib.types.str;
       default = [ ];
       description = "Systems to evaluate; an empty list evaluates every system exposed by the flake.";
+    };
+
+    legacyAttrPrefix = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Keep the historic "default." attribute prefix and the commit-status
+        contexts derived from it. Enable on deployments that predate its
+        removal and rely on existing required checks or attribute links.
+      '';
     };
 
     buildConcurrency = lib.mkOption {


### PR DESCRIPTION
Sorry for flip-flopping on this but it feels, I was doing more harm than good with this rather complex code. I would like to keep this a bit open for feedback.
With this change we no longer evaluates the flake's herculesCI output for builds.
Only the configured attribute (default `checks`) is built
Effects via nixbot_effects work as before.

What changes for users:

- onPush build jobs are gone. This is no longer built:
  `herculesCI.onPush.docs.outputs.site = ...;   # not built anymore`
  Move it into `checks` (or point `attribute` at it):
  `checks.x86_64-linux.site = ...;`

- The flake's ciSystems no longer disables systems. A flake with

  `herculesCI.ciSystems = [ "x86_64-linux" ];`

  previously skipped darwin builds even on instances with darwin
  builders. Now only the instance's evalSystems/buildSystems decide.

- Attribute names and status contexts lose the "default." prefix:
  `default.checks.x86_64-linux.foo  ->  checks.x86_64-linux.foo`
  If you rely on the old names (required checks, links), set:
  `services.nixbot.legacyAttrPrefix = true;`