### PR TITLE
executor: stamp attribute started_at after slot acquisition

### DIFF
--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -607,20 +607,18 @@ class _OrchestratorExecutor:
             return BuildOutcome.failure_no_cache
 
     async def _build_inner(self, job: NixEvalJobSuccess) -> BuildOutcome:
-        # Flip to 'building' and stamp started_at so the web UI can
-        # distinguish running attributes from queued ones. Returns no
-        # row when the attribute is already terminal.
-        marked = await q.mark_attribute_building(
-            self.o.pool,
-            build_id=self.build_record.id,
-            attr=job.attr,
-            system=job.system,
-            drv_path=job.drv_path,
-        )
-        if marked is None:
-            # Cancelled externally while waiting on dependencies: do
-            # not resurrect the row by building it anyway.
-            return BuildOutcome.cancelled
+        # Runs after slot acquisition so started_at (and the shown
+        # duration) excludes queue wait. False: row already terminal.
+        async def mark_building() -> bool:
+            marked = await q.mark_attribute_building(
+                self.o.pool,
+                build_id=self.build_record.id,
+                attr=job.attr,
+                system=job.system,
+                drv_path=job.drv_path,
+            )
+            return marked is not None
+
         # Per-attribute cancellation: the executor watches one event, so
         # mirror the build-level cancel into the attribute's own event.
         attr_cancel = asyncio.Event()
@@ -639,6 +637,7 @@ class _OrchestratorExecutor:
                     writer,
                     self.worktree_path,
                     attr_cancel,
+                    on_start=mark_building,
                 )
                 if outcome == BuildOutcome.success and self.o.config.post_build_steps:
                     props = build_props(self.event, job)

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -43,7 +43,7 @@ from .gcroots import safe_attr_filename
 from .logstore import LogContainerWriter
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable
     from pathlib import Path
 
     from .models import NixEvalJobSuccess
@@ -789,16 +789,20 @@ class NixBuildExecutor:
         self.queue = queue
         self.settings = settings
 
-    async def build_attribute(
+    async def build_attribute(  # noqa: PLR0913
         self,
         build_key: object,
         job: NixEvalJobSuccess,
         log_writer: LogWriter,
         cwd: Path,
         cancel_event: asyncio.Event | None = None,
+        on_start: Callable[[], Awaitable[bool]] | None = None,
     ) -> BuildOutcome:
         """Run `nix build` for one attribute, with one automatic retry
-        on transient errors (suppressed when cancellation is requested)."""
+        on transient errors (suppressed when cancellation is requested).
+
+        on_start fires once a slot is acquired, right before nix runs;
+        a False return (row already terminal) skips the build."""
         cancel_event = cancel_event or asyncio.Event()
         if cancel_event.is_set():
             return BuildOutcome.cancelled
@@ -833,6 +837,8 @@ class NixBuildExecutor:
             return BuildOutcome.cancelled
         await acquire_task
         try:
+            if on_start is not None and not await on_start():
+                return BuildOutcome.cancelled
             outcome, transient = await self._run_once(
                 job, log_writer, cwd, cancel_event
             )

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -98,13 +98,14 @@ class EvalRunnerLike(Protocol):
 class AttributeExecutor(Protocol):
     """What the orchestrator needs from executor.NixBuildExecutor."""
 
-    async def build_attribute(
+    async def build_attribute(  # noqa: PLR0913
         self,
         build_key: object,
         job: NixEvalJobSuccess,
         log_writer: LogWriter,
         cwd: Path,
         cancel_event: asyncio.Event | None = None,
+        on_start: Callable[[], Awaitable[bool]] | None = None,
     ) -> BuildOutcome: ...
 
 

--- a/nixbot/nixbot/tests/test_executor.py
+++ b/nixbot/nixbot/tests/test_executor.py
@@ -319,6 +319,46 @@ async def test_executor_timeout(tmp_path: Path, fake_nix: Path) -> None:
     assert b"timed out" in log
 
 
+async def test_executor_on_start_fires_after_slot_acquired(
+    tmp_path: Path, fake_nix: Path
+) -> None:
+    """on_start must not fire while the job is queued for a slot, so
+    the DB started_at stamp (and the user-visible duration) excludes
+    queue wait."""
+    fake_nix.write_text("hang")
+    executor = NixBuildExecutor(FairScheduler(1), BuildSettings(log_dir=tmp_path))
+    first_writer = LogWriter(path=tmp_path / "first.zst")
+    first_cancel = asyncio.Event()
+    first = asyncio.create_task(
+        executor.build_attribute("a", mk_job(), first_writer, tmp_path, first_cancel)
+    )
+    await asyncio.sleep(0.2)
+
+    started = asyncio.Event()
+
+    async def on_start() -> bool:
+        fake_nix.write_text("ok")
+        started.set()
+        return True
+
+    second_writer = LogWriter(path=tmp_path / "second.zst")
+    second = asyncio.create_task(
+        executor.build_attribute(
+            "b", mk_job(), second_writer, tmp_path, on_start=on_start
+        )
+    )
+    await asyncio.sleep(0.2)
+    assert not started.is_set()
+
+    first_cancel.set()
+    outcome = await asyncio.wait_for(second, timeout=5)
+    assert started.is_set()
+    assert outcome == BuildOutcome.success
+    assert await asyncio.wait_for(first, timeout=5) == BuildOutcome.cancelled
+    await first_writer.close()
+    await second_writer.close()
+
+
 async def test_executor_cancel(tmp_path: Path, fake_nix: Path) -> None:
     fake_nix.write_text("hang")
 

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -106,14 +106,17 @@ class FakeExecutor:
     gate: asyncio.Event | None = None
     started: asyncio.Event = field(default_factory=asyncio.Event)
 
-    async def build_attribute(
+    async def build_attribute(  # noqa: PLR0913
         self,
         build_key: object,
         job: NixEvalJobSuccess,
         log_writer: LogWriter,
         cwd: Path,
         cancel_event: asyncio.Event | None = None,
+        on_start: Callable[[], Awaitable[bool]] | None = None,
     ) -> BuildOutcome:
+        if on_start is not None and not await on_start():
+            return BuildOutcome.cancelled
         self.built.append(job.attr)
         self.started.set()
         if self.gate is not None:


### PR DESCRIPTION

mark_attribute_building ran before the executor granted a slot, so the
UI duration included queue wait and could exceed build_timeout (which
only starts once nix runs), e.g. 1h 3m shown on a 1h timeout.

Stamp via an on_start callback fired after slot acquisition: the
attribute stays pending while queued and the shown duration matches
what the timeout measures.
