### PR TITLE
nbo: select the server per repository

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -30,6 +30,38 @@ token = "bnix_..."
 
 Read-only commands work without a token on public instances.
 
+If you use more than one nixbot server, tell `nbo` which repositories belong to
+which server. Add a `remotes` list to each server entry. When you run `nbo`
+inside a checkout, it looks at the URL of the `origin` remote and picks the
+first server whose pattern matches:
+
+```toml
+["https://ci.example.org"]
+token = "bnix_..."
+remotes = ["github.com/acme/*"]
+
+["https://ci.other.org"]
+remotes = ["git.other.org/*"]
+```
+
+Patterns are shell-style wildcards matched against the remote URL in the form
+`host/owner/repo`, so both `git@github.com:acme/widget.git` and
+`https://github.com/acme/widget` match `github.com/acme/*`.
+
+You can also assign a single checkout to a server directly, which takes
+precedence over the patterns:
+
+```console
+git config nixbot.url https://ci.example.org
+```
+
+When several settings are present, `nbo` uses the first of:
+
+1. the `NIXBOT_URL` environment variable
+2. `git config nixbot.url`
+3. a `remotes` pattern match
+4. the only server in `hosts.toml`, if there is just one
+
 ### API tokens
 
 Restarting or cancelling builds and enabling repositories require an API token.

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -123,6 +123,9 @@ def test_build_list_and_view(
     assert "1" in out
     assert "✗ failed" in out
 
+    assert run_cli(api, "build", "list", "-R", "ACME/Widget") == 0
+    capsys.readouterr()
+
     assert (
         run_cli(
             api,

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
 
 import httpx
@@ -288,6 +289,50 @@ def test_settings_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("NIXBOT_TOKEN", "bnix_env")
     assert Settings.load().token == "bnix_env"
 
+
+def test_settings_multi_host_remotes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With several servers in hosts.toml, the one whose `remotes`
+    pattern matches the checkout's origin URL is used. A `git config
+    nixbot.url` setting in the checkout takes precedence."""
+    monkeypatch.delenv("NIXBOT_URL", raising=False)
+    monkeypatch.delenv("NIXBOT_TOKEN", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    hosts = tmp_path / "nixbot" / "hosts.toml"
+    hosts.parent.mkdir(parents=True)
+    hosts.write_text(
+        '["https://ci.example.org"]\ntoken = "bnix_one"\n'
+        'remotes = ["github.com/acme/*"]\n'
+        '["https://ci.other.org"]\ntoken = "bnix_two"\n'
+    )
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", "-C", str(tmp_path), *args], check=True)  # noqa: S603
+
+    git("init", "-q")
+    monkeypatch.chdir(tmp_path)
+
+    # No remote to match against.
+    with pytest.raises(ValueError, match="no server configured"):
+        Settings.load()
+
+    git("remote", "add", "origin", "git@github.com:acme/widget.git")
+    assert Settings.load() == Settings("https://ci.example.org", "bnix_one")
+
+    # Forge names are case-insensitive.
+    git("remote", "set-url", "origin", "https://github.com/Acme/Widget")
+    assert Settings.load() == Settings("https://ci.example.org", "bnix_one")
+
+    # The error names the unmatched remote.
+    git("remote", "set-url", "origin", "https://example.com/nobody/nothing")
+    with pytest.raises(ValueError, match=r"example\.com/nobody/nothing"):
+        Settings.load()
+    git("remote", "set-url", "origin", "git@github.com:acme/widget.git")
+
+    # An explicit git config setting beats the pattern match.
+    git("config", "nixbot.url", "https://ci.other.org")
+    assert Settings.load() == Settings("https://ci.other.org", "bnix_two")
 
 def test_settings_token_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -330,9 +330,23 @@ def test_settings_multi_host_remotes(
         Settings.load()
     git("remote", "set-url", "origin", "git@github.com:acme/widget.git")
 
-    # An explicit git config setting beats the pattern match.
-    git("config", "nixbot.url", "https://ci.other.org")
+    # git config wins over the pattern match. A trailing slash is tolerated.
+    git("config", "nixbot.url", "https://ci.other.org/")
     assert Settings.load() == Settings("https://ci.other.org", "bnix_two")
+
+
+def test_settings_url_trailing_slash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """NIXBOT_URL with a trailing slash still finds the host's token."""
+    monkeypatch.setenv("NIXBOT_URL", "https://ci.example.org/")
+    monkeypatch.delenv("NIXBOT_TOKEN", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    hosts = tmp_path / "nixbot" / "hosts.toml"
+    hosts.parent.mkdir(parents=True)
+    hosts.write_text('["https://ci.example.org"]\ntoken = "bnix_abc"\n')
+    assert Settings.load() == Settings("https://ci.example.org", "bnix_abc")
+
 
 def test_settings_token_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/nixbot_cli/nixbot_cli/config.py
+++ b/nixbot_cli/nixbot_cli/config.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import fnmatch
 import os
+import re
 import shlex
 import subprocess
 from dataclasses import dataclass
@@ -23,22 +25,65 @@ class Settings:
 
     @classmethod
     def load(cls) -> Settings:
-        """NIXBOT_URL/NIXBOT_TOKEN override hosts.toml. Without a URL the
-        config's single host is used."""
+        """Server: NIXBOT_URL, `git config nixbot.url`, the hosts.toml
+        entry whose `remotes` match the origin URL, or the only entry.
+        NIXBOT_TOKEN overrides the token from hosts.toml."""
         url = os.environ.get("NIXBOT_URL")
         token = os.environ.get("NIXBOT_TOKEN")
         hosts: dict[str, dict] = {}
         path = config_path()
         if path.exists():
             hosts = tomllib.loads(path.read_text())
+        url = url or _select_host(hosts)
         if not url:
-            if len(hosts) != 1:
-                msg = f"no server configured: set NIXBOT_URL or add one host to {path}"
-                raise ValueError(msg)
-            url = next(iter(hosts))
+            remote = _origin_remote()
+            where = (
+                f"no host in {path} has a remotes pattern matching {remote!r}"
+                if remote and hosts
+                else f"set NIXBOT_URL, git config nixbot.url, or a host in {path}"
+            )
+            msg = f"no server configured: {where}"
+            raise ValueError(msg)
         entry = hosts.get(url, {})
         token = token or entry.get("token") or _run_token_command(entry)
         return cls(url.rstrip("/"), token)
+
+
+def _git_config(key: str) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "config", "--get", key], capture_output=True, text=True, check=False
+        )
+    except OSError:
+        return None
+    return out.stdout.strip() or None
+
+
+def _origin_remote() -> str | None:
+    """The origin URL reduced to "host/owner/repo", so one pattern
+    covers SSH and HTTPS remotes."""
+    remote = _git_config("remote.origin.url")
+    if not remote:
+        return None
+    remote = re.sub(r"^\w+://|^\w+@", "", remote)
+    return remote.replace(":", "/").removesuffix(".git")
+
+
+def _select_host(hosts: dict[str, dict]) -> str | None:
+    if url := _git_config("nixbot.url"):
+        return url
+    if len(hosts) == 1:
+        return next(iter(hosts))
+    remote = _origin_remote()
+    if not remote:
+        return None
+    for url, entry in hosts.items():
+        if any(
+            fnmatch.fnmatch(remote.lower(), pat.lower())
+            for pat in entry.get("remotes", [])
+        ):
+            return url
+    return None
 
 
 def _run_token_command(entry: dict) -> str | None:

--- a/nixbot_cli/nixbot_cli/config.py
+++ b/nixbot_cli/nixbot_cli/config.py
@@ -44,9 +44,14 @@ class Settings:
             )
             msg = f"no server configured: {where}"
             raise ValueError(msg)
-        entry = hosts.get(url, {})
+        # A trailing slash must still find the host's token.
+        url = url.rstrip("/")
+        entry = next(
+            (e for u, e in hosts.items() if u.rstrip("/") == url),
+            {},
+        )
         token = token or entry.get("token") or _run_token_command(entry)
-        return cls(url.rstrip("/"), token)
+        return cls(url, token)
 
 
 def _git_config(key: str) -> str | None:

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -93,7 +93,12 @@ def resolve_repo(client: NixbotClient, spec: str | None) -> RepoRef:
             raise UsageError(msg)
         parts = remote.rstrip("/").removesuffix(".git").replace(":", "/").split("/")
         owner, name = parts[-2], parts[-1]
-    matches = [r for r in client.repos() if r["owner"] == owner and r["name"] == name]
+    # Forge names are case-insensitive.
+    matches = [
+        r
+        for r in client.repos()
+        if r["owner"].lower() == owner.lower() and r["name"].lower() == name.lower()
+    ]
     if not matches:
         server = str(client.http.base_url) or "the server"
         msg = (
@@ -101,7 +106,8 @@ def resolve_repo(client: NixbotClient, spec: str | None) -> RepoRef:
             f"(is it hosted on another nixbot instance? see nbo auth status)"
         )
         raise UsageError(msg)
-    return RepoRef(matches[0]["forge"], owner, name)
+    # Canonical spelling: the API paths are case-sensitive.
+    return RepoRef(matches[0]["forge"], matches[0]["owner"], matches[0]["name"])
 
 
 def resolve_build(client: NixbotClient, repo: RepoRef, number: int | None) -> int:

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -95,7 +95,11 @@ def resolve_repo(client: NixbotClient, spec: str | None) -> RepoRef:
         owner, name = parts[-2], parts[-1]
     matches = [r for r in client.repos() if r["owner"] == owner and r["name"] == name]
     if not matches:
-        msg = f"repository {owner}/{name} is not known to the server"
+        server = str(client.http.base_url) or "the server"
+        msg = (
+            f"repository {owner}/{name} is not known to {server} "
+            f"(is it hosted on another nixbot instance? see nbo auth status)"
+        )
         raise UsageError(msg)
     return RepoRef(matches[0]["forge"], owner, name)
 


### PR DESCRIPTION
hosts.toml entries can map remotes to servers, with git config nixbot.url as per-clone override. Errors now name the server, URLs tolerate trailing slashes, owner/repo match case-insensitively.