### PR TITLE
web: keep focused search input intact during morph swaps

### DIFF
--- a/nixbot/nixbot/web/templates/_macros.html
+++ b/nixbot/nixbot/web/templates/_macros.html
@@ -48,7 +48,7 @@
             hx-post="/admin/repos/{{ p.id }}/toggle"
             hx-select="#main"
             hx-target="#main"
-            hx-swap="morph:outerHTML">
+            hx-swap="morph:{morphStyle:'outerHTML',ignoreActiveValue:true}">
         <input type="hidden" name="q" value="{{ q }}">
         <button class="toggle-btn">{{ label }}</button>
       </form>

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -21,7 +21,7 @@
         hx-select="#main"
         hx-disinherit="hx-select hx-target hx-swap"
         hx-target="this"
-        hx-swap="morph:outerHTML"
+        hx-swap="morph:{morphStyle:'outerHTML',ignoreActiveValue:true}"
         hx-trigger="{{ trigger }}">
     <section class="content">
       <div class="build-header">

--- a/nixbot/nixbot/web/templates/index.html
+++ b/nixbot/nixbot/web/templates/index.html
@@ -9,7 +9,7 @@
         hx-include="#pipeline-filter"
         hx-select="#main"
         hx-target="this"
-        hx-swap="morph:outerHTML"
+        hx-swap="morph:{morphStyle:'outerHTML',ignoreActiveValue:true}"
         hx-trigger="sse:message throttle:1s">
     <section class="content dashboard">
       <h2 class="section">Repositories</h2>
@@ -22,7 +22,7 @@
                hx-trigger="input changed delay:200ms"
                hx-select="#main"
                hx-target="#main"
-               hx-swap="morph:outerHTML"
+               hx-swap="morph:{morphStyle:'outerHTML',ignoreActiveValue:true}"
                {% if toggleable is none or toggleable %} aria-label="search repos to add" placeholder="search repos to add" {% else %} aria-label="search repositories" placeholder="search repositories" {% endif %}>
         {% if user %}
           <form method="post"
@@ -30,7 +30,7 @@
                 hx-post="/admin/repos/refresh"
                 hx-select="#main"
                 hx-target="#main"
-                hx-swap="morph:outerHTML">
+                hx-swap="morph:{morphStyle:'outerHTML',ignoreActiveValue:true}">
             <input type="hidden" name="q" value="{{ q }}">
             <button class="toggle-btn" title="re-scan forges for new repositories">refresh repos</button>
           </form>


### PR DESCRIPTION

Morphing #main re-syncs the search input's value from the server, so
typing raced against SSE refreshes and the input's own filter request:
the cursor jumped and the query got reset.

Pass ignoreActiveValue:true to idiomorph so the focused element's value
is left alone while the rest of the page morphs.
