### PR TITLE
effects: realize fsroot with the Nix 2.33+ derivation JSON format

### DIFF
--- a/nixbot_effects/nixbot_effects/run.py
+++ b/nixbot_effects/nixbot_effects/run.py
@@ -24,6 +24,7 @@ from .proc import stream_command
 from .sandbox import (
     effect_checkout_mount,
     env_args,
+    fsroot_input_drvs,
     fsroot_mounts,
     id_token_audiences,
     pass_as_file_env,
@@ -125,14 +126,12 @@ async def _realize_fsroot(drv: dict[str, Any], opts: EffectsOptions) -> None:
     root = drv.get("env", {}).get("__hci_effect_fsroot_copy")
     if not root or os.path.exists(root):  # noqa: PTH110, ASYNC240
         return
-    name = Path(root).name.partition("-")[2] + ".drv"
-    for input_drv in drv.get("inputDrvs", {}):
-        if Path(input_drv).name.partition("-")[2] == name:
-            await stream_command(
-                nix_command("build", "--no-link", f"{input_drv}^*"),
-                log=opts.log,
-                debug=opts.debug,
-            )
+    for input_drv in fsroot_input_drvs(drv):
+        await stream_command(
+            nix_command("build", "--no-link", f"{input_drv}^*"),
+            log=opts.log,
+            debug=opts.debug,
+        )
 
 
 async def _run_in_sandbox(

--- a/nixbot_effects/nixbot_effects/sandbox.py
+++ b/nixbot_effects/nixbot_effects/sandbox.py
@@ -106,6 +106,21 @@ EFFECT_CHECKOUT_ATTR = "__nixbot_effect_checkout"
 EFFECT_CHECKOUT_PATH = "/build/checkout"
 
 
+def fsroot_input_drvs(drv: dict) -> list[str]:
+    """Input drvs producing __hci_effect_fsroot_copy; handles both the
+    legacy inputDrvs map and Nix >= 2.33 inputs.drvs (basename keys)."""
+    root = drv.get("env", {}).get("__hci_effect_fsroot_copy")
+    if not root:
+        return []
+    name = Path(root).name.partition("-")[2] + ".drv"
+    inputs = drv.get("inputDrvs") or drv.get("inputs", {}).get("drvs", {})
+    return [
+        drv_path if drv_path.startswith("/") else f"/nix/store/{drv_path}"
+        for drv_path in inputs
+        if Path(drv_path).name.partition("-")[2] == name
+    ]
+
+
 def fsroot_mounts(
     drv_env: dict[str, str], store_prefix: Path | str = "/nix/store"
 ) -> tuple[list[str], dict[str, str]]:

--- a/nixbot_effects/nixbot_effects/tests/test_effect_checkout.py
+++ b/nixbot_effects/nixbot_effects/tests/test_effect_checkout.py
@@ -8,7 +8,11 @@ import pytest
 
 from nixbot_effects import EffectError
 from nixbot_effects.run import _bubblewrap_command
-from nixbot_effects.sandbox import effect_checkout_mount, fsroot_mounts
+from nixbot_effects.sandbox import (
+    effect_checkout_mount,
+    fsroot_input_drvs,
+    fsroot_mounts,
+)
 
 
 def test_undeclared_checkout_is_ignored() -> None:
@@ -93,3 +97,36 @@ def test_fsroot_mounts_marks_copy_done(tmp_path: Path) -> None:
     )
     assert args == ["--ro-bind", str(root / "bin"), "/bin"]
     assert env == {"__hci_effect_fsroot_copied": "1"}
+
+
+FSROOT = "/nix/store/1vl52m30m4fbdaghiln6dr9xnzhpsc4l-mkEffect-root"
+FSROOT_DRV = "c000000000000000000000000000000c-mkEffect-root.drv"
+
+
+def test_fsroot_input_drvs_legacy_format() -> None:
+    drv = {
+        "env": {"__hci_effect_fsroot_copy": FSROOT},
+        "inputDrvs": {
+            f"/nix/store/{FSROOT_DRV}": {"outputs": ["out"]},
+            "/nix/store/a000000000000000000000000000000a-bash-5.3.drv": {},
+        },
+    }
+    assert fsroot_input_drvs(drv) == [f"/nix/store/{FSROOT_DRV}"]
+
+
+def test_fsroot_input_drvs_v4_format() -> None:
+    drv = {
+        "env": {"__hci_effect_fsroot_copy": FSROOT},
+        "inputs": {
+            "drvs": {
+                FSROOT_DRV: {"outputs": ["out"]},
+                "a000000000000000000000000000000a-bash-5.3.drv": {},
+            },
+            "srcs": [],
+        },
+    }
+    assert fsroot_input_drvs(drv) == [f"/nix/store/{FSROOT_DRV}"]
+
+
+def test_fsroot_input_drvs_without_fsroot() -> None:
+    assert fsroot_input_drvs({"env": {}}) == []


### PR DESCRIPTION

Nix 2.33 (commit 0c37a6220) moved input derivations from the
top-level inputDrvs map to inputs.drvs keyed by basename.
_realize_fsroot only read inputDrvs, so the mkEffect-root was never
built and effects failed with ENOENT.

Extract fsroot_input_drvs, which handles both layouts.
