### PR TITLE
effects: cancel running effect runs on an effects restart

### DIFF
--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -8,9 +8,11 @@ keeps the module dependency graph acyclic.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -43,6 +45,21 @@ if TYPE_CHECKING:
     from .orchestrator import Orchestrator
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RunningEffect:
+    """Registered for the full lifetime of a claimed effect item, so an
+    effects restart can always free the item's dedup key. `settled` is
+    set once the item released its row."""
+
+    task: asyncio.Task[None]
+    settled: asyncio.Event = field(default_factory=asyncio.Event)
+    restart: bool = False
+
+    def cancel(self) -> None:
+        self.restart = True
+        self.task.cancel()
 
 
 async def maybe_run_effects(
@@ -214,6 +231,30 @@ async def run_effect_item(
 ) -> None:
     """Dispatcher entry for one queued effect: run it, or skip it when a
     dependency did not succeed."""
+    task = asyncio.current_task()
+    if task is None:
+        msg = "run_effect_item must run inside a task"
+        raise RuntimeError(msg)
+    running = RunningEffect(task=task)
+    o.running_effects[(build.id, name)] = running
+    try:
+        await _claimed_effect_item(o, info, build, name, credentials)
+    except asyncio.CancelledError:
+        # The restart resets the row and logs after `settled`.
+        if not running.restart:
+            raise
+    finally:
+        o.running_effects.pop((build.id, name), None)
+        running.settled.set()
+
+
+async def _claimed_effect_item(
+    o: Orchestrator,
+    info: RepoInfo,
+    build: BuildRecord,
+    name: str,
+    credentials: FetchCredentials | None,
+) -> None:
     row = await q.effect_status(o.pool, build_id=build.id, name=name)
     if row != "pending":
         # Swept after a crash mid-run, or already terminal. Started

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -126,6 +126,9 @@ class Orchestrator:
     attr_cancel_events: dict[tuple[int, str], asyncio.Event] = field(
         default_factory=dict
     )
+    running_effects: dict[tuple[int, str], effects_run.RunningEffect] = field(
+        default_factory=dict
+    )
     # Injectable for tests. Defaults to the real implementations.
     register_gcroot: GcrootRegistrar = gcroots.register_gcroot
     write_output_path: OutputWriter = outputs.write_output_path

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -159,6 +159,21 @@ async def _rerun_names(
     return sorted(names)
 
 
+async def _cancel_running_effects(
+    o: Orchestrator, build_id: int, names: list[str] | None
+) -> None:
+    """A hung effect run would hold its work-queue dedup key forever,
+    starving the re-enqueued item (issue #139)."""
+    running = [
+        r
+        for (bid, name), r in o.running_effects.items()
+        if bid == build_id and (names is None or name in names)
+    ]
+    for r in running:
+        r.cancel()
+    await asyncio.gather(*(r.settled.wait() for r in running))
+
+
 async def rerun_effects(
     o: Orchestrator,
     info: RepoInfo,
@@ -183,6 +198,7 @@ async def rerun_effects(
                     extra={"build_id": build.id, "effect": only},
                 )
                 return
+        await _cancel_running_effects(o, build.id, names)
         # Reset under the claim: resetting earlier (e.g. in the
         # service) could clobber a rerun already in flight. Drop the
         # previous run's logs here too, so pending rows show no stale

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -1168,6 +1168,47 @@ async def test_rerun_effects_runs_effects_again(
     assert attrs_before == attrs_after
 
 
+async def test_rerun_effects_cancels_hung_effect(
+    pool: asyncpg.Pool,
+    run_effect_build: EffectBuildRunner,
+    upstream: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #139: a restart cancels a hung effect run instead of
+    starving forever behind its work-queue dedup key."""
+    add_commit(upstream, "hung")
+    build, orchestrator, project, _ran = await run_effect_build()
+    assert build is not None
+
+    async def hung_run(ctx: object, name: str, log_write: object = None) -> bool:
+        await asyncio.Event().wait()
+        return True
+
+    monkeypatch.setattr(effects_run_mod, "run_effect", hung_run)
+    await orchestrator.rerun_effects(project, build)
+    queue = WorkQueue(pool)
+    item = await queue.claim_next()
+    assert item is not None
+    assert item.kind == "effect"
+    hung_item = asyncio.create_task(
+        orchestrator.run_effect_item(project, build, item.payload["name"])
+    )
+    await asyncio.sleep(0)
+    assert (build.id, "deploy") in orchestrator.running_effects
+
+    ran2 = patch_effects(monkeypatch)
+    await asyncio.wait_for(orchestrator.rerun_effects(project, build), timeout=5)
+    await hung_item
+    await queue.finish(item.id)
+    await drain_effect_items(orchestrator, project, pool)
+    assert ran2 == ["deploy"]
+    status = await pool.fetchval(
+        "SELECT status FROM build_effects WHERE build_id = $1 AND name = 'deploy'",
+        build.id,
+    )
+    assert status == "succeeded"
+
+
 async def test_rerun_single_effect(
     pool: asyncpg.Pool,
     make_env: EnvFactory,


### PR DESCRIPTION

A restart re-enqueued each effect under the dedup key a hung run
still held, so the fresh item was never claimable and the reset row
stayed pending forever (#139).

Register a RunningEffect handle for the full lifetime of a claimed
effect item. rerun_effects cancels matching handles and awaits their
settlement before resetting and re-enqueueing.

Fixes: #139
