### PR TITLE
server: attribute rows shrink only when an eval result commits

### DIFF
--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -25,6 +25,7 @@ from .build_scheduler import (
 )
 from .db import BuildStatus
 from .db_gen import builds as q
+from .db_gen import maintenance as mq
 from .events import BuildResult, EvalReport
 from .executor import failure_excerpt
 from .flake_prefetch import PrefetchError, prefetch_flake_inputs
@@ -53,22 +54,49 @@ logger = logging.getLogger(__name__)
 LIVE_WARNINGS_FLUSH_INTERVAL = 2.0
 
 
+def _job_columns(
+    jobs: Sequence[NixEvalJob],
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    successes = [job for job in jobs if isinstance(job, NixEvalJobSuccess)]
+    return (
+        [job.attr for job in successes],
+        [job.system for job in successes],
+        [job.drv_path for job in successes],
+        [json.dumps(job.outputs) for job in successes],
+    )
+
+
 async def record_attributes(
     pool: asyncpg.Pool, build_id: int, jobs: Sequence[NixEvalJob]
 ) -> None:
-    """Persist eval results as pending rows (with statically-known
-    outputs) so crash recovery can resume without a re-eval. Eval
-    failures are settled by the scheduler."""
-    successes = [job for job in jobs if isinstance(job, NixEvalJobSuccess)]
-    if not successes:
+    """Persist eval results as pending rows so crash recovery can
+    resume without a re-eval."""
+    attrs, systems, drv_paths, outputs = _job_columns(jobs)
+    if not attrs:
         return
     await q.record_attributes(
         pool,
         build_id=build_id,
-        attrs=[job.attr for job in successes],
-        systems=[job.system for job in successes],
-        drv_paths=[job.drv_path for job in successes],
-        outputs=[json.dumps(job.outputs) for job in successes],
+        attrs=attrs,
+        systems=systems,
+        drv_paths=drv_paths,
+        outputs=outputs,
+    )
+
+
+async def commit_eval_result(
+    pool: asyncpg.Pool, build_id: int, jobs: Sequence[NixEvalJob]
+) -> None:
+    """Publish a completed eval: the only operation that may shrink
+    the attribute set."""
+    attrs, systems, drv_paths, outputs = _job_columns(jobs)
+    await mq.commit_eval_result(
+        pool,
+        build_id=build_id,
+        attrs=attrs,
+        systems=systems,
+        drv_paths=drv_paths,
+        outputs=outputs,
     )
 
 
@@ -215,19 +243,14 @@ async def _record_eval_success(
     live_warnings: LiveWarningAggregator,
 ) -> None:
     """Persist a completed evaluation and report it to the forge."""
-    # Idempotent backstop for the streaming inserts during eval;
-    # pending rows are what crash recovery resumes from. The
-    # scheduler drops unsupported systems. Their pending rows
-    # would never turn terminal, so don't record them.
+    # The scheduler drops unsupported systems, their rows would stay
+    # pending forever.
     buildable = [
         job
         for job in jobs
         if isinstance(job, NixEvalJobSuccess) and job.system in o.config.build_systems
     ]
-    await record_attributes(o.pool, build.id, buildable)
-    # The full eval result is recorded in build_attributes. A later
-    # build of the same tree may reuse it instead of re-evaluating.
-    await q.mark_eval_completed(o.pool, id_=build.id)
+    await commit_eval_result(o.pool, build.id, buildable)
     await o.reporter.eval_finished(
         event,
         build,
@@ -426,8 +449,7 @@ async def _try_reuse_eval(
     reused = await _reusable_eval_jobs(o, build)
     if reused is None:
         return False
-    await record_attributes(o.pool, build.id, reused)
-    await q.mark_eval_completed(o.pool, id_=build.id)
+    await commit_eval_result(o.pool, build.id, reused)
     await db.set_build_status(o.pool, build.id, BuildStatus.BUILDING)
     await o.reporter.eval_finished(event, build, EvalReport(success=True, jobs=reused))
     # cache_failures=False: see _ReadOnlyFailedBuildCache.

--- a/nixbot/nixbot/db_gen/builds.py
+++ b/nixbot/nixbot/db_gen/builds.py
@@ -30,7 +30,6 @@ __all__: collections.abc.Sequence[str] = (
     "lock_build_row",
     "mark_attribute_building",
     "mark_effects_started",
-    "mark_eval_completed",
     "record_attributes",
     "set_build_status",
     "set_eval_warnings",
@@ -239,10 +238,6 @@ UPDATE builds SET effects_started = TRUE,
 WHERE id = $4::bigint AND effects_started = FALSE RETURNING id
 """
 
-MARK_EVAL_COMPLETED: typing.Final[str] = """-- name: MarkEvalCompleted :exec
-UPDATE builds SET eval_completed = TRUE WHERE id = $1
-"""
-
 RECORD_ATTRIBUTES: typing.Final[str] = """-- name: RecordAttributes :exec
 INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, status)
 SELECT $1::bigint, u.attr, u.system, u.drv_path, u.outputs, 'pending'
@@ -250,7 +245,11 @@ FROM (SELECT unnest($2::text[]) AS attr,
              unnest($3::text[]) AS system,
              unnest($4::text[]) AS drv_path,
              unnest($5::jsonb[]) AS outputs) u
-ON CONFLICT (build_id, attr) DO NOTHING
+ON CONFLICT (build_id, attr) DO UPDATE SET
+    system = EXCLUDED.system,
+    drv_path = EXCLUDED.drv_path,
+    outputs = EXCLUDED.outputs
+WHERE build_attributes.status IN ('pending', 'building')
 """
 
 SET_BUILD_STATUS: typing.Final[str] = """-- name: SetBuildStatus :exec
@@ -484,10 +483,6 @@ async def mark_effects_started(conn: ConnectionLike, *, commit_sha: str, branch:
     if row is None:
         return None
     return row[0]
-
-
-async def mark_eval_completed(conn: ConnectionLike, *, id_: int) -> None:
-    await conn.execute(MARK_EVAL_COMPLETED, id_)
 
 
 async def record_attributes(conn: ConnectionLike, *, build_id: int, attrs: collections.abc.Sequence[str], systems: collections.abc.Sequence[str], drv_paths: collections.abc.Sequence[str], outputs: collections.abc.Sequence[str]) -> None:

--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -17,6 +17,7 @@ __all__: collections.abc.Sequence[str] = (
     "cancel_build",
     "cleanup_old_rows",
     "commit_built",
+    "commit_eval_result",
     "count_unfinished_attributes",
     "delete_attributes_by_name",
     "delete_effects_by_name",
@@ -148,6 +149,27 @@ COMMIT_BUILT: typing.Final[str] = """-- name: CommitBuilt :one
 SELECT 1 AS one FROM builds WHERE project_id = $1 AND commit_sha = $2 LIMIT 1
 """
 
+COMMIT_EVAL_RESULT: typing.Final[str] = """-- name: CommitEvalResult :exec
+WITH new_rows AS (
+    INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, status)
+    SELECT $1::bigint, u.attr, u.system, u.drv_path, u.outputs, 'pending'
+    FROM (SELECT unnest($2::text[]) AS attr,
+                 unnest($3::text[]) AS system,
+                 unnest($4::text[]) AS drv_path,
+                 unnest($5::jsonb[]) AS outputs) u
+    ON CONFLICT (build_id, attr) DO UPDATE SET
+        system = EXCLUDED.system,
+        drv_path = EXCLUDED.drv_path,
+        outputs = EXCLUDED.outputs
+    WHERE build_attributes.status IN ('pending', 'building')
+), pruned AS (
+    DELETE FROM build_attributes WHERE build_id = $1
+    AND attr != ALL($2::text[])
+    AND (status IN ('pending', 'building') OR drv_path IS NULL)
+)
+UPDATE builds SET eval_completed = TRUE WHERE builds.id = $1
+"""
+
 COUNT_UNFINISHED_ATTRIBUTES: typing.Final[str] = """-- name: CountUnfinishedAttributes :one
 SELECT count(*) AS count FROM build_attributes
 WHERE build_id = $1 AND status IN ('pending', 'building')
@@ -236,11 +258,7 @@ WHERE build_id = $1
 """
 
 RESET_EVAL_FOR_REEVAL: typing.Final[str] = """-- name: ResetEvalForReeval :exec
-WITH flag AS (
-    UPDATE builds SET eval_completed = FALSE WHERE id = $1
-)
-DELETE FROM build_attributes WHERE build_id = $1
-AND (status IN ('pending', 'building') OR drv_path IS NULL)
+UPDATE builds SET eval_completed = FALSE WHERE id = $1
 """
 
 RUNNING_BUILD_IDS: typing.Final[str] = """-- name: RunningBuildIds :many
@@ -345,6 +363,10 @@ async def commit_built(conn: ConnectionLike, *, project_id: int, commit_sha: str
     if row is None:
         return None
     return row[0]
+
+
+async def commit_eval_result(conn: ConnectionLike, *, build_id: int, attrs: collections.abc.Sequence[str], systems: collections.abc.Sequence[str], drv_paths: collections.abc.Sequence[str], outputs: collections.abc.Sequence[str]) -> None:
+    await conn.execute(COMMIT_EVAL_RESULT, build_id, attrs, systems, drv_paths, outputs)
 
 
 async def count_unfinished_attributes(conn: ConnectionLike, *, build_id: int) -> int | None:

--- a/nixbot/nixbot/queries/builds.sql
+++ b/nixbot/nixbot/queries/builds.sql
@@ -56,15 +56,19 @@ FROM n
 RETURNING *;
 
 -- name: RecordAttributes :exec
--- Batch insert of one eval's attribute rows; arrays are zipped
--- positionally by unnest.
+-- Streaming inserts while the eval runs. Rows only grow or refresh
+-- here, they shrink solely in CommitEvalResult.
 INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, status)
 SELECT sqlc.arg(build_id)::bigint, u.attr, u.system, u.drv_path, u.outputs, 'pending'
 FROM (SELECT unnest(sqlc.arg(attrs)::text[]) AS attr,
              unnest(sqlc.arg(systems)::text[]) AS system,
              unnest(sqlc.arg(drv_paths)::text[]) AS drv_path,
              unnest(sqlc.arg(outputs)::jsonb[]) AS outputs) u
-ON CONFLICT (build_id, attr) DO NOTHING;
+ON CONFLICT (build_id, attr) DO UPDATE SET
+    system = EXCLUDED.system,
+    drv_path = EXCLUDED.drv_path,
+    outputs = EXCLUDED.outputs
+WHERE build_attributes.status IN ('pending', 'building');
 
 -- name: SetEvalWarnings :exec
 UPDATE builds SET eval_warnings = sqlc.arg(warnings)::jsonb WHERE id = $1;
@@ -106,9 +110,6 @@ SET status = sqlc.arg(status),
         ELSE NULL
     END
 WHERE builds.id = sqlc.arg(id)::bigint;
-
--- name: MarkEvalCompleted :exec
-UPDATE builds SET eval_completed = TRUE WHERE id = $1;
 
 -- name: FindCompletedEval :one
 SELECT id FROM builds WHERE project_id = $1 AND tree_hash = $2

--- a/nixbot/nixbot/queries/maintenance.sql
+++ b/nixbot/nixbot/queries/maintenance.sql
@@ -67,18 +67,31 @@ SELECT count(*) AS count FROM build_attributes
 WHERE build_id = $1 AND status IN ('pending', 'building');
 
 -- name: ResetEvalForReeval :exec
--- Stale rows (e.g. failed_eval with NULL drv_path) would wedge the
--- aggregate; the re-eval rewrites them. Finished rows with a drv_path
--- are kept: their results are valid and the re-eval skips
--- already-built attributes. One atomic statement: the
--- eval_completed flag must never be observable as set while the
--- partial row set already lost entries (a concurrent build of the
--- same tree would reuse the incomplete eval).
-WITH flag AS (
-    UPDATE builds SET eval_completed = FALSE WHERE id = sqlc.arg(build_id)
+-- Flag only: an interrupted re-eval must not lose rows.
+UPDATE builds SET eval_completed = FALSE WHERE id = sqlc.arg(build_id);
+
+-- name: CommitEvalResult :exec
+-- The only place the attribute set shrinks. Refreshes non-terminal
+-- rows, prunes rows the eval no longer produced, publishes via
+-- eval_completed, atomically.
+WITH new_rows AS (
+    INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, status)
+    SELECT sqlc.arg(build_id)::bigint, u.attr, u.system, u.drv_path, u.outputs, 'pending'
+    FROM (SELECT unnest(sqlc.arg(attrs)::text[]) AS attr,
+                 unnest(sqlc.arg(systems)::text[]) AS system,
+                 unnest(sqlc.arg(drv_paths)::text[]) AS drv_path,
+                 unnest(sqlc.arg(outputs)::jsonb[]) AS outputs) u
+    ON CONFLICT (build_id, attr) DO UPDATE SET
+        system = EXCLUDED.system,
+        drv_path = EXCLUDED.drv_path,
+        outputs = EXCLUDED.outputs
+    WHERE build_attributes.status IN ('pending', 'building')
+), pruned AS (
+    DELETE FROM build_attributes WHERE build_id = sqlc.arg(build_id)
+    AND attr != ALL(sqlc.arg(attrs)::text[])
+    AND (status IN ('pending', 'building') OR drv_path IS NULL)
 )
-DELETE FROM build_attributes WHERE build_id = sqlc.arg(build_id)
-AND (status IN ('pending', 'building') OR drv_path IS NULL);
+UPDATE builds SET eval_completed = TRUE WHERE builds.id = sqlc.arg(build_id);
 
 -- name: DeleteAttributesByName :exec
 DELETE FROM build_attributes WHERE build_id = $1

--- a/nixbot/nixbot/restart_dispatch.py
+++ b/nixbot/nixbot/restart_dispatch.py
@@ -133,13 +133,8 @@ async def _reeval(
             event,
             worktree_path,
         ):
-            # Stale rows (e.g. failed_eval with NULL drv_path) would
-            # wedge the aggregate. The re-eval rewrites them. Finished
-            # rows with a drv_path are kept: their results are valid
-            # and the re-eval skips already-built attributes.
-            # The flag must drop before the rows: a concurrent build
-            # of the same tree must not reuse the partial set
-            # (run_build only clears it after this window).
+            # Flag only. Rows are rewritten when the re-eval commits,
+            # so an interrupted re-eval loses nothing.
             await q.reset_eval_for_reeval(s.pool, build_id=build.id)
             await s.orchestrator.run_build(event, build, worktree_path)
     finally:

--- a/nixbot/nixbot/tests/test_db.py
+++ b/nixbot/nixbot/tests/test_db.py
@@ -205,6 +205,42 @@ async def test_get_or_create_build_concurrent_no_duplicates(postgres_dsn: str) -
         assert count == 1
 
 
+async def test_commit_eval_result_atomic(pool: asyncpg.Pool) -> None:
+    """Committing an eval result refreshes non-terminal rows, prunes
+    rows the eval no longer produced and sets eval_completed, all in
+    one statement. Finished rows keep their results."""
+    project_id = await insert_project(pool, forge_repo_id="commit-eval")
+    build_id = await insert_build(pool, project_id, eval_completed=False)
+    await pool.execute(
+        "INSERT INTO build_attributes (build_id, attr, system, status, drv_path) "
+        "VALUES ($1, 'done', 'x86_64-linux', 'succeeded', '/nix/store/done.drv'), "
+        "($1, 'restarted', 'x86_64-linux', 'pending', '/nix/store/old.drv'), "
+        "($1, 'vanished', 'x86_64-linux', 'pending', '/nix/store/gone.drv'), "
+        "($1, 'broken', 'x86_64-linux', 'failed_eval', NULL)",
+        build_id,
+    )
+
+    await build_run.commit_eval_result(
+        pool, build_id, [mk_job("done"), mk_job("restarted"), mk_job("new")]
+    )
+
+    rows = {
+        r["attr"]: (r["status"], r["drv_path"])
+        for r in await pool.fetch(
+            "SELECT attr, status, drv_path FROM build_attributes WHERE build_id = $1",
+            build_id,
+        )
+    }
+    assert rows == {
+        "done": ("succeeded", "/nix/store/done.drv"),
+        "restarted": ("pending", "/nix/store/restarted.drv"),
+        "new": ("pending", "/nix/store/new.drv"),
+    }
+    assert await pool.fetchval(
+        "SELECT eval_completed FROM builds WHERE id = $1", build_id
+    )
+
+
 async def test_cancelled_build_not_reused(pool: asyncpg.Pool) -> None:
     # A cancelled build carries no verdict. Re-pushing the same tree
     # must build again instead of re-reporting "cancelled".

--- a/nixbot/nixbot/tests/test_service.py
+++ b/nixbot/nixbot/tests/test_service.py
@@ -431,13 +431,53 @@ async def test_restart_failed_eval_attribute_reevaluates(
     await asyncio.gather(*service._tasks)  # noqa: SLF001
 
     assert reevals == [build_id]
-    # Stale NULL-drv rows are cleared so the re-eval result is
-    # authoritative.
+    # The stale row survives until a successful eval commits its
+    # result. Interrupted re-evals must never lose rows.
     count = await pool.fetchval(
         "SELECT count(*) FROM build_attributes WHERE build_id = $1",
         build_id,
     )
-    assert count == 0
+    assert count == 1
+
+
+async def test_interrupted_reeval_keeps_attribute_rows(
+    service: CIService, git_repo: tuple[Path, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An attribute restart falls back to re-evaluation when the stored
+    derivations were garbage-collected. A re-eval that never completes
+    (cancel, crash) must not lose any attribute rows."""
+    repo, sha = git_repo
+
+    async def all_gcd(paths: list[str]) -> set[str]:
+        return set()
+
+    monkeypatch.setattr("nixbot.restart_dispatch.check_store_paths", all_gcd)
+
+    pool = service.pool
+    project_id = await seed_project(pool, str(repo))
+    build_id = await insert_build(
+        pool, project_id, commit_sha=sha, status="failed", eval_completed=True
+    )
+    await pool.execute(
+        "INSERT INTO build_attributes (build_id, attr, system, status, drv_path) "
+        "VALUES ($1, 'ok', 'x86_64-linux', 'succeeded', '/nix/store/aaa.drv'), "
+        "($1, 'bad', 'x86_64-linux', 'failed', '/nix/store/bbb.drv')",
+        build_id,
+    )
+
+    capture_run_build(service)  # the re-eval never records a result
+    await service.restart_attribute(build_id, "bad")
+    await service.drain_work()
+    await asyncio.gather(*service._tasks)  # noqa: SLF001
+
+    attrs = {
+        r["attr"]: r["status"]
+        for r in await pool.fetch(
+            "SELECT attr, status FROM build_attributes WHERE build_id = $1", build_id
+        )
+    }
+    assert set(attrs) == {"ok", "bad"}
+    assert attrs["ok"] == "succeeded"
 
 
 async def test_restart_cancelled_build_reschedules_attributes(


### PR DESCRIPTION
Attribute rows could be lost when a re-eval was cancelled (15→12 attrs observed). Now the attribute set only shrinks in CommitEvalResult, one atomic statement at eval success. Verified live on eve.