### PR TITLE
web: show effect status icon on the effect log page

### DIFF
--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -1608,6 +1608,31 @@ def test_effect_log_raw_text(client: WebHarness, tmp_path: Path) -> None:
     assert "activating system" in response.text
 
 
+def test_effect_log_viewer_status_icon(client: WebHarness, tmp_path: Path) -> None:
+    """The effect log page shows the same status icon as the build page."""
+
+    async def seed_effect_log() -> None:
+        ctx = client.ctx
+        ctx.state_dir = tmp_path
+        build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
+        log_file = effect_log_path(tmp_path, build_id, "deploy3")
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        log_file.write_bytes(
+            zstandard.ZstdCompressor().compress(b"activating system...\n")
+        )
+        await ctx.pool.execute(
+            "INSERT INTO build_effects (build_id, name, status, log_size, "
+            "finished_at) VALUES ($1, 'deploy3', 'succeeded', 42, now())",
+            build_id,
+        )
+
+    client.loop.run_until_complete(seed_effect_log())
+    text = client.get("/repos/github/acme/widget/builds/2/logs/effect:deploy3").text
+    assert "status-icon succeeded" in text
+    # Controls must target the effect endpoints, not /attrs/effect:...
+    assert "attrs/effect" not in text
+
+
 def test_effect_changes_notify_build_events(client: WebHarness) -> None:
     """The page's SSE refresh rides on build_events. Without a trigger
     on build_effects the Effects section never updates live."""

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -969,9 +969,18 @@ class _LogRoutes:
         project, build, path = await self._resolve(
             request, forge, owner, name, number, attr
         )
-        attr_status = await gen.attribute_status(
-            self.ctx.pool, build_id=build["id"], attr=attr
-        )
+        # Effect statuses live in build_effects, not attributes.
+        is_effect = attr.startswith("effect:")
+        if is_effect:
+            attr_status = await maint_gen.effect_status(
+                self.ctx.pool,
+                build_id=build["id"],
+                name=attr.removeprefix("effect:"),
+            )
+        else:
+            attr_status = await gen.attribute_status(
+                self.ctx.pool, build_id=build["id"], attr=attr
+            )
         # Live pages render no snapshot: the stream replays full
         # history on connect, the client would throw it away.
         writer = self.registry.get(build["id"], attr)
@@ -994,7 +1003,7 @@ class _LogRoutes:
                 content = await asyncio.to_thread(
                     render_log_lines, data.decode(errors="replace")
                 )
-            elif attr_status in ("pending", "building"):
+            elif attr_status in ("pending", "building", "running"):
                 # The build page links queued attributes before any
                 # log exists. Show a waiting page instead of a 404.
                 waiting = True
@@ -1019,6 +1028,7 @@ class _LogRoutes:
             project=project,
             build=build,
             attr_status=attr_status,
+            is_effect=is_effect,
             attr=attr,
             content=content,
             toc=toc,

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -24,7 +24,14 @@
           </small>
         </h2>
         <div class="controls">
-          {% if can_control and attr_status in ('pending', 'building') %}
+          {% if is_effect %}
+            {% if can_control and build.status == "succeeded" and attr_status not in ("pending", "running") %}
+              <form method="post"
+                    action="{{ build_path(project, build.number) }}/effects/restart?name={{ attr | replace('effect:', '', 1) | urlencode }}">
+                <button>restart</button>
+              </form>
+            {% endif %}
+          {% elif can_control and attr_status in ('pending', 'building') %}
             <form method="post"
                   action="{{ build_path(project, build.number) }}/attrs/{{ attr | urlencode }}/cancel">
               <button>cancel</button>
@@ -123,7 +130,7 @@
   {% endif %}
   <script>
     const LIVE = {{ live | tojson }};
-    const RUNNING = {{ (attr_status in ("pending", "building")) | tojson }};
+    const RUNNING = {{ (attr_status in ("pending", "building", "running")) | tojson }};
     const log = document.getElementById("log");
     /* Failures sit at the end. Start there unless a line is linked. */
     if (log && !location.hash) log.scrollTop = log.scrollHeight;


### PR DESCRIPTION

Effect statuses live in build_effects, not attributes, so the log
viewer rendered no icon and wrong controls for effect: keys.
