### PR TITLE
cli: select the server by matching hosts.toml remotes patterns

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -30,6 +30,38 @@ token = "bnix_..."
 
 Read-only commands work without a token on public instances.
 
+If you use more than one nixbot server, tell `nbo` which repositories belong to
+which server. Add a `remotes` list to each server entry. When you run `nbo`
+inside a checkout, it looks at the URL of the `origin` remote and picks the
+first server whose pattern matches:
+
+```toml
+["https://ci.example.org"]
+token = "bnix_..."
+remotes = ["github.com/acme/*"]
+
+["https://ci.other.org"]
+remotes = ["git.other.org/*"]
+```
+
+Patterns are shell-style wildcards matched against the remote URL in the form
+`host/owner/repo`, so both `git@github.com:acme/widget.git` and
+`https://github.com/acme/widget` match `github.com/acme/*`.
+
+You can also assign a single checkout to a server directly, which takes
+precedence over the patterns:
+
+```console
+git config nixbot.url https://ci.example.org
+```
+
+When several settings are present, `nbo` uses the first of:
+
+1. the `NIXBOT_URL` environment variable
+2. `git config nixbot.url`
+3. a `remotes` pattern match
+4. the only server in `hosts.toml`, if there is just one
+
 ### API tokens
 
 Restarting or cancelling builds and enabling repositories require an API token.

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -25,6 +25,7 @@ from .build_scheduler import (
 )
 from .db import BuildStatus
 from .db_gen import builds as q
+from .db_gen import maintenance as mq
 from .events import BuildResult, EvalReport
 from .executor import failure_excerpt
 from .flake_prefetch import PrefetchError, prefetch_flake_inputs
@@ -53,22 +54,49 @@ logger = logging.getLogger(__name__)
 LIVE_WARNINGS_FLUSH_INTERVAL = 2.0
 
 
