### PR TITLE
effects: set __hci_effect_fsroot_copied to suppress upstream fsroot cp

### DIFF
--- a/nixbot_effects/nixbot_effects/run.py
+++ b/nixbot_effects/nixbot_effects/run.py
@@ -165,6 +165,8 @@ async def _run_in_sandbox(
             drv_env, opts.effect_checkout, etc_dir
         )
         env.update(checkout_env)
+        fsroot_args, fsroot_env = fsroot_mounts(drv_env)
+        env.update(fsroot_env)
         # Private daemon socket: each connection gets its own untrusted
         # nix-daemon, so effects cannot use trusted-user privileges.
         daemon_socket = work_dir / "daemon-socket"
@@ -191,7 +193,7 @@ async def _run_in_sandbox(
                     extra_sandbox_paths=opts.extra_sandbox_paths,
                     bind_mounts=bind_mounts,
                     checkout_args=checkout_args,
-                    fsroot_args=fsroot_mounts(drv_env),
+                    fsroot_args=fsroot_args,
                 ),
                 "--ro-bind",
                 str(secrets_file),

--- a/nixbot_effects/nixbot_effects/sandbox.py
+++ b/nixbot_effects/nixbot_effects/sandbox.py
@@ -106,21 +106,27 @@ EFFECT_CHECKOUT_ATTR = "__nixbot_effect_checkout"
 EFFECT_CHECKOUT_PATH = "/build/checkout"
 
 
-def fsroot_mounts(drv_env: dict[str, str]) -> list[str]:
-    """bwrap arguments for __hci_effect_fsroot_copy, a store path whose
-    top-level entries (bin/sh, usr/bin/env) appear in the sandbox root."""
+def fsroot_mounts(
+    drv_env: dict[str, str], store_prefix: Path | str = "/nix/store"
+) -> tuple[list[str], dict[str, str]]:
+    """bwrap arguments and environment for __hci_effect_fsroot_copy, a
+    store path whose top-level entries (bin/sh, usr/bin/env) appear in
+    the sandbox root."""
     root = drv_env.get("__hci_effect_fsroot_copy")
     if not root:
-        return []
+        return [], {}
     path = Path(root)
-    if not path.is_relative_to("/nix/store"):
+    if not path.is_relative_to(store_prefix):
         msg = f"__hci_effect_fsroot_copy must be a store path, got {root}"
         raise EffectError(msg)
-    return [
+    args = [
         arg
         for entry in sorted(path.iterdir())
         for arg in ("--ro-bind", str(entry), f"/{entry.name}")
     ]
+    # Stops the hercules-ci-effects setup hook from cp'ing onto the
+    # read-only bind mounts.
+    return args, {"__hci_effect_fsroot_copied": "1"}
 
 
 def effect_checkout_mount(

--- a/nixbot_effects/nixbot_effects/tests/test_effect_checkout.py
+++ b/nixbot_effects/nixbot_effects/tests/test_effect_checkout.py
@@ -79,6 +79,17 @@ def test_default_chdir_without_checkout() -> None:
 
 
 def test_fsroot_mounts() -> None:
-    assert fsroot_mounts({}) == []
+    assert fsroot_mounts({}) == ([], {})
     with pytest.raises(EffectError, match="store path"):
         fsroot_mounts({"__hci_effect_fsroot_copy": "/var/evil"})
+
+
+def test_fsroot_mounts_marks_copy_done(tmp_path: Path) -> None:
+    root = tmp_path / "store" / "aaa-mkEffect-root"
+    (root / "bin").mkdir(parents=True)
+    args, env = fsroot_mounts(
+        {"__hci_effect_fsroot_copy": str(root)},
+        store_prefix=root.parent,
+    )
+    assert args == ["--ro-bind", str(root / "bin"), "/bin"]
+    assert env == {"__hci_effect_fsroot_copied": "1"}


### PR DESCRIPTION

hercules-ci-effects' setup hook copies the fsroot onto / unless the
agent sets this marker. Without it the cp hit our read-only bind mounts
of the same store path and failed with 'cp: ... are the same file'.
