### PR TITLE
nbo: consistent command behavior

### DIFF
--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -111,6 +111,10 @@ def test_repo_list_and_toggle(
 
     assert run_cli(api, "repo", "disable", "acme/widget") == 0
     assert "disabled" in capsys.readouterr().out
+    # Without an argument the repository comes from the CWD's git remote,
+    # like every other command.
+    with pytest.raises(cli.UsageError):
+        run_cli(api, "repo", "enable")
     assert run_cli(api, "repo", "enable", "github/acme/widget") == 0
     assert api.repo(REPO)["enabled"] is True
     capsys.readouterr()
@@ -159,6 +163,24 @@ def test_build_restart_cancel(
         == 0
     )
     assert [a for _, a in BACKEND.attr_restarts] == ["bad1"]
+    # --attr is repeatable, like watch --attr and restart --effect.
+    BACKEND.attr_restarts.clear()
+    assert (
+        run_cli(
+            api,
+            "build",
+            "restart",
+            "1",
+            "-R",
+            "acme/widget",
+            "--attr",
+            "bad1",
+            "--attr",
+            "good",
+        )
+        == 0
+    )
+    assert [a for _, a in BACKEND.attr_restarts] == ["bad1", "good"]
     assert run_cli(api, "build", "restart", "1", "-R", "acme/widget", "--effects") == 0
     BACKEND.effect_restarts.clear()
     assert (

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -204,6 +204,12 @@ def test_build_restart_cancel(
     assert "cancelling build #2" in capsys.readouterr().out
     assert len(BACKEND.cancelled) == 1
 
+    # Cancelling a finished build or attribute is an error, not a no-op.
+    with pytest.raises(cli.UsageError, match="finished"):
+        run_cli(api, "build", "cancel", "1", "-R", "acme/widget")
+    with pytest.raises(cli.UsageError, match="finished"):
+        run_cli(api, "build", "cancel", "1", "-R", "acme/widget", "--attr", "bad1")
+
 
 def test_log_summary_attr_and_drv(
     harness: WebHarness,

--- a/nixbot_cli/nixbot_cli/effects.py
+++ b/nixbot_cli/nixbot_cli/effects.py
@@ -87,6 +87,7 @@ async def list_command(args: argparse.Namespace) -> None:
         fp=sys.stdout,
         indent=2,
     )
+    print()
 
 
 async def graph_command(args: argparse.Namespace) -> None:
@@ -103,6 +104,7 @@ async def list_schedules_command(args: argparse.Namespace) -> None:
     if args.flake_ref:
         options = await options_from_flake_ref(args.flake_ref, options)
     json.dump(await list_scheduled_effects(options), fp=sys.stdout, indent=2)
+    print()
 
 
 async def run_command(args: argparse.Namespace) -> None:

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -363,13 +363,6 @@ def watch_attrs(
     return EXIT_BUILD_FAILED if failed else EXIT_OK
 
 
-def resolve_attr(
-    client: NixbotClient, repo: RepoRef, number: int, selector: str
-) -> str:
-    """Full attribute name for a selector (exact, substring or drv path)."""
-    return _match_attr(client.build(repo, number)["attributes"], selector)["attr"]
-
-
 def cmd_build_restart(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
@@ -395,11 +388,21 @@ def cmd_build_restart(client: NixbotClient, args: argparse.Namespace) -> int:
 def cmd_build_cancel(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
+    detail = client.build(repo, number)
     if args.attr:
-        for attr in [resolve_attr(client, repo, number, a) for a in args.attr]:
+        for row in [_match_attr(detail["attributes"], a) for a in args.attr]:
+            attr, status = row["attr"], row["status"]
+            if status not in RUNNING_STATUSES:
+                label = STATUS_LABELS.get(status, status)
+                msg = f"{attr} of build #{number} already finished ({label})"
+                raise UsageError(msg)
             client.cancel_attr(repo, number, attr)
             print(f"cancelling {attr} of build #{number}")
     else:
+        status = detail["build"]["status"]
+        if status not in RUNNING_STATUSES:
+            msg = f"build #{number} already finished ({STATUS_LABELS.get(status, status)})"
+            raise UsageError(msg)
         client.cancel_build(repo, number)
         print(f"cancelling build #{number}")
     return EXIT_OK

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -382,9 +382,10 @@ def cmd_build_restart(client: NixbotClient, args: argparse.Namespace) -> int:
             client.restart_effects(repo, number, effect)
             print(f"restarting effect {effect} of build #{number}")
     elif args.attr:
-        attr = resolve_attr(client, repo, number, args.attr)
-        client.restart_attr(repo, number, attr)
-        print(f"restarting {attr} of build #{number}")
+        rows = client.build(repo, number)["attributes"]
+        for attr in [_match_attr(rows, a)["attr"] for a in args.attr]:
+            client.restart_attr(repo, number, attr)
+            print(f"restarting {attr} of build #{number}")
     else:
         client.restart_build(repo, number)
         print(f"restarting build #{number}")
@@ -395,9 +396,9 @@ def cmd_build_cancel(client: NixbotClient, args: argparse.Namespace) -> int:
     repo = resolve_repo(client, args.repo)
     number = resolve_build(client, repo, args.number)
     if args.attr:
-        attr = resolve_attr(client, repo, number, args.attr)
-        client.cancel_attr(repo, number, attr)
-        print(f"cancelling {attr} of build #{number}")
+        for attr in [resolve_attr(client, repo, number, a) for a in args.attr]:
+            client.cancel_attr(repo, number, attr)
+            print(f"cancelling {attr} of build #{number}")
     else:
         client.cancel_build(repo, number)
         print(f"cancelling build #{number}")
@@ -564,7 +565,12 @@ def build_parser() -> argparse.ArgumentParser:
     repo_list.set_defaults(func=cmd_repo_list)
     for action in ("enable", "disable"):
         p = repo.add_parser(action, help=f"{action} CI for a repository")
-        p.add_argument("repository", metavar="[FORGE/]OWNER/NAME")
+        p.add_argument(
+            "repository",
+            nargs="?",
+            metavar="[FORGE/]OWNER/NAME",
+            help="repository (default: inferred from the git remote)",
+        )
         p.set_defaults(func=cmd_repo_set_enabled, action=action)
 
     build = sub.add_parser("build", help="inspect and control builds").add_subparsers(
@@ -622,7 +628,12 @@ running ones. Piped or in CI it prints one line per finished attribute.""",
     )
     b_restart.add_argument("number", type=int, nargs="?")
     _add_repo_arg(b_restart)
-    b_restart.add_argument("--attr", help="restart only this attribute")
+    b_restart.add_argument(
+        "--attr",
+        action="append",
+        metavar="ATTR|DRV-PATH",
+        help="restart only this attribute (repeatable)",
+    )
     b_restart.add_argument("--effects", action="store_true", help="restart the effects")
     b_restart.add_argument(
         "--effect",
@@ -634,7 +645,12 @@ running ones. Piped or in CI it prints one line per finished attribute.""",
     b_cancel = build.add_parser("cancel", help="cancel a build or attribute")
     b_cancel.add_argument("number", type=int, nargs="?")
     _add_repo_arg(b_cancel)
-    b_cancel.add_argument("--attr", help="cancel only this attribute")
+    b_cancel.add_argument(
+        "--attr",
+        action="append",
+        metavar="ATTR|DRV-PATH",
+        help="cancel only this attribute (repeatable)",
+    )
     b_cancel.set_defaults(func=cmd_build_cancel)
 
     log = sub.add_parser(


### PR DESCRIPTION
repo enable/disable infers the repo from the git remote, --attr is repeatable everywhere, cancelling finished builds fails instead of lying, effects list output ends with a newline.