+def _job_columns(
+    jobs: Sequence[NixEvalJob],
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    successes = [job for job in jobs if isinstance(job, NixEvalJobSuccess)]
+    return (
+        [job.attr for job in successes],
+        [job.system for job in successes],
+        [job.drv_path for job in successes],
+        [json.dumps(job.outputs) for job in successes],
+    )
+
+
 async def record_attributes(
     pool: asyncpg.Pool, build_id: int, jobs: Sequence[NixEvalJob]
 ) -> None:
-    """Persist eval results as pending rows (with statically-known
-    outputs) so crash recovery can resume without a re-eval. Eval
-    failures are settled by the scheduler."""
-    successes = [job for job in jobs if isinstance(job, NixEvalJobSuccess)]
-    if not successes:
+    """Persist eval results as pending rows so crash recovery can
+    resume without a re-eval."""
+    attrs, systems, drv_paths, outputs = _job_columns(jobs)
+    if not attrs:
         return
     await q.record_attributes(
         pool,
         build_id=build_id,
-        attrs=[job.attr for job in successes],
-        systems=[job.system for job in successes],
-        drv_paths=[job.drv_path for job in successes],
-        outputs=[json.dumps(job.outputs) for job in successes],
+        attrs=attrs,
+        systems=systems,
+        drv_paths=drv_paths,
+        outputs=outputs,
+    )
+
+
+async def commit_eval_result(
+    pool: asyncpg.Pool, build_id: int, jobs: Sequence[NixEvalJob]
+) -> None:
+    """Publish a completed eval: the only operation that may shrink
+    the attribute set."""
+    attrs, systems, drv_paths, outputs = _job_columns(jobs)
+    await mq.commit_eval_result(
+        pool,
+        build_id=build_id,
+        attrs=attrs,
+        systems=systems,
+        drv_paths=drv_paths,
+        outputs=outputs,
     )
 
 
@@ -215,19 +243,14 @@ async def _record_eval_success(
     live_warnings: LiveWarningAggregator,
 ) -> None:
     """Persist a completed evaluation and report it to the forge."""
-    # Idempotent backstop for the streaming inserts during eval;
-    # pending rows are what crash recovery resumes from. The
-    # scheduler drops unsupported systems. Their pending rows
-    # would never turn terminal, so don't record them.
+    # The scheduler drops unsupported systems, their rows would stay
+    # pending forever.
     buildable = [
         job
         for job in jobs
         if isinstance(job, NixEvalJobSuccess) and job.system in o.config.build_systems
     ]
-    await record_attributes(o.pool, build.id, buildable)
-    # The full eval result is recorded in build_attributes. A later
-    # build of the same tree may reuse it instead of re-evaluating.
-    await q.mark_eval_completed(o.pool, id_=build.id)
+    await commit_eval_result(o.pool, build.id, buildable)
     await o.reporter.eval_finished(
         event,
         build,
@@ -426,8 +449,7 @@ async def _try_reuse_eval(
     reused = await _reusable_eval_jobs(o, build)
     if reused is None:
         return False
-    await record_attributes(o.pool, build.id, reused)
-    await q.mark_eval_completed(o.pool, id_=build.id)
+    await commit_eval_result(o.pool, build.id, reused)
     await db.set_build_status(o.pool, build.id, BuildStatus.BUILDING)
     await o.reporter.eval_finished(event, build, EvalReport(success=True, jobs=reused))
     # cache_failures=False: see _ReadOnlyFailedBuildCache.

--- a/nixbot/nixbot/db_gen/builds.py
+++ b/nixbot/nixbot/db_gen/builds.py
@@ -30,7 +30,6 @@ __all__: collections.abc.Sequence[str] = (
     "lock_build_row",
     "mark_attribute_building",
     "mark_effects_started",
-    "mark_eval_completed",
     "record_attributes",
     "set_build_status",
     "set_eval_warnings",
@@ -239,10 +238,6 @@ UPDATE builds SET effects_started = TRUE,
 WHERE id = $4::bigint AND effects_started = FALSE RETURNING id
 """
 
-MARK_EVAL_COMPLETED: typing.Final[str] = """-- name: MarkEvalCompleted :exec
-UPDATE builds SET eval_completed = TRUE WHERE id = $1
-"""
-
 RECORD_ATTRIBUTES: typing.Final[str] = """-- name: RecordAttributes :exec
 INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, status)
 SELECT $1::bigint, u.attr, u.system, u.drv_path, u.outputs, 'pending'
@@ -250,7 +245,11 @@ FROM (SELECT unnest($2::text[]) AS attr,
              unnest($3::text[]) AS system,
              unnest($4::text[]) AS drv_path,
              unnest($5::jsonb[]) AS outputs) u
-ON CONFLICT (build_id, attr) DO NOTHING
+ON CONFLICT (build_id, attr) DO UPDATE SET
+    system = EXCLUDED.system,
+    drv_path = EXCLUDED.drv_path,
+    outputs = EXCLUDED.outputs
+WHERE build_attributes.status IN ('pending', 'building')
 """
 
 SET_BUILD_STATUS: typing.Final[str] = """-- name: SetBuildStatus :exec
@@ -484,10 +483,6 @@ async def mark_effects_started(conn: ConnectionLike, *, commit_sha: str, branch:
     if row is None:
         return None
     return row[0]
-
-
-async def mark_eval_completed(conn: ConnectionLike, *, id_: int) -> None:
-    await conn.execute(MARK_EVAL_COMPLETED, id_)
 
 
 async def record_attributes(conn: ConnectionLike, *, build_id: int, attrs: collections.abc.Sequence[str], systems: collections.abc.Sequence[str], drv_paths: collections.abc.Sequence[str], outputs: collections.abc.Sequence[str]) -> None:

--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -17,6 +17,7 @@ __all__: collections.abc.Sequence[str] = (
     "cancel_build",
     "cleanup_old_rows",
     "commit_built",
+    "commit_eval_result",
     "count_unfinished_attributes",
     "delete_attributes_by_name",
     "delete_effects_by_name",
@@ -148,6 +149,27 @@ COMMIT_BUILT: typing.Final[str] = """-- name: CommitBuilt :one
 SELECT 1 AS one FROM builds WHERE project_id = $1 AND commit_sha = $2 LIMIT 1
 """
 
+COMMIT_EVAL_RESULT: typing.Final[str] = """-- name: CommitEvalResult :exec
+WITH new_rows AS (
+    INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, status)
+    SELECT $1::bigint, u.attr, u.system, u.drv_path, u.outputs, 'pending'
+    FROM (SELECT unnest($2::text[]) AS attr,
+                 unnest($3::text[]) AS system,
+                 unnest($4::text[]) AS drv_path,
+                 unnest($5::jsonb[]) AS outputs) u
+    ON CONFLICT (build_id, attr) DO UPDATE SET
+        system = EXCLUDED.system,
+        drv_path = EXCLUDED.drv_path,
+        outputs = EXCLUDED.outputs
+    WHERE build_attributes.status IN ('pending', 'building')
+), pruned AS (
+    DELETE FROM build_attributes WHERE build_id = $1
+    AND attr != ALL($2::text[])
+    AND (status IN ('pending', 'building') OR drv_path IS NULL)
+)
+UPDATE builds SET eval_completed = TRUE WHERE builds.id = $1
+"""
+
 COUNT_UNFINISHED_ATTRIBUTES: typing.Final[str] = """-- name: CountUnfinishedAttributes :one
 SELECT count(*) AS count FROM build_attributes
 WHERE build_id = $1 AND status IN ('pending', 'building')
@@ -236,11 +258,7 @@ WHERE build_id = $1
 """
 
 RESET_EVAL_FOR_REEVAL: typing.Final[str] = """-- name: ResetEvalForReeval :exec
-WITH flag AS (
-    UPDATE builds SET eval_completed = FALSE WHERE id = $1
-)
-DELETE FROM build_attributes WHERE build_id = $1
-AND (status IN ('pending', 'building') OR drv_path IS NULL)
+UPDATE builds SET eval_completed = FALSE WHERE id = $1
 """
 
 RUNNING_BUILD_IDS: typing.Final[str] = """-- name: RunningBuildIds :many
@@ -345,6 +363,10 @@ async def commit_built(conn: ConnectionLike, *, project_id: int, commit_sha: str
     if row is None:
         return None
     return row[0]
+
+
+async def commit_eval_result(conn: ConnectionLike, *, build_id: int, attrs: collections.abc.Sequence[str], systems: collections.abc.Sequence[str], drv_paths: collections.abc.Sequence[str], outputs: collections.abc.Sequence[str]) -> None:
+    await conn.execute(COMMIT_EVAL_RESULT, build_id, attrs, systems, drv_paths, outputs)
 
 
 async def count_unfinished_attributes(conn: ConnectionLike, *, build_id: int) -> int | None:

--- a/nixbot/nixbot/queries/builds.sql
+++ b/nixbot/nixbot/queries/builds.sql
@@ -56,15 +56,19 @@ FROM n
 RETURNING *;
 
 -- name: RecordAttributes :exec
--- Batch insert of one eval's attribute rows; arrays are zipped
--- positionally by unnest.
+-- Streaming inserts while the eval runs. Rows only grow or refresh
+-- here, they shrink solely in CommitEvalResult.
 INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, status)
 SELECT sqlc.arg(build_id)::bigint, u.attr, u.system, u.drv_path, u.outputs, 'pending'
 FROM (SELECT unnest(sqlc.arg(attrs)::text[]) AS attr,
              unnest(sqlc.arg(systems)::text[]) AS system,
              unnest(sqlc.arg(drv_paths)::text[]) AS drv_path,
              unnest(sqlc.arg(outputs)::jsonb[]) AS outputs) u
-ON CONFLICT (build_id, attr) DO NOTHING;
+ON CONFLICT (build_id, attr) DO UPDATE SET
+    system = EXCLUDED.system,
+    drv_path = EXCLUDED.drv_path,
+    outputs = EXCLUDED.outputs
+WHERE build_attributes.status IN ('pending', 'building');
 
 -- name: SetEvalWarnings :exec
 UPDATE builds SET eval_warnings = sqlc.arg(warnings)::jsonb WHERE id = $1;
@@ -106,9 +110,6 @@ SET status = sqlc.arg(status),
         ELSE NULL
     END
 WHERE builds.id = sqlc.arg(id)::bigint;
-
--- name: MarkEvalCompleted :exec
-UPDATE builds SET eval_completed = TRUE WHERE id = $1;
 
 -- name: FindCompletedEval :one
 SELECT id FROM builds WHERE project_id = $1 AND tree_hash = $2

--- a/nixbot/nixbot/queries/maintenance.sql
+++ b/nixbot/nixbot/queries/maintenance.sql
@@ -67,18 +67,31 @@ SELECT count(*) AS count FROM build_attributes
 WHERE build_id = $1 AND status IN ('pending', 'building');
 
 -- name: ResetEvalForReeval :exec
--- Stale rows (e.g. failed_eval with NULL drv_path) would wedge the
--- aggregate; the re-eval rewrites them. Finished rows with a drv_path
--- are kept: their results are valid and the re-eval skips
--- already-built attributes. One atomic statement: the
--- eval_completed flag must never be observable as set while the
--- partial row set already lost entries (a concurrent build of the
--- same tree would reuse the incomplete eval).
-WITH flag AS (
-    UPDATE builds SET eval_completed = FALSE WHERE id = sqlc.arg(build_id)
+-- Flag only: an interrupted re-eval must not lose rows.
+UPDATE builds SET eval_completed = FALSE WHERE id = sqlc.arg(build_id);
+
+-- name: CommitEvalResult :exec
+-- The only place the attribute set shrinks. Refreshes non-terminal
+-- rows, prunes rows the eval no longer produced, publishes via
+-- eval_completed, atomically.
+WITH new_rows AS (
+    INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, status)
+    SELECT sqlc.arg(build_id)::bigint, u.attr, u.system, u.drv_path, u.outputs, 'pending'
+    FROM (SELECT unnest(sqlc.arg(attrs)::text[]) AS attr,
+                 unnest(sqlc.arg(systems)::text[]) AS system,
+                 unnest(sqlc.arg(drv_paths)::text[]) AS drv_path,
+                 unnest(sqlc.arg(outputs)::jsonb[]) AS outputs) u
+    ON CONFLICT (build_id, attr) DO UPDATE SET
+        system = EXCLUDED.system,
+        drv_path = EXCLUDED.drv_path,
+        outputs = EXCLUDED.outputs
+    WHERE build_attributes.status IN ('pending', 'building')
+), pruned AS (
+    DELETE FROM build_attributes WHERE build_id = sqlc.arg(build_id)
+    AND attr != ALL(sqlc.arg(attrs)::text[])
+    AND (status IN ('pending', 'building') OR drv_path IS NULL)
 )
-DELETE FROM build_attributes WHERE build_id = sqlc.arg(build_id)
-AND (status IN ('pending', 'building') OR drv_path IS NULL);
+UPDATE builds SET eval_completed = TRUE WHERE builds.id = sqlc.arg(build_id);
 
 -- name: DeleteAttributesByName :exec
 DELETE FROM build_attributes WHERE build_id = $1

--- a/nixbot/nixbot/restart_dispatch.py
+++ b/nixbot/nixbot/restart_dispatch.py
@@ -133,13 +133,8 @@ async def _reeval(
             event,
             worktree_path,
         ):
-            # Stale rows (e.g. failed_eval with NULL drv_path) would
-            # wedge the aggregate. The re-eval rewrites them. Finished
-            # rows with a drv_path are kept: their results are valid
-            # and the re-eval skips already-built attributes.
-            # The flag must drop before the rows: a concurrent build
-            # of the same tree must not reuse the partial set
-            # (run_build only clears it after this window).
+            # Flag only. Rows are rewritten when the re-eval commits,
+            # so an interrupted re-eval loses nothing.
             await q.reset_eval_for_reeval(s.pool, build_id=build.id)
             await s.orchestrator.run_build(event, build, worktree_path)
     finally:

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -285,6 +285,8 @@ def test_print_table_aligns_colored_cells(
 ) -> None:
     """ANSI color codes must not count towards the column width."""
     green_ok = "\x1b[32m\u2713 ok\x1b[0m"
+    linked = "\x1b]8;;https://ci.example.org/b/1\x1b\\240\x1b]8;;\x1b\\"
+    assert strip_ansi(linked) == "240"
     cli.print_table(
         [
             {"status": green_ok, "branch": "main"},

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -341,9 +341,22 @@ def test_settings_multi_host_remotes(
         Settings.load()
     git("remote", "set-url", "origin", "git@github.com:acme/widget.git")
 
-    # An explicit git config setting beats the pattern match.
-    git("config", "nixbot.url", "https://ci.other.org")
+    # git config wins over the pattern match. A trailing slash is tolerated.
+    git("config", "nixbot.url", "https://ci.other.org/")
     assert Settings.load() == Settings("https://ci.other.org", "bnix_two")
+
+
+def test_settings_url_trailing_slash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """NIXBOT_URL with a trailing slash still finds the host's token."""
+    monkeypatch.setenv("NIXBOT_URL", "https://ci.example.org/")
+    monkeypatch.delenv("NIXBOT_TOKEN", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    hosts = tmp_path / "nixbot" / "hosts.toml"
+    hosts.parent.mkdir(parents=True)
+    hosts.write_text('["https://ci.example.org"]\ntoken = "bnix_abc"\n')
+    assert Settings.load() == Settings("https://ci.example.org", "bnix_abc")
 
 
 def test_settings_token_command(

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 import httpx
@@ -290,6 +291,15 @@ def test_settings_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert Settings.load().token == "bnix_env"
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 14), reason="argparse suggestions need Python 3.14"
+)
+def test_command_typo_suggestion(capsys: pytest.CaptureFixture[str]) -> None:
+    """A mistyped subcommand suggests the closest real one."""
+    with pytest.raises(SystemExit):
+        cli.build_parser().parse_args(["build", "lst"])
+    assert "'list'" in capsys.readouterr().err
+
 
 def test_settings_multi_host_remotes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -334,6 +344,7 @@ def test_settings_multi_host_remotes(
     # An explicit git config setting beats the pattern match.
     git("config", "nixbot.url", "https://ci.other.org")
     assert Settings.load() == Settings("https://ci.other.org", "bnix_two")
+
 
 def test_settings_token_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -124,6 +124,9 @@ def test_build_list_and_view(
     assert "1" in out
     assert "✗ failed" in out
 
+    assert run_cli(api, "build", "list", "-R", "ACME/Widget") == 0
+    capsys.readouterr()
+
     assert (
         run_cli(
             api,

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -111,6 +111,10 @@ def test_repo_list_and_toggle(
 
     assert run_cli(api, "repo", "disable", "acme/widget") == 0
     assert "disabled" in capsys.readouterr().out
+    # Without an argument the repository comes from the CWD's git remote,
+    # like every other command.
+    with pytest.raises(cli.UsageError):
+        run_cli(api, "repo", "enable")
     assert run_cli(api, "repo", "enable", "github/acme/widget") == 0
     assert api.repo(REPO)["enabled"] is True
     capsys.readouterr()
@@ -159,6 +163,24 @@ def test_build_restart_cancel(
         == 0
     )
     assert [a for _, a in BACKEND.attr_restarts] == ["bad1"]
+    # --attr is repeatable, like watch --attr and restart --effect.
+    BACKEND.attr_restarts.clear()
+    assert (
+        run_cli(
+            api,
+            "build",
+            "restart",
+            "1",
+            "-R",
+            "acme/widget",
+            "--attr",
+            "bad1",
+            "--attr",
+            "good",
+        )
+        == 0
+    )
+    assert [a for _, a in BACKEND.attr_restarts] == ["bad1", "good"]
     assert run_cli(api, "build", "restart", "1", "-R", "acme/widget", "--effects") == 0
     BACKEND.effect_restarts.clear()
     assert (

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -14,7 +14,7 @@ import zstandard
 from nixbot_cli import main as cli
 from nixbot_cli.api import NixbotClient, RepoRef
 from nixbot_cli.config import Settings
-from nixbot_cli.term import sanitize_line
+from nixbot_cli.term import sanitize_line, strip_ansi
 
 from nixbot.api_tokens import ApiTokenStore
 from nixbot.auth import AuthzConfig, User
@@ -278,6 +278,23 @@ def test_auth_status(
     assert "server: http://test" in out
     assert "bnix_sec" in out
     assert "server is reachable" in out
+
+
+def test_print_table_aligns_colored_cells(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """ANSI color codes must not count towards the column width."""
+    green_ok = "\x1b[32m\u2713 ok\x1b[0m"
+    cli.print_table(
+        [
+            {"status": green_ok, "branch": "main"},
+            {"status": "\u2717 failed", "branch": "dev"},
+        ],
+        ["status", "branch"],
+    )
+    lines = capsys.readouterr().out.splitlines()
+    stripped = [strip_ansi(line) for line in lines]
+    assert stripped[0].index("main") == stripped[1].index("dev")
 
 
 def test_settings_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -204,6 +204,12 @@ def test_build_restart_cancel(
     assert "cancelling build #2" in capsys.readouterr().out
     assert len(BACKEND.cancelled) == 1
 
+    # Cancelling a finished build or attribute is an error, not a no-op.
+    with pytest.raises(cli.UsageError, match="finished"):
+        run_cli(api, "build", "cancel", "1", "-R", "acme/widget")
+    with pytest.raises(cli.UsageError, match="finished"):
+        run_cli(api, "build", "cancel", "1", "-R", "acme/widget", "--attr", "bad1")
+
 
 def test_log_summary_attr_and_drv(
     harness: WebHarness,

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
 
 import httpx
@@ -288,6 +289,51 @@ def test_settings_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("NIXBOT_TOKEN", "bnix_env")
     assert Settings.load().token == "bnix_env"
 
+
+
+def test_settings_multi_host_remotes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With several servers in hosts.toml, the one whose `remotes`
+    pattern matches the checkout's origin URL is used. A `git config
+    nixbot.url` setting in the checkout takes precedence."""
+    monkeypatch.delenv("NIXBOT_URL", raising=False)
+    monkeypatch.delenv("NIXBOT_TOKEN", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    hosts = tmp_path / "nixbot" / "hosts.toml"
+    hosts.parent.mkdir(parents=True)
+    hosts.write_text(
+        '["https://ci.example.org"]\ntoken = "bnix_one"\n'
+        'remotes = ["github.com/acme/*"]\n'
+        '["https://ci.other.org"]\ntoken = "bnix_two"\n'
+    )
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", "-C", str(tmp_path), *args], check=True)  # noqa: S603
+
+    git("init", "-q")
+    monkeypatch.chdir(tmp_path)
+
+    # No remote to match against.
+    with pytest.raises(ValueError, match="no server configured"):
+        Settings.load()
+
+    git("remote", "add", "origin", "git@github.com:acme/widget.git")
+    assert Settings.load() == Settings("https://ci.example.org", "bnix_one")
+
+    # Forge names are case-insensitive.
+    git("remote", "set-url", "origin", "https://github.com/Acme/Widget")
+    assert Settings.load() == Settings("https://ci.example.org", "bnix_one")
+
+    # The error names the unmatched remote.
+    git("remote", "set-url", "origin", "https://example.com/nobody/nothing")
+    with pytest.raises(ValueError, match=r"example\.com/nobody/nothing"):
+        Settings.load()
+    git("remote", "set-url", "origin", "git@github.com:acme/widget.git")
+
+    # An explicit git config setting beats the pattern match.
+    git("config", "nixbot.url", "https://ci.other.org")
+    assert Settings.load() == Settings("https://ci.other.org", "bnix_two")
 
 def test_settings_token_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/nixbot/nixbot/tests/test_db.py
+++ b/nixbot/nixbot/tests/test_db.py
@@ -205,6 +205,42 @@ async def test_get_or_create_build_concurrent_no_duplicates(postgres_dsn: str) -
         assert count == 1
 
 
+async def test_commit_eval_result_atomic(pool: asyncpg.Pool) -> None:
+    """Committing an eval result refreshes non-terminal rows, prunes
+    rows the eval no longer produced and sets eval_completed, all in
+    one statement. Finished rows keep their results."""
+    project_id = await insert_project(pool, forge_repo_id="commit-eval")
+    build_id = await insert_build(pool, project_id, eval_completed=False)
+    await pool.execute(
+        "INSERT INTO build_attributes (build_id, attr, system, status, drv_path) "
+        "VALUES ($1, 'done', 'x86_64-linux', 'succeeded', '/nix/store/done.drv'), "
+        "($1, 'restarted', 'x86_64-linux', 'pending', '/nix/store/old.drv'), "
+        "($1, 'vanished', 'x86_64-linux', 'pending', '/nix/store/gone.drv'), "
+        "($1, 'broken', 'x86_64-linux', 'failed_eval', NULL)",
+        build_id,
+    )
+
+    await build_run.commit_eval_result(
+        pool, build_id, [mk_job("done"), mk_job("restarted"), mk_job("new")]
+    )
+
+    rows = {
+        r["attr"]: (r["status"], r["drv_path"])
+        for r in await pool.fetch(
+            "SELECT attr, status, drv_path FROM build_attributes WHERE build_id = $1",
+            build_id,
+        )
+    }
+    assert rows == {
+        "done": ("succeeded", "/nix/store/done.drv"),
+        "restarted": ("pending", "/nix/store/restarted.drv"),
+        "new": ("pending", "/nix/store/new.drv"),
+    }
+    assert await pool.fetchval(
+        "SELECT eval_completed FROM builds WHERE id = $1", build_id
+    )
+
+
 async def test_cancelled_build_not_reused(pool: asyncpg.Pool) -> None:
     # A cancelled build carries no verdict. Re-pushing the same tree
     # must build again instead of re-reporting "cancelled".

--- a/nixbot/nixbot/tests/test_service.py
+++ b/nixbot/nixbot/tests/test_service.py
@@ -431,13 +431,53 @@ async def test_restart_failed_eval_attribute_reevaluates(
     await asyncio.gather(*service._tasks)  # noqa: SLF001
 
     assert reevals == [build_id]
-    # Stale NULL-drv rows are cleared so the re-eval result is
-    # authoritative.
+    # The stale row survives until a successful eval commits its
+    # result. Interrupted re-evals must never lose rows.
     count = await pool.fetchval(
         "SELECT count(*) FROM build_attributes WHERE build_id = $1",
         build_id,
     )
-    assert count == 0
+    assert count == 1
+
+
+async def test_interrupted_reeval_keeps_attribute_rows(
+    service: CIService, git_repo: tuple[Path, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An attribute restart falls back to re-evaluation when the stored
+    derivations were garbage-collected. A re-eval that never completes
+    (cancel, crash) must not lose any attribute rows."""
+    repo, sha = git_repo
+
+    async def all_gcd(paths: list[str]) -> set[str]:
+        return set()
+
+    monkeypatch.setattr("nixbot.restart_dispatch.check_store_paths", all_gcd)
+
+    pool = service.pool
+    project_id = await seed_project(pool, str(repo))
+    build_id = await insert_build(
+        pool, project_id, commit_sha=sha, status="failed", eval_completed=True
+    )
+    await pool.execute(
+        "INSERT INTO build_attributes (build_id, attr, system, status, drv_path) "
+        "VALUES ($1, 'ok', 'x86_64-linux', 'succeeded', '/nix/store/aaa.drv'), "
+        "($1, 'bad', 'x86_64-linux', 'failed', '/nix/store/bbb.drv')",
+        build_id,
+    )
+
+    capture_run_build(service)  # the re-eval never records a result
+    await service.restart_attribute(build_id, "bad")
+    await service.drain_work()
+    await asyncio.gather(*service._tasks)  # noqa: SLF001
+
+    attrs = {
+        r["attr"]: r["status"]
+        for r in await pool.fetch(
+            "SELECT attr, status FROM build_attributes WHERE build_id = $1", build_id
+        )
+    }
+    assert set(attrs) == {"ok", "bad"}
+    assert attrs["ok"] == "succeeded"
 
 
 async def test_restart_cancelled_build_reschedules_attributes(

--- a/nixbot_cli/nixbot_cli/api.py
+++ b/nixbot_cli/nixbot_cli/api.py
@@ -20,8 +20,9 @@ if TYPE_CHECKING:
 class ApiError(Exception):
     """Non-2xx response from the nixbot API."""
 
-    def __init__(self, status: int, detail: str) -> None:
-        super().__init__(f"HTTP {status}: {detail}")
+    def __init__(self, status: int, detail: str, request: str = "") -> None:
+        suffix = f" ({request})" if request else ""
+        super().__init__(f"HTTP {status}: {detail}{suffix}")
         self.status = status
         self.detail = detail
 
@@ -82,7 +83,7 @@ class NixbotClient:
                 detail = response.json().get("detail", response.text)
             except ValueError:
                 detail = response.text
-            raise ApiError(response.status_code, str(detail))
+            raise ApiError(response.status_code, str(detail), f"{method} {path}")
         return response
 
     def _json(

--- a/nixbot_cli/nixbot_cli/config.py
+++ b/nixbot_cli/nixbot_cli/config.py
@@ -44,9 +44,14 @@ class Settings:
             )
             msg = f"no server configured: {where}"
             raise ValueError(msg)
-        entry = hosts.get(url, {})
+        # A trailing slash must still find the host's token.
+        url = url.rstrip("/")
+        entry = next(
+            (e for u, e in hosts.items() if u.rstrip("/") == url),
+            {},
+        )
         token = token or entry.get("token") or _run_token_command(entry)
-        return cls(url.rstrip("/"), token)
+        return cls(url, token)
 
 
 def _git_config(key: str) -> str | None:

--- a/nixbot_cli/nixbot_cli/config.py
+++ b/nixbot_cli/nixbot_cli/config.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import fnmatch
 import os
+import re
 import shlex
 import subprocess
 from dataclasses import dataclass
@@ -23,22 +25,62 @@ class Settings:
 
     @classmethod
     def load(cls) -> Settings:
-        """NIXBOT_URL/NIXBOT_TOKEN override hosts.toml. Without a URL the
-        config's single host is used."""
+        """Server: NIXBOT_URL, `git config nixbot.url`, the hosts.toml
+        entry whose `remotes` match the origin URL, or the only entry.
+        NIXBOT_TOKEN overrides the token from hosts.toml."""
         url = os.environ.get("NIXBOT_URL")
         token = os.environ.get("NIXBOT_TOKEN")
         hosts: dict[str, dict] = {}
         path = config_path()
         if path.exists():
             hosts = tomllib.loads(path.read_text())
+        url = url or _select_host(hosts)
         if not url:
-            if len(hosts) != 1:
-                msg = f"no server configured: set NIXBOT_URL or add one host to {path}"
-                raise ValueError(msg)
-            url = next(iter(hosts))
+            remote = _origin_remote()
+            where = (
+                f"no host in {path} has a remotes pattern matching {remote!r}"
+                if remote
+                else f"set NIXBOT_URL, git config nixbot.url, or a host in {path}"
+            )
+            msg = f"no server configured: {where}"
+            raise ValueError(msg)
         entry = hosts.get(url, {})
         token = token or entry.get("token") or _run_token_command(entry)
         return cls(url.rstrip("/"), token)
+
+
+def _git_config(key: str) -> str | None:
+    out = subprocess.run(
+        ["git", "config", "--get", key], capture_output=True, text=True, check=False
+    )
+    return out.stdout.strip() or None
+
+
+def _origin_remote() -> str | None:
+    """The origin URL reduced to "host/owner/repo", so one pattern
+    covers SSH and HTTPS remotes."""
+    remote = _git_config("remote.origin.url")
+    if not remote:
+        return None
+    remote = re.sub(r"^\w+://|^\w+@", "", remote)
+    return remote.replace(":", "/").removesuffix(".git")
+
+
+def _select_host(hosts: dict[str, dict]) -> str | None:
+    if url := _git_config("nixbot.url"):
+        return url
+    if len(hosts) == 1:
+        return next(iter(hosts))
+    remote = _origin_remote()
+    if not remote:
+        return None
+    for url, entry in hosts.items():
+        if any(
+            fnmatch.fnmatch(remote.lower(), pat.lower())
+            for pat in entry.get("remotes", [])
+        ):
+            return url
+    return None
 
 
 def _run_token_command(entry: dict) -> str | None:

--- a/nixbot_cli/nixbot_cli/effects.py
+++ b/nixbot_cli/nixbot_cli/effects.py
@@ -87,6 +87,7 @@ async def list_command(args: argparse.Namespace) -> None:
         fp=sys.stdout,
         indent=2,
     )
+    print()
 
 
 async def graph_command(args: argparse.Namespace) -> None:
@@ -103,6 +104,7 @@ async def list_schedules_command(args: argparse.Namespace) -> None:
     if args.flake_ref:
         options = await options_from_flake_ref(args.flake_ref, options)
     json.dump(await list_scheduled_effects(options), fp=sys.stdout, indent=2)
+    print()
 
 
 async def run_command(args: argparse.Namespace) -> None:

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -385,9 +385,9 @@ def cmd_build_restart(client: NixbotClient, args: argparse.Namespace) -> int:
             client.restart_effects(repo, number, effect)
             print(f"restarting effect {effect} of build #{number}")
     elif args.attr:
-        attr = resolve_attr(client, repo, number, args.attr)
-        client.restart_attr(repo, number, attr)
-        print(f"restarting {attr} of build #{number}")
+        for attr in [resolve_attr(client, repo, number, a) for a in args.attr]:
+            client.restart_attr(repo, number, attr)
+            print(f"restarting {attr} of build #{number}")
     else:
         client.restart_build(repo, number)
         print(f"restarting build #{number}")
@@ -398,9 +398,9 @@ def cmd_build_cancel(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
     if args.attr:
-        attr = resolve_attr(client, repo, number, args.attr)
-        client.cancel_attr(repo, number, attr)
-        print(f"cancelling {attr} of build #{number}")
+        for attr in [resolve_attr(client, repo, number, a) for a in args.attr]:
+            client.cancel_attr(repo, number, attr)
+            print(f"cancelling {attr} of build #{number}")
     else:
         client.cancel_build(repo, number)
         print(f"cancelling build #{number}")
@@ -567,7 +567,12 @@ def build_parser() -> argparse.ArgumentParser:
     repo_list.set_defaults(func=cmd_repo_list)
     for action in ("enable", "disable"):
         p = repo.add_parser(action, help=f"{action} CI for a repository")
-        p.add_argument("repository", metavar="[FORGE/]OWNER/NAME")
+        p.add_argument(
+            "repository",
+            nargs="?",
+            metavar="[FORGE/]OWNER/NAME",
+            help="repository (default: inferred from the git remote)",
+        )
         p.set_defaults(func=cmd_repo_set_enabled, action=action)
 
     build = sub.add_parser("build", help="inspect and control builds").add_subparsers(
@@ -625,7 +630,12 @@ running ones. Piped or in CI it prints one line per finished attribute.""",
     )
     b_restart.add_argument("number", type=int, nargs="?")
     _add_repo_arg(b_restart)
-    b_restart.add_argument("--attr", help="restart only this attribute")
+    b_restart.add_argument(
+        "--attr",
+        action="append",
+        metavar="ATTR|DRV-PATH",
+        help="restart only this attribute (repeatable)",
+    )
     b_restart.add_argument("--effects", action="store_true", help="restart the effects")
     b_restart.add_argument(
         "--effect",
@@ -637,7 +647,12 @@ running ones. Piped or in CI it prints one line per finished attribute.""",
     b_cancel = build.add_parser("cancel", help="cancel a build or attribute")
     b_cancel.add_argument("number", type=int, nargs="?")
     _add_repo_arg(b_cancel)
-    b_cancel.add_argument("--attr", help="cancel only this attribute")
+    b_cancel.add_argument(
+        "--attr",
+        action="append",
+        metavar="ATTR|DRV-PATH",
+        help="cancel only this attribute (repeatable)",
+    )
     b_cancel.set_defaults(func=cmd_build_cancel)
 
     log = sub.add_parser(

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -24,6 +24,7 @@ from .term import (
     cyan,
     dim,
     green,
+    link,
     sanitize_block,
     sanitize_line,
     status_str,
@@ -159,7 +160,10 @@ def cmd_repo_list(client: NixbotClient, args: argparse.Namespace) -> int:
     rows = [
         {
             **r,
-            "repo": f"{r['forge']}/{r['owner']}/{r['name']}",
+            "repo": link(
+                f"{r['forge']}/{r['owner']}/{r['name']}",
+                f"{client.http.base_url}/repos/{r['forge']}/{r['owner']}/{r['name']}",
+            ),
             "enabled": green("enabled") if r["enabled"] else dim("disabled"),
             "url": dim(r["url"]),
         }
@@ -192,6 +196,10 @@ def cmd_build_list(client: NixbotClient, args: argparse.Namespace) -> int:
     rows = [
         {
             **b,
+            "number": link(
+                str(b["number"]),
+                f"{client.http.base_url}/repos/{repo}/builds/{b['number']}",
+            ),
             "status": status_str(b["status"]),
             "branch": cyan(b["branch"]),
             "commit": dim(b["commit_sha"][:12]),
@@ -215,8 +223,9 @@ def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
         print_json(detail, args.json)
         return EXIT_OK
     build, attrs = detail["build"], detail["attributes"]
+    build_url = f"{client.http.base_url}/repos/{repo}/builds/{number}"
     print(
-        f"{bold(f'build #{number}')} {repo} {cyan(build['branch'])} "
+        f"{link(bold(f'build #{number}'), build_url)} {repo} {cyan(build['branch'])} "
         f"@ {dim(build['commit_sha'][:12])}"
     )
     print(f"status: {status_str(build['status'])}")
@@ -231,7 +240,8 @@ def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
     print(f"attributes: {len(attrs)}" + (f" ({summary})" if attrs else ""))
     failed = [a for a in attrs if a["status"] in FAILED_STATUSES]
     for a in failed:
-        print(f"  {status_str(a['status'])}  {a['attr']}")
+        log_url = client.log_url(repo, number, a["attr"], raw=False)
+        print(f"  {status_str(a['status'])}  {link(a['attr'], log_url)}")
     if failed:
         print(f"logs: nbo log {number} <attr> [-R {repo}]")
     return EXIT_OK

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -20,9 +20,14 @@ from .term import (
     FAILED_STATUSES,
     RUNNING_STATUSES,
     STATUS_LABELS,
+    bold,
+    cyan,
+    dim,
+    green,
     sanitize_block,
     sanitize_line,
     status_str,
+    strip_ansi,
 )
 from .watch_tty import TtyWatch
 
@@ -39,6 +44,11 @@ class UsageError(Exception):
     """Bad invocation: reported on stderr, exit 2."""
 
 
+def visible_len(text: str) -> int:
+    """Column width of a cell: ANSI color codes take no space."""
+    return len(strip_ansi(text))
+
+
 def print_table(rows: list[dict[str, Any]], columns: list[str]) -> None:
     """Aligned columns like gh. The header row only appears on a TTY."""
     cells = [
@@ -46,14 +56,15 @@ def print_table(rows: list[dict[str, Any]], columns: list[str]) -> None:
         for row in rows
     ]
     if sys.stdout.isatty():
-        cells.insert(0, [c.upper() for c in columns])
+        cells.insert(0, [bold(c.upper()) for c in columns])
     if not cells:
         return
-    widths = [max(len(r[i]) for r in cells) for i in range(len(columns))]
+    widths = [max(visible_len(r[i]) for r in cells) for i in range(len(columns))]
     for row in cells:
         print(
             "  ".join(
-                cell.ljust(w) for cell, w in zip(row, widths, strict=True)
+                cell + " " * (w - visible_len(cell))
+                for cell, w in zip(row, widths, strict=True)
             ).rstrip()
         )
 
@@ -149,7 +160,8 @@ def cmd_repo_list(client: NixbotClient, args: argparse.Namespace) -> int:
         {
             **r,
             "repo": f"{r['forge']}/{r['owner']}/{r['name']}",
-            "enabled": "enabled" if r["enabled"] else "disabled",
+            "enabled": green("enabled") if r["enabled"] else dim("disabled"),
+            "url": dim(r["url"]),
         }
         for r in repos
     ]
@@ -181,7 +193,9 @@ def cmd_build_list(client: NixbotClient, args: argparse.Namespace) -> int:
         {
             **b,
             "status": status_str(b["status"]),
-            "commit": b["commit_sha"][:12],
+            "branch": cyan(b["branch"]),
+            "commit": dim(b["commit_sha"][:12]),
+            "created_at": dim(b["created_at"]),
             "pr": b["pr_number"],
         }
         for b in page["items"]
@@ -201,7 +215,10 @@ def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
         print_json(detail, args.json)
         return EXIT_OK
     build, attrs = detail["build"], detail["attributes"]
-    print(f"build #{number} {repo} {build['branch']} @ {build['commit_sha'][:12]}")
+    print(
+        f"{bold(f'build #{number}')} {repo} {cyan(build['branch'])} "
+        f"@ {dim(build['commit_sha'][:12])}"
+    )
     print(f"status: {status_str(build['status'])}")
     if build.get("error"):
         print(f"error: {build['error']}")

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -93,7 +93,12 @@ def resolve_repo(client: NixbotClient, spec: str | None) -> RepoRef:
             raise UsageError(msg)
         parts = remote.rstrip("/").removesuffix(".git").replace(":", "/").split("/")
         owner, name = parts[-2], parts[-1]
-    matches = [r for r in client.repos() if r["owner"] == owner and r["name"] == name]
+    # Forge names are case-insensitive.
+    matches = [
+        r
+        for r in client.repos()
+        if r["owner"].lower() == owner.lower() and r["name"].lower() == name.lower()
+    ]
     if not matches:
         server = str(client.http.base_url) or "the server"
         msg = (
@@ -101,7 +106,8 @@ def resolve_repo(client: NixbotClient, spec: str | None) -> RepoRef:
             f"(is it hosted on another nixbot instance? see nbo auth status)"
         )
         raise UsageError(msg)
-    return RepoRef(matches[0]["forge"], owner, name)
+    # Canonical spelling: the API paths are case-sensitive.
+    return RepoRef(matches[0]["forge"], matches[0]["owner"], matches[0]["name"])
 
 
 def resolve_build(client: NixbotClient, repo: RepoRef, number: int | None) -> int:

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -95,7 +95,11 @@ def resolve_repo(client: NixbotClient, spec: str | None) -> RepoRef:
         owner, name = parts[-2], parts[-1]
     matches = [r for r in client.repos() if r["owner"] == owner and r["name"] == name]
     if not matches:
-        msg = f"repository {owner}/{name} is not known to the server"
+        server = str(client.http.base_url) or "the server"
+        msg = (
+            f"repository {owner}/{name} is not known to {server} "
+            f"(is it hosted on another nixbot instance? see nbo auth status)"
+        )
         raise UsageError(msg)
     return RepoRef(matches[0]["forge"], owner, name)
 

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -397,11 +397,20 @@ def cmd_build_restart(client: NixbotClient, args: argparse.Namespace) -> int:
 def cmd_build_cancel(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
+    detail = client.build(repo, number)
     if args.attr:
+        attrs = {a["attr"]: a["status"] for a in detail["attributes"]}
         for attr in [resolve_attr(client, repo, number, a) for a in args.attr]:
+            if attrs.get(attr) not in RUNNING_STATUSES:
+                msg = f"{attr} of build #{number} already finished ({attrs.get(attr)})"
+                raise UsageError(msg)
             client.cancel_attr(repo, number, attr)
             print(f"cancelling {attr} of build #{number}")
     else:
+        status = detail["build"]["status"]
+        if status not in RUNNING_STATUSES:
+            msg = f"build #{number} already finished ({STATUS_LABELS.get(status, status)})"
+            raise UsageError(msg)
         client.cancel_build(repo, number)
         print(f"cancelling build #{number}")
     return EXIT_OK

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -512,8 +512,18 @@ def _add_json_arg(parser: argparse.ArgumentParser) -> None:
     )
 
 
+class _Parser(argparse.ArgumentParser):
+    """Suggests the closest command on typos (Python 3.14+). Subcommand
+    parsers are created with type(parser) and inherit this."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if sys.version_info >= (3, 14):
+            kwargs.setdefault("suggest_on_error", True)
+        super().__init__(*args, **kwargs)
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="nbo", description="nixbot CI client")
+    parser = _Parser(prog="nbo", description="nixbot CI client")
     sub = parser.add_subparsers(dest="command", required=True)
 
     repo = sub.add_parser("repo", help="manage repositories").add_subparsers(

--- a/nixbot_cli/nixbot_cli/term.py
+++ b/nixbot_cli/nixbot_cli/term.py
@@ -38,6 +38,29 @@ def _color(text: str, code: str) -> str:
     return f"\x1b[{code}m{text}\x1b[0m"
 
 
+def bold(text: str) -> str:
+    return _color(text, "1")
+
+
+def dim(text: str) -> str:
+    return _color(text, "2")
+
+
+def cyan(text: str) -> str:
+    return _color(text, "36")
+
+
+def green(text: str) -> str:
+    return _color(text, "32")
+
+
+_SGR_RE = re.compile(r"\x1b\[[0-9;:]*m")
+
+
+def strip_ansi(text: str) -> str:
+    return _SGR_RE.sub("", text)
+
+
 def status_str(status: str, *, cached: bool = False) -> str:
     label = STATUS_LABELS.get(status, status)
     if status == "succeeded" and cached:

--- a/nixbot_cli/nixbot_cli/term.py
+++ b/nixbot_cli/nixbot_cli/term.py
@@ -54,11 +54,19 @@ def green(text: str) -> str:
     return _color(text, "32")
 
 
-_SGR_RE = re.compile(r"\x1b\[[0-9;:]*m")
+def link(text: str, url: str) -> str:
+    """OSC 8 terminal hyperlink. Plain text when piped."""
+    if not sys.stdout.isatty():
+        return text
+    return f"\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\"
+
+
+# SGR colors and OSC 8 hyperlink wrappers take no column space.
+_INVISIBLE_RE = re.compile(r"\x1b\[[0-9;:]*m|\x1b\]8;;[^\x07\x1b]*(?:\x07|\x1b\\)")
 
 
 def strip_ansi(text: str) -> str:
-    return _SGR_RE.sub("", text)
+    return _INVISIBLE_RE.sub("", text)
 
 
 def status_str(status: str, *, cached: bool = False) -> str:


### PR DESCRIPTION
nbo needed NIXBOT_URL or a single-entry hosts.toml, so it could not
handle several nixbot instances. Host entries may now list remotes glob
patterns that are matched against the checkout's origin URL.
git config nixbot.url pins a single clone.
