### PR TITLE
effects: silence nix HEAD-ref warning on detached worktrees

### DIFF
--- a/nixbot_effects/nixbot_effects/eval.py
+++ b/nixbot_effects/nixbot_effects/eval.py
@@ -89,10 +89,12 @@ async def effects_args(opts: EffectsOptions) -> dict[str, Any]:
 
 def _flake_url(opts: EffectsOptions, rev: str) -> str:
     """The flake URL for builtins.getFlake: the locked URL of a resolved
-    remote flake ref, otherwise a git+file:// URL of the local path."""
+    remote flake ref, otherwise a git+file:// URL of the local path.
+    ref=HEAD silences nix's "could not read HEAD ref" warning on
+    detached worktrees."""
     if opts.locked_url:
         return opts.locked_url
-    return f"git+file://{opts.path}?rev={rev}#"
+    return f"git+file://{opts.path}?ref=HEAD&rev={rev}#"
 
 
 async def _effects_expr(opts: EffectsOptions, body: str) -> str:

--- a/nixbot_effects/nixbot_effects/tests/test_flake_args.py
+++ b/nixbot_effects/nixbot_effects/tests/test_flake_args.py
@@ -69,7 +69,8 @@ class TestFlakeUrl:
     def test_local_path_fallback(self, locked_url: str | None) -> None:
         opts = EffectsOptions(path=Path("/home/user/my-repo"), locked_url=locked_url)
         assert (
-            _flake_url(opts, "abc1234") == "git+file:///home/user/my-repo?rev=abc1234#"
+            _flake_url(opts, "abc1234")
+            == "git+file:///home/user/my-repo?ref=HEAD&rev=abc1234#"
         )
 
     def test_locked_url_used(self) -> None:


### PR DESCRIPTION

Effect worktrees are checked out with a detached HEAD, so nix logs
"could not read HEAD ref from repo ..., using 'master'" for every
git+file:// flake URL. Pin ref=HEAD alongside rev, as already done for
eval in nix_eval.py; the ref is never resolved since rev is pinned.
