### PR TITLE
show builds waiting for an eval slot as pending

### DIFF
--- a/nixbot/nixbot/bootstrap.py
+++ b/nixbot/nixbot/bootstrap.py
@@ -285,7 +285,7 @@ async def build_service(config: Config) -> tuple[CIService, FastAPI]:
         config=config,
         pool=pool,
         repos=RepoManager(config.state_dir),
-        eval_runner=EvalRunner(config.eval_concurrency, limiter=CgroupLimiter.create()),
+        eval_runner=EvalRunner(limiter=CgroupLimiter.create()),
         executor=executor,
         failed_build_cache=lambda project_id: PostgresFailedBuildCache(
             pool, project_id

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -32,7 +32,7 @@ from .flake_prefetch import PrefetchError, prefetch_flake_inputs
 from .live_warnings import LiveWarningAggregator
 from .memory import calculate_eval_workers
 from .models import CacheStatus, NixEvalJobSuccess
-from .nix_eval import EvalError, EvalSettings
+from .nix_eval import EvalError, EvalResult, EvalSettings
 from .post_build import build_props, run_post_build_steps
 from .repo_config import BranchConfig
 
@@ -298,27 +298,17 @@ async def _reap(*tasks: asyncio.Future[Any]) -> None:
             await task
 
 
-async def _run_build_inner(
+async def _evaluate(  # noqa: PLR0913
     o: Orchestrator,
     event: ChangeEvent,
     build: BuildRecord,
     worktree_path: Path,
     credentials: FetchCredentials | None,
-) -> None:
-    await o.reporter.build_started(event, build)
-    await db.set_build_status(o.pool, build.id, BuildStatus.EVALUATING)
-
-    if await _try_reuse_eval(o, event, build, worktree_path, credentials):
-        return
-
-    branch_config = BranchConfig.load(worktree_path)
-    await _prefetch_inputs(o, build, worktree_path, branch_config, credentials)
-    eval_settings = _eval_settings(o, event, build, credentials)
-    # Race the evaluation against the cancel event: a superseded
-    # build must not hold the eval slot to completion.
-    cancel_event = o.cancel_events.setdefault(build.id, asyncio.Event())
-
-    jobs_queue: asyncio.Queue[list[NixEvalJob] | None] = asyncio.Queue()
+    jobs_queue: asyncio.Queue[list[NixEvalJob] | None],
+    live_warnings: LiveWarningAggregator,
+) -> EvalResult:
+    """Wait for an eval slot, then prefetch and evaluate, streaming
+    jobs into jobs_queue and warnings into live_warnings."""
 
     async def record_job_batch(jobs: list[NixEvalJob]) -> None:
         # Pending rows appear in the UI while the eval is running.
@@ -334,10 +324,8 @@ async def _run_build_inner(
         )
         await jobs_queue.put(jobs)
 
-    # Deduplicated warnings appear on the build page while the eval
-    # runs; DB writes are throttled since retry storms emit one
-    # line per narinfo.
-    live_warnings = LiveWarningAggregator()
+    # DB writes are throttled since retry storms emit one line per
+    # narinfo.
     last_flush = 0.0
 
     async def record_stderr_line(line: str) -> None:
@@ -351,13 +339,41 @@ async def _run_build_inner(
                 o.pool, id_=build.id, warnings=json.dumps(live_warnings.snapshot())
             )
 
-    eval_task = asyncio.ensure_future(
-        o.eval_runner.run(
+    branch_config = BranchConfig.load(worktree_path)
+    async with o.eval_slots:
+        await db.set_build_status(o.pool, build.id, BuildStatus.EVALUATING)
+        await _prefetch_inputs(o, build, worktree_path, branch_config, credentials)
+        return await o.eval_runner.run(
             worktree_path,
             branch_config,
-            eval_settings,
+            _eval_settings(o, event, build, credentials),
             on_jobs=record_job_batch,
             on_stderr_line=record_stderr_line,
+        )
+
+
+async def _run_build_inner(
+    o: Orchestrator,
+    event: ChangeEvent,
+    build: BuildRecord,
+    worktree_path: Path,
+    credentials: FetchCredentials | None,
+) -> None:
+    await o.reporter.build_started(event, build)
+    # Reruns enter with a terminal row. Stay pending until a slot is held.
+    await db.set_build_status(o.pool, build.id, BuildStatus.PENDING)
+
+    if await _try_reuse_eval(o, event, build, worktree_path, credentials):
+        return
+
+    jobs_queue: asyncio.Queue[list[NixEvalJob] | None] = asyncio.Queue()
+    live_warnings = LiveWarningAggregator()
+    # Race slot wait and evaluation against the cancel event. A
+    # superseded build must not hold or wait for the slot to completion.
+    cancel_event = o.cancel_events.setdefault(build.id, asyncio.Event())
+    eval_task = asyncio.ensure_future(
+        _evaluate(
+            o, event, build, worktree_path, credentials, jobs_queue, live_warnings
         )
     )
     # Builds start as soon as the first eval batch arrives.

--- a/nixbot/nixbot/db_gen/builds.py
+++ b/nixbot/nixbot/db_gen/builds.py
@@ -262,21 +262,22 @@ WITH failed_effects AS (
 )
 UPDATE builds
 SET status = $1,
-    error = COALESCE($2, error),
-    -- A fresh eval must not show the previous attempt's streamed
-    -- warnings.
-    eval_warnings = CASE
-        WHEN $1 = 'evaluating' THEN NULL
-        ELSE eval_warnings
+    -- Every run starts at pending. Drop the previous attempt's
+    -- error, warnings, job set and duration.
+    error = CASE
+        WHEN $1 = 'pending' THEN NULL
+        ELSE COALESCE($2, error)
     END,
-    -- A fresh eval invalidates the recorded job set until it
-    -- completes again.
+    eval_warnings = CASE
+        WHEN $1 = 'pending' THEN NULL ELSE eval_warnings
+    END,
     eval_completed = CASE
-        WHEN $1 = 'evaluating' THEN FALSE
-        ELSE eval_completed
+        WHEN $1 = 'pending' THEN FALSE ELSE eval_completed
     END,
     started_at = CASE
-        WHEN started_at IS NULL AND $1 <> 'pending' THEN now()
+        WHEN $1 = 'pending' THEN NULL
+        WHEN started_at IS NULL
+            AND $1 IN ('evaluating', 'building') THEN now()
         ELSE started_at
     END,
     -- Invariant: non-terminal states never carry finished_at, else

--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -29,7 +29,6 @@ __all__: collections.abc.Sequence[str] = (
     "project_has_builds",
     "reset_build_for_restart",
     "reset_effects_state",
-    "reset_eval_for_reeval",
     "running_build_ids",
     "succeeded_attribute_outputs",
     "supersede_pending_changes",
@@ -257,10 +256,6 @@ WHERE build_id = $1
   AND ($2::text[] IS NULL OR name = ANY($2::text[]))
 """
 
-RESET_EVAL_FOR_REEVAL: typing.Final[str] = """-- name: ResetEvalForReeval :exec
-UPDATE builds SET eval_completed = FALSE WHERE id = $1
-"""
-
 RUNNING_BUILD_IDS: typing.Final[str] = """-- name: RunningBuildIds :many
 SELECT id FROM builds WHERE status IN ('pending', 'evaluating', 'building')
 """
@@ -424,10 +419,6 @@ async def reset_build_for_restart(conn: ConnectionLike, *, attr: str | None, bui
 
 async def reset_effects_state(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str] | None) -> None:
     await conn.execute(RESET_EFFECTS_STATE, build_id, names)
-
-
-async def reset_eval_for_reeval(conn: ConnectionLike, *, build_id: int) -> None:
-    await conn.execute(RESET_EVAL_FOR_REEVAL, build_id)
 
 
 def running_build_ids(conn: ConnectionLike) -> QueryResults[int]:

--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -531,31 +531,16 @@ def _kill_process_tree(proc: asyncio.subprocess.Process) -> None:
 
 
 class EvalRunner:
-    """Runs nix-eval-jobs with a global concurrency cap."""
+    """Runs nix-eval-jobs. Concurrency is capped by the caller
+    (Orchestrator.eval_slots)."""
 
-    def __init__(
-        self, concurrency: int = 1, limiter: CgroupLimiter | None = None
-    ) -> None:
-        self._semaphore = asyncio.Semaphore(concurrency)
+    def __init__(self, limiter: CgroupLimiter | None = None) -> None:
         self.limiter = limiter
         # Probed on first use. System users without a session can't
         # create transient scopes.
         self._systemd_scope_ok: bool | None = None
 
     async def run(
-        self,
-        worktree_path: Path,
-        branch_config: BranchConfig,
-        settings: EvalSettings,
-        on_jobs: JobBatchCallback | None = None,
-        on_stderr_line: StderrLineCallback | None = None,
-    ) -> EvalResult:
-        async with self._semaphore:
-            return await self._run(
-                worktree_path, branch_config, settings, on_jobs, on_stderr_line
-            )
-
-    async def _run(
         self,
         worktree_path: Path,
         branch_config: BranchConfig,

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -144,6 +144,11 @@ class Orchestrator:
     task_tokens: TaskTokens = field(default_factory=TaskTokens)
     # Second contexts attached to an in-flight build, for status fan-out.
     linked_events: dict[int, list[ChangeEvent]] = field(default_factory=dict)
+    # Caps concurrent evaluations to bound memory use.
+    eval_slots: asyncio.Semaphore = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.eval_slots = asyncio.Semaphore(self.config.eval_concurrency)
 
     def _log_dir(self, build_id: int) -> Path:
         return build_log_dir(self.config.state_dir, build_id)

--- a/nixbot/nixbot/queries/builds.sql
+++ b/nixbot/nixbot/queries/builds.sql
@@ -86,21 +86,22 @@ WITH failed_effects AS (
 )
 UPDATE builds
 SET status = sqlc.arg(status),
-    error = COALESCE(sqlc.narg(error), error),
-    -- A fresh eval must not show the previous attempt's streamed
-    -- warnings.
-    eval_warnings = CASE
-        WHEN sqlc.arg(status) = 'evaluating' THEN NULL
-        ELSE eval_warnings
+    -- Every run starts at pending. Drop the previous attempt's
+    -- error, warnings, job set and duration.
+    error = CASE
+        WHEN sqlc.arg(status) = 'pending' THEN NULL
+        ELSE COALESCE(sqlc.narg(error), error)
     END,
-    -- A fresh eval invalidates the recorded job set until it
-    -- completes again.
+    eval_warnings = CASE
+        WHEN sqlc.arg(status) = 'pending' THEN NULL ELSE eval_warnings
+    END,
     eval_completed = CASE
-        WHEN sqlc.arg(status) = 'evaluating' THEN FALSE
-        ELSE eval_completed
+        WHEN sqlc.arg(status) = 'pending' THEN FALSE ELSE eval_completed
     END,
     started_at = CASE
-        WHEN started_at IS NULL AND sqlc.arg(status) <> 'pending' THEN now()
+        WHEN sqlc.arg(status) = 'pending' THEN NULL
+        WHEN started_at IS NULL
+            AND sqlc.arg(status) IN ('evaluating', 'building') THEN now()
         ELSE started_at
     END,
     -- Invariant: non-terminal states never carry finished_at, else

--- a/nixbot/nixbot/queries/maintenance.sql
+++ b/nixbot/nixbot/queries/maintenance.sql
@@ -66,10 +66,6 @@ AND name = ANY(sqlc.arg(names)::text[]);
 SELECT count(*) AS count FROM build_attributes
 WHERE build_id = $1 AND status IN ('pending', 'building');
 
--- name: ResetEvalForReeval :exec
--- Flag only: an interrupted re-eval must not lose rows.
-UPDATE builds SET eval_completed = FALSE WHERE id = sqlc.arg(build_id);
-
 -- name: CommitEvalResult :exec
 -- The only place the attribute set shrinks. Refreshes non-terminal
 -- rows, prunes rows the eval no longer produced, publishes via

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -147,7 +147,8 @@ WHERE b.project_id = $1 AND a.attr = $2;
 -- name: WebQueue :many
 -- queue_position numbers the GLOBAL queue of pending builds: computed
 -- before any visibility filter so every viewer sees the same
--- position, and NULL for already-running builds.
+-- position, and NULL for already-running builds. Ordered by id, so a
+-- restarted old build sorts first although it queued last.
 SELECT b.*, p.owner, p.name AS project_name, p.forge, p.url,
        q.queue_position
 FROM builds b

--- a/nixbot/nixbot/restart_dispatch.py
+++ b/nixbot/nixbot/restart_dispatch.py
@@ -133,9 +133,6 @@ async def _reeval(
             event,
             worktree_path,
         ):
-            # Flag only. Rows are rewritten when the re-eval commits,
-            # so an interrupted re-eval loses nothing.
-            await q.reset_eval_for_reeval(s.pool, build_id=build.id)
             await s.orchestrator.run_build(event, build, worktree_path)
     finally:
         s.orchestrator.cancel_events.pop(build.id, None)

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -476,7 +476,7 @@ class ForgeStatusReporter:
             build,
             f"{self.context_prefix}/nix-eval",
             StatusState.pending,
-            "evaluating flake",
+            "waiting for evaluation",
         )
 
     async def eval_finished(

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -56,6 +56,8 @@ async def postgres_dsn(postgres_dsn: str) -> str:
         await insert_build(
             pool, project_id, number=2, status="building", branch="pr", started=True
         )
+        await insert_build(pool, project_id, number=3, status="evaluating", branch="q")
+        await insert_build(pool, project_id, number=4, status="pending", branch="q")
         await pool.execute(
             """
             INSERT INTO build_attributes (build_id, attr, system, status, error, drv_path)
@@ -152,6 +154,11 @@ def test_build_list_and_view(
     assert "build #1" in out
     assert "1 failed" in out
     assert "bad1" in out
+
+    for argv in (("view", "4"), ("list", "--status", "pending")):
+        assert run_cli(api, "build", *argv, "-R", "acme/widget") == 0
+        out = capsys.readouterr().out
+        assert "pending · queued for eval (pos 1) behind acme/widget#3" in out
 
 
 def test_build_restart_cancel(

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -128,9 +128,11 @@ class FakeExecutor:
 @dataclass
 class RecordingReporter:
     events: list[tuple] = field(default_factory=list)
+    started: asyncio.Event = field(default_factory=asyncio.Event)
 
     async def build_started(self, event: ChangeEvent, build: BuildRecord) -> None:
         self.events.append(("started", build.id))
+        self.started.set()
 
     async def eval_finished(
         self, event: ChangeEvent, build: BuildRecord, report: EvalReport
@@ -728,6 +730,56 @@ async def test_cancel_interrupts_evaluation(
     assert executor.built == []
     # The pending nix-eval status must resolve (merge queues).
     assert ("eval-cancelled", build.id) in reporter.events
+
+
+async def test_build_waiting_for_eval_slot_stays_pending(
+    pool: asyncpg.Pool, tmp_path: Path, upstream: Path
+) -> None:
+    """A build waiting on eval_concurrency is pending, not evaluating (#151)."""
+    sha = add_commit(upstream, "slot")
+    block = asyncio.Event()
+    eval_runner = FakeEvalRunner([mk_job("a")], block=block)
+    orchestrator, reporter = make_orchestrator(
+        pool, tmp_path, eval_runner, FakeExecutor()
+    )
+    projects = [
+        replace(await make_project(pool, name=n), clone_url=str(upstream))
+        for n in ("first", "second")
+    ]
+
+    async def rows() -> list[asyncpg.Record]:
+        return await pool.fetch(
+            "SELECT id, status, started_at FROM builds"
+            " WHERE project_id = ANY($1) ORDER BY id",
+            [p.id for p in projects],
+        )
+
+    def start(p: RepoInfo) -> asyncio.Task[BuildRecord | None]:
+        return asyncio.create_task(
+            orchestrator.handle_change_event(
+                ChangeEvent(repo=p, branch="main", commit_sha=sha)
+            )
+        )
+
+    tasks = [start(projects[0])]
+    await asyncio.wait_for(eval_runner.started.wait(), timeout=10)
+    reporter.started.clear()
+    tasks.append(start(projects[1]))
+    await asyncio.wait_for(reporter.started.wait(), timeout=10)
+    await asyncio.sleep(0.05)
+    r1, r2 = await rows()
+    assert eval_runner.calls == 1
+    assert r1["status"] == BuildStatus.EVALUATING
+    assert (r2["status"], r2["started_at"]) == (BuildStatus.PENDING, None)
+
+    orchestrator.cancel_events[r2["id"]].set()
+    await asyncio.wait_for(tasks[1], timeout=10)
+    _, r2 = await rows()
+    assert (r2["status"], r2["started_at"]) == (BuildStatus.CANCELLED, None)
+
+    block.set()
+    await asyncio.wait_for(tasks[0], timeout=10)
+    assert eval_runner.calls == 1
 
 
 async def test_pending_attribute_rows_recorded_for_crash_recovery(

--- a/nixbot/nixbot/tests/test_recovery.py
+++ b/nixbot/nixbot/tests/test_recovery.py
@@ -267,7 +267,7 @@ async def test_failed_rebuild_settles_pending_effects(pool: asyncpg.Pool) -> Non
     assert "did not succeed" in row["error"]
 
 
-async def test_eval_start_clears_stale_eval_warnings(pool: asyncpg.Pool) -> None:
+async def test_rerun_clears_stale_eval_warnings(pool: asyncpg.Pool) -> None:
     """A re-run build must not show the previous attempt's warnings."""
 
     build_id = await make_build(pool, "lw-rerun")
@@ -280,7 +280,7 @@ async def test_eval_start_clears_stale_eval_warnings(pool: asyncpg.Pool) -> None
     assert await pool.fetchval(
         "SELECT eval_warnings FROM builds WHERE id = $1", build_id
     )
-    await db.set_build_status(pool, build_id, "evaluating")
+    await db.set_build_status(pool, build_id, "pending")
     assert (
         await pool.fetchval("SELECT eval_warnings FROM builds WHERE id = $1", build_id)
         is None

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -326,6 +326,31 @@ def test_overview_pass_rate_ignores_pr_branches(client: WebHarness) -> None:
         )
 
 
+def test_pending_build_shows_eval_blocker(client: WebHarness) -> None:
+    pool = client.ctx.queries.pool
+
+    async def setup() -> int:
+        project_id = await insert_project(pool, name="slotq", forge_repo_id="slotq")
+        await insert_build(pool, project_id, number=1, status="evaluating")
+        await insert_build(pool, project_id, number=2, status="pending")
+        return project_id
+
+    project_id = client.run(setup())
+    try:
+        pending = client.get("/repos/github/acme/slotq/builds/2").text
+        assert "waiting for eval slot" in pending
+        assert 'href="/repos/github/acme/slotq/builds/1"' in pending
+        evaluating = client.get("/repos/github/acme/slotq/builds/1").text
+        assert "waiting for eval slot" not in evaluating
+        api = client.get("/api/repos/github/acme/slotq/builds/2").json()["build"]
+        assert api["eval_queue"]["position"] >= 1
+        assert [b["number"] for b in api["eval_queue"]["blocked_by"]] == [1]
+        api = client.get("/api/repos/github/acme/slotq/builds/1").json()["build"]
+        assert api["eval_queue"] is None
+    finally:
+        client.run(pool.execute("DELETE FROM projects WHERE id = $1", project_id))
+
+
 def test_project_filter_escapes_like_wildcards(client: WebHarness) -> None:
     # `%` and `_` must match literally, not as ILIKE wildcards.
     assert "acme/widget" in client.get("/?q=widg").text

--- a/nixbot/nixbot/web/api_routes.py
+++ b/nixbot/nixbot/web/api_routes.py
@@ -50,6 +50,20 @@ class EvalWarningGroup(BaseModel):
     count: int
 
 
+class BuildRef(BaseModel):
+    owner: str
+    project_name: str
+    forge: str
+    number: int
+
+
+class EvalQueue(BaseModel):
+    """Why a pending build is not evaluating yet."""
+
+    position: int | None
+    blocked_by: list[BuildRef]  # builds holding an eval slot
+
+
 class Build(BaseModel):
     """One CI run of a commit."""
 
@@ -67,6 +81,7 @@ class Build(BaseModel):
     created_at: datetime
     started_at: datetime | None
     finished_at: datetime | None
+    eval_queue: EvalQueue | None = None  # only while pending
 
 
 class BuildPage(BaseModel):
@@ -172,10 +187,12 @@ def clean_row(row: dict[str, Any]) -> dict[str, Any]:
 async def _build_or_404(  # noqa: PLR0913
     ctx: WebContext, request: Request, forge: str, owner: str, name: str, number: int
 ) -> dict[str, Any]:
+    """Build row with eval_queue attached."""
     project = await ctx.repo_or_404(forge, owner, name, request)
     build = await ctx.queries.build_by_number(project["id"], number)
     if build is None:
         raise HTTPException(status_code=404)
+    await ctx.queries.attach_eval_queue([build], await ctx.visible_repo_ids(request))
     return build
 
 
@@ -220,6 +237,9 @@ def create_api_router(ctx: WebContext) -> APIRouter:
             filters=BuildFilters(
                 status=status, branch=branch, pr_number=pr_number, commit=commit
             ),
+        )
+        await ctx.queries.attach_eval_queue(
+            builds.items, await ctx.visible_repo_ids(request)
         )
         return {
             "items": [clean_row(b) for b in builds.items],

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -450,6 +450,9 @@ class _PageRoutes:
         )
         group_counts, inline = await self._grouped_attributes(build["id"], None)
         total = sum(group_counts.values())
+        await ctx.queries.attach_eval_queue(
+            [build], await ctx.visible_repo_ids(request)
+        )
         return await ctx.render(
             "build.html",
             request=request,

--- a/nixbot/nixbot/web/queries.py
+++ b/nixbot/nixbot/web/queries.py
@@ -218,3 +218,23 @@ class WebQueries:
         computed before any visibility filter so every viewer sees the
         same position, and NULL for already-running builds."""
         return _dicts(await gen.web_queue(self.pool, project_ids=project_ids))
+
+    async def attach_eval_queue(
+        self, builds: list[dict[str, Any]], project_ids: list[int] | None = None
+    ) -> None:
+        """Set build["eval_queue"]. Pending builds get their queue
+        position and the builds holding eval slots (visibility
+        filtered). Other builds get None."""
+        for b in builds:
+            b["eval_queue"] = None
+        pending = [b for b in builds if b["status"] == "pending"]
+        if not pending:
+            return
+        queue = await self.queue(project_ids)
+        positions = {q["id"]: q["queue_position"] for q in queue}
+        blocked_by = [q for q in queue if q["status"] == "evaluating"]
+        for b in pending:
+            b["eval_queue"] = {
+                "position": positions.get(b["id"]),
+                "blocked_by": blocked_by,
+            }

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -72,6 +72,16 @@
         </div>
       </div>
       {% if build.error %}<pre class="error">{{ build.error | excerpt(2000) | ansi }}</pre>{% endif %}
+      {% if build.eval_queue %}
+        <p class="build-meta">
+          waiting for eval slot
+          {% if build.eval_queue.position %}· position {{ build.eval_queue.position }}{% endif %}
+          {% for b in build.eval_queue.blocked_by %}
+            {% if loop.first %}· currently evaluating:{% endif %}
+            <a href="{{ build_path(b, b.number) }}">{{ repo_name(b.owner, b.project_name) }} #{{ b.number }}</a>{{ "," if not loop.last }}
+          {% endfor %}
+        </p>
+      {% endif %}
       {% if build.status in RUNNING_STATUSES and attrs_total %}
         <div class="build-progress"
              role="progressbar"

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -25,6 +25,7 @@ from .term import (
     dim,
     green,
     link,
+    queue_note,
     sanitize_block,
     sanitize_line,
     status_str,
@@ -197,7 +198,7 @@ def cmd_build_list(client: NixbotClient, args: argparse.Namespace) -> int:
         {
             **b,
             "number": link(str(b["number"]), client.build_url(repo, b["number"])),
-            "status": status_str(b["status"]),
+            "status": status_str(b["status"]) + queue_note(b),
             "branch": cyan(b["branch"]),
             "commit": dim(b["commit_sha"][:12]),
             "created_at": dim(b["created_at"]),
@@ -225,7 +226,7 @@ def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
         f"{repo} {cyan(build['branch'])} "
         f"@ {dim(build['commit_sha'][:12])}"
     )
-    print(f"status: {status_str(build['status'])}")
+    print(f"status: {status_str(build['status'])}{queue_note(build)}")
     if build.get("error"):
         print(f"error: {build['error']}")
     counts: dict[str, int] = {}
@@ -284,6 +285,7 @@ def watch_build(client: NixbotClient, repo: RepoRef, number: int) -> int:
     cursor: tuple[str, int] | None = None
     finished = 0
     events: Iterator[dict] | None = None
+    last_note = None
     while True:
         delta = client.finished_attrs(
             repo,
@@ -300,6 +302,10 @@ def watch_build(client: NixbotClient, repo: RepoRef, number: int) -> int:
             finished += len(attrs)
         if build["status"] not in RUNNING_STATUSES:
             break
+        note = queue_note(build)
+        if note and note != last_note:
+            print(f"{build['status']}{note}", flush=True)
+            last_note = note
         if events is None:
             events = client.events(build=build["id"])
         # Any change hint or keepalive triggers a refetch. A closed
@@ -318,6 +324,19 @@ def watch_attrs(
     attribute, and on failure its log tail plus a log URL. Exit 1 when
     any of them failed."""
     detail = client.build(repo, number)
+    events: Iterator[dict] | None = None
+    last_note = None
+    # Attributes only exist once evaluation has started.
+    while detail["build"]["status"] == "pending":
+        note = queue_note(detail["build"])
+        if note != last_note:
+            print(f"pending{note}", flush=True)
+            last_note = note
+        if events is None:
+            events = client.events(build=detail["build"]["id"])
+        if next(events, None) is None:
+            events = None
+        detail = client.build(repo, number)
     watched = {
         a["attr"]: a for s in selectors for a in [_match_attr(detail["attributes"], s)]
     }
@@ -342,7 +361,6 @@ def watch_attrs(
             pending[name] = attr
         else:
             report(attr)
-    events: Iterator[dict] | None = None
     while pending:
         if events is None:
             events = client.events(build=detail["build"]["id"])

--- a/nixbot_cli/nixbot_cli/term.py
+++ b/nixbot_cli/nixbot_cli/term.py
@@ -81,6 +81,21 @@ def status_str(status: str, *, cached: bool = False) -> str:
     return _color(f"{glyph} {label}", "33")
 
 
+def queue_note(build: dict) -> str:
+    """' · queued for eval (pos N) behind owner/repo#N', or ''."""
+    q = build.get("eval_queue")
+    if not q:
+        return ""
+    behind = ", ".join(
+        f"{b['owner']}/{b['project_name']}#{b['number']}" for b in q["blocked_by"]
+    )
+    return (
+        " · queued for eval"
+        + (f" (pos {q['position']})" if q["position"] else "")
+        + (f" behind {behind}" if behind else "")
+    )
+
+
 def fmt_duration(seconds: float) -> str:
     if seconds < MINUTE:
         return f"{seconds:.0f}s"

--- a/nixbot_cli/nixbot_cli/watch_tty.py
+++ b/nixbot_cli/nixbot_cli/watch_tty.py
@@ -25,6 +25,7 @@ from .term import (
     FAILED_STATUSES,
     RUNNING_STATUSES,
     fmt_duration,
+    queue_note,
     sanitize_line,
     status_str,
 )
@@ -217,6 +218,7 @@ class TtyWatch:
         self.finished = 0
         self.failed = 0
         self.build_status = "pending"
+        self.queue_note = ""
         self.started_at = time.time()  # replaced by the build's start time
         self.spin = 0
 
@@ -270,6 +272,7 @@ class TtyWatch:
             build, attrs = delta["build"], delta["items"]
             with self.lock:
                 self.build_status = build["status"]
+                self.queue_note = queue_note(build)
             self._record_finished(attrs)
             if attrs:
                 cursor = (attrs[-1]["finished_at"], attrs[-1]["id"])
@@ -303,7 +306,7 @@ class TtyWatch:
         with self.lock:
             running = sorted(self.running.items(), key=lambda kv: kv[1])
             finished, failed = self.finished, self.failed
-            status = self.build_status
+            status = self.build_status + self.queue_note
             gist = dict(self.gist)
         elapsed = fmt_duration(time.time() - self.started_at)
         _, term_rows = self.display.size()


### PR DESCRIPTION

The build was marked 'evaluating' before acquiring the eval_concurrency
slot, so a blocked build looked like a running one everywhere. Let the
orchestrator own the semaphore and flip to 'evaluating' only once the
slot is held. Expose position and blocking builds as build.eval_queue
in the API, web build page and nbo list/view/watch.

Closes #151
