### PR TITLE
nix_eval: pass ref=HEAD to silence detached-HEAD warning

### DIFF
--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -198,11 +198,13 @@ def build_flake_ref(worktree_path: Path, branch_config: BranchConfig) -> str:
     uses nix's workdir export, whose narHash includes checked-out
     submodule contents, while the eval workers re-fetch the locked
     __final input by rev (submodules as empty dirs) and fail the
-    narHash check (nix >= 2.36)."""
+    narHash check (nix >= 2.36). ref=HEAD silences nix's "could not
+    read HEAD ref" warning on the detached worktree; the ref is never
+    resolved since rev is pinned."""
     rev = detached_head_rev(worktree_path)
     if rev is None:
         return branch_config.flake_dir
-    url = f"git+file://{worktree_path}?rev={rev}"
+    url = f"git+file://{worktree_path}?ref=HEAD&rev={rev}"
     if branch_config.flake_dir != ".":
         url += f"&dir={branch_config.flake_dir}"
     return url

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -89,15 +89,20 @@ def test_eval_command_pins_worktree_rev(tmp_path: Path) -> None:
     git(repo, "checkout", "-q", "--detach")
 
     cmd = build_eval_command(repo, BranchConfig(), settings)
-    assert cmd[cmd.index("--flake") + 1] == f"git+file://{repo}?rev={rev}"
+    assert cmd[cmd.index("--flake") + 1] == f"git+file://{repo}?ref=HEAD&rev={rev}"
 
     cmd = build_eval_command(repo, BranchConfig(flake_dir="sub"), settings)
-    assert cmd[cmd.index("--flake") + 1] == f"git+file://{repo}?rev={rev}&dir=sub"
+    assert (
+        cmd[cmd.index("--flake") + 1] == f"git+file://{repo}?ref=HEAD&rev={rev}&dir=sub"
+    )
 
     cmd = build_eval_command(
         repo, BranchConfig(attribute="hydraJobs", legacy_eval=True), settings
     )
-    assert cmd[cmd.index("--flake") + 1] == f"git+file://{repo}?rev={rev}#hydraJobs"
+    assert (
+        cmd[cmd.index("--flake") + 1]
+        == f"git+file://{repo}?ref=HEAD&rev={rev}#hydraJobs"
+    )
 
 
 def test_eval_command_legacy_eval(tmp_path: Path) -> None:


### PR DESCRIPTION

Worktrees are checked out detached, so nix's getDefaultRef cannot
resolve a symbolic HEAD and warns 'could not read HEAD ref from repo
..., using master' on every eval. Only an explicit ref= suppresses the
lookup; with rev= pinned the ref is never resolved, so HEAD is safe
even for synthetic PR merge commits that exist on no branch.
