### PR TITLE
ship a patched nix CLI for flake prefetch-inputs

### DIFF
--- a/nix/flakelet.nix
+++ b/nix/flakelet.nix
@@ -99,7 +99,7 @@
           pkgs.coreutils
           pkgs.bubblewrap
           nix-eval-jobs
-          pkgs.nix
+          nix-eval-jobs.nix
         ];
 
         # Remote builders need a HOME for ~/.ssh.

--- a/nixosModules/nixbot.nix
+++ b/nixosModules/nixbot.nix
@@ -967,6 +967,9 @@ in
         pkgs.coreutils
         pkgs.bubblewrap
         packages.nix-eval-jobs
+        # Patched nix CLI (see packages/nix-eval-jobs.nix). Listed before
+        # the system nix so flake prefetch-inputs/archive use it.
+        packages.nix-eval-jobs.nix
         config.nix.package
       ];
 

--- a/packages/nix-eval-jobs.nix
+++ b/packages/nix-eval-jobs.nix
@@ -38,12 +38,21 @@ let
     hash = "sha256-Yvn9a059LvW9FkSGH20LRPlBIhmVqQxGMBXke+hxkgs=";
   };
 
+  # `nix flake prefetch-inputs` randomly skipped inputs, so the eval
+  # sandbox then lacked them (#153, NixOS/nix#16373).
+  prefetchInputsDedupPatch = pkgs.fetchpatch {
+    url = "https://github.com/Mic92/nix-1/commit/e9bc07a77ddb16de5d47738e6f4b9e0188d7ed7a.patch";
+    hash = "sha256-3QBE/cmolXVFcak1T49fC2vftb9CJyUsoJ4Z7WDqVJ4=";
+  };
+
   patchIfNeeded =
     components:
-    if pkgs.lib.versionOlder components.version "2.36" then
-      components.appendPatches [ srcToStoreCachePatch ]
-    else
-      components;
+    components.appendPatches (
+      pkgs.lib.optional (pkgs.lib.versionOlder components.version "2.36") srcToStoreCachePatch
+      ++ [ prefetchInputsDedupPatch ]
+    );
+
+  nixComponents = patchIfNeeded nixComponents_2_35;
 
   # polyfill for nixpkgs without nix 2.35 (e.g. stable release branches)
   nixComponents_2_35 =
@@ -64,11 +73,16 @@ let
 in
 (pkgs.nix-eval-jobs.override {
   # nix-eval-jobs 2.35.x requires Nix >= 2.35 (tryEnterPrivateMountNamespace)
-  nixComponents = patchIfNeeded nixComponents_2_35;
+  inherit nixComponents;
 }).overrideAttrs
   (
-    finalAttrs: _prevAttrs: {
+    finalAttrs: prevAttrs: {
       version = "2.35.2";
+      # The nix CLI nixbot runs (flake prefetch-inputs/archive) must carry
+      # the same patches, so expose it alongside nix-eval-jobs.
+      passthru = (prevAttrs.passthru or { }) // {
+        nix = nixComponents.nix-cli;
+      };
       src = fetchFromGitHub {
         owner = "NixOS";
         repo = "nix-eval-jobs";

--- a/packages/nixbot.nix
+++ b/packages/nixbot.nix
@@ -2,7 +2,6 @@
   buildPythonPackage,
   git,
   hatchling,
-  nix,
   nix-eval-jobs,
   pydantic,
   pytestCheckHook,
@@ -51,7 +50,7 @@ buildPythonPackage (finalAttrs: {
     nixbot-effects
   ];
 
-  buildInputs = [ nix ];
+  buildInputs = [ nix-eval-jobs.nix ];
 
   # Tests run in passthru.tests.pytest to keep the test closure
   # (playwright browsers, postgresql) out of the package build.
@@ -66,7 +65,7 @@ buildPythonPackage (finalAttrs: {
     git
     # For the eval/prefetch integration tests: nix works daemon-less
     # against a scratch store set up in preCheck.
-    nix
+    nix-eval-jobs.nix
     nix-eval-jobs
     pytestCheckHook
     pytest-asyncio

--- a/packages/process-compose.nix
+++ b/packages/process-compose.nix
@@ -4,7 +4,6 @@
   coreutils,
   git,
   lib,
-  nix,
   nix-eval-jobs,
   openssh,
   postgresql,
@@ -139,7 +138,7 @@ writeShellApplication {
     nix-eval-jobs
     git
     openssh
-    nix
+    nix-eval-jobs.nix
     coreutils
   ]
   # The service wraps effects in a bwrap sandbox on Linux.


### PR DESCRIPTION
`nix flake prefetch-inputs` randomly skipped lock nodes because it deduplicated them by the address of a `std::bind` copy. The command still exited 0, so nixbot went on to gc-root paths that were never fetched and failed the eval.

nixbot so far used whatever nix the host had in PATH, so there was no place to carry the fix. Expose the nix CLI built from the same patched components as nix-eval-jobs (`nix-eval-jobs.nix`) and put it before the system nix in the service PATH, the dev stack and the test inputs.

Upstream fix: https://github.com/NixOS/nix/pull/16373

Fixes #153