### PR TITLE
list gated-off effects as skipped, show effects run status

### DIFF
--- a/nixbot/nixbot/build_reuse.py
+++ b/nixbot/nixbot/build_reuse.py
@@ -18,7 +18,7 @@ from .canceller import RegisterOutcome
 from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
-from .db_gen import web as web_q
+from .effects_run import post_effects_summary
 from .events import BuildResult, EvalReport
 from .gitrepo import GitError, run_git
 
@@ -75,27 +75,16 @@ async def replay_effect_statuses(
 ) -> None:
     """Re-post each finished effect's status and the aggregate summary
     onto the reusing commit's SHA, so a failed deploy is not green."""
-    effects = [
-        e
-        for e in await web_q.web_effects(o.pool, build_id=build.id)
-        if e.status in ("succeeded", "failed")
-    ]
-    if not effects:
-        return
-    for effect in effects:
-        await o.reporter.effect_finished(
-            event,
-            build,
-            effect.name,
-            success=effect.status == "succeeded",
-            error=effect.error,
-        )
-    await o.reporter.effects_finished(
-        event,
-        build,
-        failed=sum(1 for e in effects if e.status != "succeeded"),
-        succeeded=sum(1 for e in effects if e.status == "succeeded"),
-    )
+    for effect in await builds_q.effects_for_build(o.pool, build_id=build.id):
+        if effect.status in ("succeeded", "failed", "dependency_failed"):
+            await o.reporter.effect_finished(
+                event,
+                build,
+                effect.name,
+                success=effect.status == "succeeded",
+                error=effect.error,
+            )
+    await post_effects_summary(o, event, build)
 
 
 async def finish_linked(

--- a/nixbot/nixbot/db_gen/builds.py
+++ b/nixbot/nixbot/db_gen/builds.py
@@ -31,6 +31,7 @@ __all__: collections.abc.Sequence[str] = (
     "mark_attribute_building",
     "mark_effects_started",
     "record_attributes",
+    "record_skipped_effects",
     "set_build_status",
     "set_eval_warnings",
     "settle_unfinished_attributes",
@@ -250,6 +251,13 @@ ON CONFLICT (build_id, attr) DO UPDATE SET
     drv_path = EXCLUDED.drv_path,
     outputs = EXCLUDED.outputs
 WHERE build_attributes.status IN ('pending', 'building')
+"""
+
+RECORD_SKIPPED_EFFECTS: typing.Final[str] = """-- name: RecordSkippedEffects :exec
+INSERT INTO build_effects (build_id, name, status, finished_at)
+SELECT $1::bigint, u.name, 'skipped', now()
+FROM unnest($2::text[]) AS u(name)
+ON CONFLICT (build_id, name) DO NOTHING
 """
 
 SET_BUILD_STATUS: typing.Final[str] = """-- name: SetBuildStatus :exec
@@ -488,6 +496,10 @@ async def mark_effects_started(conn: ConnectionLike, *, commit_sha: str, branch:
 
 async def record_attributes(conn: ConnectionLike, *, build_id: int, attrs: collections.abc.Sequence[str], systems: collections.abc.Sequence[str], drv_paths: collections.abc.Sequence[str], outputs: collections.abc.Sequence[str]) -> None:
     await conn.execute(RECORD_ATTRIBUTES, build_id, attrs, systems, drv_paths, outputs)
+
+
+async def record_skipped_effects(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str]) -> None:
+    await conn.execute(RECORD_SKIPPED_EFFECTS, build_id, names)
 
 
 async def set_build_status(conn: ConnectionLike, *, status: str, error: str | None, terminal: collections.abc.Sequence[str], id_: int) -> None:

--- a/nixbot/nixbot/db_gen/builds.py
+++ b/nixbot/nixbot/db_gen/builds.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 __all__: collections.abc.Sequence[str] = (
     "AttributeStatusesRow",
     "EffectDepStatusesRow",
+    "EffectsSummaryRow",
     "EvalJobRowsRow",
     "LockBuildRowRow",
     "QueryResults",
@@ -21,6 +22,7 @@ __all__: collections.abc.Sequence[str] = (
     "detach_build_from_pr",
     "effect_dep_statuses",
     "effects_for_build",
+    "effects_summary",
     "eval_job_rows",
     "find_completed_eval",
     "find_reusable_build",
@@ -65,6 +67,13 @@ class AttributeStatusesRow:
 @dataclasses.dataclass()
 class EffectDepStatusesRow:
     name: str
+    status: str
+
+
+@dataclasses.dataclass()
+class EffectsSummaryRow:
+    failed: int
+    succeeded: int
     status: str
 
 
@@ -181,6 +190,23 @@ WHERE e.build_id = $1 AND e.name = $2
 
 EFFECTS_FOR_BUILD: typing.Final[str] = """-- name: EffectsForBuild :many
 SELECT id, build_id, name, status, error, log_size, log_truncated, started_at, finished_at, deps FROM build_effects WHERE build_id = $1 ORDER BY name
+"""
+
+EFFECTS_SUMMARY: typing.Final[str] = """-- name: EffectsSummary :one
+SELECT
+    count(*) FILTER (WHERE status IN ('failed', 'dependency_failed'))::bigint AS failed,
+    count(*) FILTER (WHERE status = 'succeeded')::bigint AS succeeded,
+    CASE
+        WHEN bool_or(status = 'running')
+          OR (bool_or(status = 'pending') AND NOT bool_and(status = 'pending'))
+          THEN 'running'
+        WHEN bool_or(status IN ('failed', 'dependency_failed')) THEN 'failed'
+        WHEN bool_or(status = 'pending') THEN 'pending'
+        WHEN bool_or(status = 'succeeded') THEN 'succeeded'
+        ELSE 'skipped'
+    END::text AS status
+FROM build_effects WHERE build_id = $1
+HAVING count(*) > 0
 """
 
 EVAL_JOB_ROWS: typing.Final[str] = """-- name: EvalJobRows :many
@@ -436,6 +462,13 @@ def effects_for_build(conn: ConnectionLike, *, build_id: int) -> QueryResults[mo
     def _decode_hook(row: asyncpg.Record) -> models.BuildEffect:
         return models.BuildEffect(id=row[0], build_id=row[1], name=row[2], status=row[3], error=row[4], log_size=row[5], log_truncated=row[6], started_at=row[7], finished_at=row[8], deps=row[9])
     return QueryResults[models.BuildEffect](conn, EFFECTS_FOR_BUILD, _decode_hook, build_id)
+
+
+async def effects_summary(conn: ConnectionLike, *, build_id: int) -> EffectsSummaryRow | None:
+    row = await conn.fetchrow(EFFECTS_SUMMARY, build_id)
+    if row is None:
+        return None
+    return EffectsSummaryRow(failed=row[0], succeeded=row[1], status=row[2])
 
 
 def eval_job_rows(conn: ConnectionLike, *, build_id: int) -> QueryResults[EvalJobRowsRow]:

--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -20,7 +20,6 @@ __all__: collections.abc.Sequence[str] = (
     "commit_eval_result",
     "count_unfinished_attributes",
     "delete_attributes_by_name",
-    "delete_effects_by_name",
     "drop_removed_effects",
     "effect_status",
     "fail_interrupted_effects",
@@ -177,11 +176,6 @@ WHERE build_id = $1 AND status IN ('pending', 'building')
 DELETE_ATTRIBUTES_BY_NAME: typing.Final[str] = """-- name: DeleteAttributesByName :exec
 DELETE FROM build_attributes WHERE build_id = $1
 AND attr = ANY($2::text[])
-"""
-
-DELETE_EFFECTS_BY_NAME: typing.Final[str] = """-- name: DeleteEffectsByName :exec
-DELETE FROM build_effects WHERE build_id = $1
-AND name = ANY($2::text[])
 """
 
 DROP_REMOVED_EFFECTS: typing.Final[str] = """-- name: DropRemovedEffects :exec
@@ -373,10 +367,6 @@ async def count_unfinished_attributes(conn: ConnectionLike, *, build_id: int) ->
 
 async def delete_attributes_by_name(conn: ConnectionLike, *, build_id: int, attrs: collections.abc.Sequence[str]) -> None:
     await conn.execute(DELETE_ATTRIBUTES_BY_NAME, build_id, attrs)
-
-
-async def delete_effects_by_name(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str]) -> None:
-    await conn.execute(DELETE_EFFECTS_BY_NAME, build_id, names)
 
 
 async def drop_removed_effects(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str]) -> None:

--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -308,7 +308,10 @@ ORDER BY number DESC LIMIT $8 OFFSET $7
 """
 
 WEB_EFFECTS: typing.Final[str] = """-- name: WebEffects :many
-SELECT id, build_id, name, status, error, log_size, log_truncated, started_at, finished_at, deps FROM build_effects WHERE build_id = $1 ORDER BY name
+SELECT id, build_id, name, status, error, log_size, log_truncated, started_at, finished_at, deps FROM build_effects WHERE build_id = $1
+ORDER BY array_position(
+    ARRAY['failed', 'dependency_failed', 'running', 'pending', 'succeeded', 'skipped'],
+    status), name
 """
 
 WEB_NEIGHBOR_NUMBERS: typing.Final[str] = """-- name: WebNeighborNumbers :one

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -20,7 +20,6 @@ from nixbot_effects import EffectError
 
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
-from .db_gen import web as web_q
 from .db_gen import work_queue as wq
 from .effects import (
     EffectMeta,
@@ -330,14 +329,11 @@ async def post_effects_summary(
 ) -> None:
     """Post the aggregate status once all effects settle. The items run
     independently, so the last to finish reports it."""
-    statuses = [e.status for e in await web_q.web_effects(o.pool, build_id=build.id)]
-    if any(s in ("pending", "running") for s in statuses):
+    summary = await builds_q.effects_summary(o.pool, build_id=build.id)
+    if summary is None or summary.status in ("pending", "running"):
         return
     await o.reporter.effects_finished(
-        event,
-        build,
-        failed=sum(1 for s in statuses if s in ("failed", "dependency_failed")),
-        succeeded=sum(1 for s in statuses if s == "succeeded"),
+        event, build, failed=summary.failed, succeeded=summary.succeeded
     )
 
 

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -1,4 +1,4 @@
-"""Effects execution: gated discovery after a successful build,
+"""Effects execution: discovery after a successful build, gating,
 per-effect queue items, and running one queued effect with its own
 row and log.
 
@@ -62,50 +62,22 @@ class RunningEffect:
         self.task.cancel()
 
 
-async def maybe_run_effects(
+async def maybe_run_effects(  # noqa: PLR0913
     o: Orchestrator,
     event: ChangeEvent,
     build: BuildRecord,
     worktree_path: Path,
     credentials: FetchCredentials | None = None,
+    *,
+    only: list[str] | None = None,
 ) -> None:
-    effects = await discover_effects(o, event, build, worktree_path, credentials)
-    if effects is None:
-        return
-    # Effects removed from the flake since the last run would
-    # otherwise linger as stale pending rows.
-    await q.drop_removed_effects(o.pool, build_id=build.id, names=list(effects))
-    await enqueue_effects(o, event, build, effects)
-
-
-async def discover_effects(
-    o: Orchestrator,
-    event: ChangeEvent,
-    build: BuildRecord,
-    worktree_path: Path,
-    credentials: FetchCredentials | None = None,
-) -> dict[str, EffectMeta] | None:
-    """Gating, the started-flag, and effect discovery. Returns None
-    when effects must not or cannot run."""
-    repo = event.repo
-    # Gating config comes from the default branch of the central
-    # clone: the worktree is PR-controlled, so its nixbot.toml
-    # could grant the PR effects (and deploy secrets).
-    default_branch_config = await o.default_branch_repo_config(
-        repo, credentials=credentials
-    )
-    if not should_run_effects(
-        default_branch_config,
-        repo.default_branch,
-        event.branch,
-        is_pull_request=event.pr_number is not None,
-    ):
-        return None
+    """`only` narrows a rerun to the named effects."""
+    allowed = await _effects_allowed(o, event, credentials)
     # The started-flag guards against auto-re-running effects on crash
     # recovery (deploys are not idempotent). Record the triggering ref:
     # effect items carry only build_id and must report on this commit,
     # not the build's stored commit_sha (a reused PR head).
-    if (
+    if allowed and (
         await builds_q.mark_effects_started(
             o.pool,
             id_=build.id,
@@ -115,29 +87,67 @@ async def discover_effects(
         )
         is None
     ):
-        return None
-    task_token = o.task_tokens.issue(build.project_id)
+        return
+    effects = await discover_effects(o, event, build, worktree_path)
+    if effects is None:
+        return
+    # Also drops rows a rerun selected that the flake no longer has.
+    await q.drop_removed_effects(o.pool, build_id=build.id, names=list(effects))
+    if only is not None:
+        effects = {n: m for n, m in effects.items() if n in only}
+    if allowed:
+        await enqueue_effects(o, event, build, effects)
+    elif effects:
+        # Gated refs (PRs) still list what a merge would run.
+        await builds_q.record_skipped_effects(
+            o.pool, build_id=build.id, names=list(effects)
+        )
+
+
+async def _effects_allowed(
+    o: Orchestrator, event: ChangeEvent, credentials: FetchCredentials | None
+) -> bool:
+    repo = event.repo
+    # Gating config comes from the default branch of the central
+    # clone: the worktree is PR-controlled, so its nixbot.toml
+    # could grant the PR effects (and deploy secrets).
+    default_branch_config = await o.default_branch_repo_config(
+        repo, credentials=credentials
+    )
+    return should_run_effects(
+        default_branch_config,
+        repo.default_branch,
+        event.branch,
+        is_pull_request=event.pr_number is not None,
+    )
+
+
+async def discover_effects(
+    o: Orchestrator,
+    event: ChangeEvent,
+    build: BuildRecord,
+    worktree_path: Path,
+) -> dict[str, EffectMeta] | None:
+    """The flake's effects, or None when discovery failed. A pure eval of
+    a tree the build already evaluated, so it needs no tokens."""
     ctx = effects_context(
         o.config,
-        repo,
+        event.repo,
         worktree_path=worktree_path,
         rev=event.commit_sha,
         branch=event.branch,
-        git_token=credentials.token if credentials is not None else None,
-        task_token=task_token,
+        git_token=None,
+        task_token=None,
     )
     try:
         # A bad effect DAG (cycle, unknown dependency) fails discovery
         # here and its reason ends up in the log.
-        effects = await list_effects(ctx)
+        return await list_effects(ctx)
     except (EffectError, OSError):
         # OSError: nix/git missing from PATH. Effects are best-effort
         # and must not fail the (already reported) build.
         logger.exception("effects discovery failed", extra={"build_id": build.id})
         return None
-    finally:
-        o.task_tokens.revoke(task_token)
-    return effects
 
 
 def _dedup_key(build: BuildRecord, name: str, meta: EffectMeta) -> str:
@@ -178,16 +188,18 @@ async def enqueue_effects(
 async def _skip_effect(
     o: Orchestrator, event: ChangeEvent, build: BuildRecord, name: str, failed_dep: str
 ) -> None:
-    """Terminal 'skipped' row: the effect never ran because a dependency
-    did not succeed. Counts as failed on the forge (a deploy that never
-    ran must not look green)."""
-    error = f"skipped: dependency '{failed_dep}' did not succeed"
-    await builds_q.start_effect(o.pool, build_id=build.id, name=name, status="skipped")
+    """Terminal row for an effect whose dependency did not succeed.
+    Counts as failed on the forge (a deploy that never ran must not
+    look green)."""
+    error = f"dependency '{failed_dep}' did not succeed"
+    await builds_q.start_effect(
+        o.pool, build_id=build.id, name=name, status="dependency_failed"
+    )
     await builds_q.finish_effect(
         o.pool,
         build_id=build.id,
         name=name,
-        status="skipped",
+        status="dependency_failed",
         error=error,
         log_size=0,
         log_truncated=False,
@@ -324,7 +336,7 @@ async def post_effects_summary(
     await o.reporter.effects_finished(
         event,
         build,
-        failed=sum(1 for s in statuses if s != "succeeded"),
+        failed=sum(1 for s in statuses if s in ("failed", "dependency_failed")),
         succeeded=sum(1 for s in statuses if s == "succeeded"),
     )
 

--- a/nixbot/nixbot/migrations/0025_effect_skipped_rename.sql
+++ b/nixbot/nixbot/migrations/0025_effect_skipped_rename.sql
@@ -1,0 +1,4 @@
+-- 'skipped' now means gated off on this ref (e.g. pull requests).
+-- Effects that did not run because a dependency failed get the same
+-- name attributes use.
+UPDATE build_effects SET status = 'dependency_failed' WHERE status = 'skipped';

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -423,9 +423,11 @@ class Orchestrator:
         build: BuildRecord,
         worktree_path: Path,
         credentials: FetchCredentials | None = None,
+        *,
+        only: list[str] | None = None,
     ) -> None:
         await effects_run.maybe_run_effects(
-            self, event, build, worktree_path, credentials
+            self, event, build, worktree_path, credentials, only=only
         )
 
     async def run_effect_item(

--- a/nixbot/nixbot/queries/builds.sql
+++ b/nixbot/nixbot/queries/builds.sql
@@ -197,6 +197,13 @@ ON CONFLICT (build_id, name) DO UPDATE SET
     log_truncated = FALSE, started_at = now(), finished_at = NULL,
     deps = EXCLUDED.deps;
 
+-- name: RecordSkippedEffects :exec
+-- DO NOTHING: rows from a real run (build reused by a gated ref) stay.
+INSERT INTO build_effects (build_id, name, status, finished_at)
+SELECT sqlc.arg(build_id)::bigint, u.name, 'skipped', now()
+FROM unnest(sqlc.arg(names)::text[]) AS u(name)
+ON CONFLICT (build_id, name) DO NOTHING;
+
 -- name: EffectDepStatuses :many
 -- Statuses of the effects this effect declared in `after`.
 SELECT d.name, d.status FROM build_effects e

--- a/nixbot/nixbot/queries/builds.sql
+++ b/nixbot/nixbot/queries/builds.sql
@@ -217,6 +217,24 @@ UPDATE build_effects SET
     log_size = $4, log_truncated = $5, finished_at = now()
 WHERE build_id = $1 AND name = $2;
 
+-- name: EffectsSummary :one
+-- status: running while anything is in flight, else the worst outcome.
+-- No row for a build without effects.
+SELECT
+    count(*) FILTER (WHERE status IN ('failed', 'dependency_failed'))::bigint AS failed,
+    count(*) FILTER (WHERE status = 'succeeded')::bigint AS succeeded,
+    CASE
+        WHEN bool_or(status = 'running')
+          OR (bool_or(status = 'pending') AND NOT bool_and(status = 'pending'))
+          THEN 'running'
+        WHEN bool_or(status IN ('failed', 'dependency_failed')) THEN 'failed'
+        WHEN bool_or(status = 'pending') THEN 'pending'
+        WHEN bool_or(status = 'succeeded') THEN 'succeeded'
+        ELSE 'skipped'
+    END::text AS status
+FROM build_effects WHERE build_id = $1
+HAVING count(*) > 0;
+
 -- name: EffectsForBuild :many
 SELECT * FROM build_effects WHERE build_id = $1 ORDER BY name;
 

--- a/nixbot/nixbot/queries/maintenance.sql
+++ b/nixbot/nixbot/queries/maintenance.sql
@@ -56,12 +56,6 @@ UPDATE build_effects SET status = 'pending', error = NULL,
 WHERE build_id = sqlc.arg(build_id)
   AND (sqlc.narg(names)::text[] IS NULL OR name = ANY(sqlc.narg(names)::text[]));
 
--- name: DeleteEffectsByName :exec
--- Removes rows of effects that a rerun selected but discovery no
--- longer found in the flake. They would stay pending forever.
-DELETE FROM build_effects WHERE build_id = $1
-AND name = ANY(sqlc.arg(names)::text[]);
-
 -- name: CountUnfinishedAttributes :one
 SELECT count(*) AS count FROM build_attributes
 WHERE build_id = $1 AND status IN ('pending', 'building');

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -117,7 +117,11 @@ WHERE a.build_id = $1 AND a.finished_at IS NOT NULL
 ORDER BY a.finished_at, a.id;
 
 -- name: WebEffects :many
-SELECT * FROM build_effects WHERE build_id = $1 ORDER BY name;
+-- Worst first.
+SELECT * FROM build_effects WHERE build_id = $1
+ORDER BY array_position(
+    ARRAY['failed', 'dependency_failed', 'running', 'pending', 'succeeded', 'skipped'],
+    status), name;
 
 -- name: WebAttributeCounts :many
 SELECT status, count(*) AS count FROM build_attributes

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -13,7 +13,7 @@ import logging
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
-from . import build_run, db, effects_run
+from . import build_run, db
 from .canceller import branch_key
 from .db import BuildStatus
 from .db_gen import builds as builds_q
@@ -141,8 +141,8 @@ async def rerun_pending_attributes(
 async def _rerun_names(
     o: Orchestrator, build: BuildRecord, only: str
 ) -> list[str] | None:
-    """The effect plus its transitively skipped dependents. A skipped
-    row must not stay skipped after a green rerun. Returns None when
+    """The effect plus its transitive dependency_failed dependents. They
+    must not stay failed after a green rerun. Returns None when
     `only` is not a row of this build."""
     rows = await builds_q.effects_for_build(o.pool, build_id=build.id)
     if all(r.name != only for r in rows):
@@ -153,7 +153,7 @@ async def _rerun_names(
         changed = False
         for r in rows:
             deps = set(json.loads(r.deps)) if r.deps else set()
-            if r.status == "skipped" and r.name not in names and deps & names:
+            if r.status == "dependency_failed" and r.name not in names and deps & names:
                 names.add(r.name)
                 changed = True
     return sorted(names)
@@ -183,7 +183,7 @@ async def rerun_effects(
 ) -> None:
     """Effects-only restart: fresh worktree at the recorded commit,
     attributes untouched. `only` narrows the rerun to one effect and
-    its skipped dependents."""
+    its dependency_failed dependents."""
     if build.id in o.cancel_events:
         # A concurrent rerun (or double click) would deploy twice.
         return
@@ -209,25 +209,9 @@ async def rerun_effects(
             event,
             worktree_path,
         ):
-            if names is None:
-                await o.maybe_run_effects(event, build, worktree_path, credentials)
-            else:
-                effects = await effects_run.discover_effects(
-                    o, event, build, worktree_path, credentials
-                )
-                if effects is not None:
-                    # Selected effects that discovery no longer found
-                    # would stay pending forever.
-                    if missing := sorted(set(names) - effects.keys()):
-                        await q.delete_effects_by_name(
-                            o.pool, build_id=build.id, names=missing
-                        )
-                    await effects_run.enqueue_effects(
-                        o,
-                        event,
-                        build,
-                        {n: m for n, m in effects.items() if n in names},
-                    )
+            await o.maybe_run_effects(
+                event, build, worktree_path, credentials, only=names
+            )
             await o.refresh_schedules(event)
         # The enqueued effect items share this build's key and only
         # become claimable once this item finishes.

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -70,7 +70,7 @@ async def postgres_dsn(postgres_dsn: str) -> str:
         )
         await pool.execute(
             "INSERT INTO build_effects (build_id, name, status) "
-            "VALUES ($1, 'deploy', 'failed'), ($1, 'notify', 'skipped')",
+            "VALUES ($1, 'deploy', 'failed'), ($1, 'notify', 'dependency_failed')",
             failed,
         )
     return postgres_dsn

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -336,6 +336,13 @@ def run_effect_build(
     return run
 
 
+async def effect_statuses(pool: asyncpg.Pool, build_id: int) -> dict[str, str]:
+    rows = await pool.fetch(
+        "SELECT name, status FROM build_effects WHERE build_id = $1", build_id
+    )
+    return {r["name"]: r["status"] for r in rows}
+
+
 async def drain_effect_items(
     orchestrator: Orchestrator, info: RepoInfo, pool: asyncpg.Pool
 ) -> None:
@@ -1162,7 +1169,7 @@ async def test_pr_worktree_config_cannot_grant_effects(
     base = git(upstream, "rev-parse", "HEAD")
 
     ran = patch_effects(monkeypatch)
-    orchestrator, _, project = await make_env(
+    orchestrator, reporter, project = await make_env(
         FakeEvalRunner([mk_job("a")]),
         FakeExecutor(),
         name="pr-grant",
@@ -1182,6 +1189,9 @@ async def test_pr_worktree_config_cannot_grant_effects(
     assert not await pool.fetchval(
         "SELECT effects_started FROM builds WHERE id = $1", build.id
     )
+    # Listed for visibility (Mic92/nixbot#106), never queued or reported.
+    assert await effect_statuses(pool, build.id) == {"deploy": "skipped"}
+    assert not [e for e in reporter.events if e[0].startswith("effect")]
 
 
 async def test_rerun_effects_runs_effects_again(
@@ -1308,7 +1318,7 @@ async def test_rerun_single_effect(
     }
     assert statuses == {
         "deploy": "failed",
-        "notify": "skipped",
+        "notify": "dependency_failed",
         "other": "succeeded",
     }
     other_finished = await pool.fetchval(
@@ -1671,7 +1681,7 @@ async def test_effect_item_not_claimable_until_dep_settles(
         "SELECT status FROM build_effects WHERE build_id = $1 AND name = 'deploy'",
         build.id,
     )
-    assert row["status"] == "skipped"
+    assert row["status"] == "dependency_failed"
 
 
 async def test_effect_dep_failure_skips_dependent(
@@ -1680,8 +1690,8 @@ async def test_effect_dep_failure_skips_dependent(
     upstream: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An effect whose dependency failed is marked skipped and never
-    runs; skipped counts as a failure in the summary."""
+    """An effect whose dependency failed is marked dependency_failed and
+    never runs. It counts as a failure in the summary."""
 
     async def failing_run(ctx: object, name: str, log_write: object = None) -> bool:
         return False
@@ -1705,7 +1715,7 @@ async def test_effect_dep_failure_skips_dependent(
         )
     }
     assert rows["build-image"][0] == "failed"
-    assert rows["deploy"][0] == "skipped"
+    assert rows["deploy"][0] == "dependency_failed"
     assert "build-image" in rows["deploy"][1]
 
 
@@ -1991,6 +2001,7 @@ async def test_reuse_for_default_branch_push_runs_effects(
     assert pr_build is not None
     await drain_effect_items(orchestrator, project, pool)
     assert ran == []
+    assert await effect_statuses(pool, pr_build.id) == {"deploy": "skipped"}
 
     # Squash-merge: an identical tree under a new SHA reuses the build.
     git(upstream, "commit", "--allow-empty", "-m", "reuse-deploy-merge")
@@ -2004,6 +2015,7 @@ async def test_reuse_for_default_branch_push_runs_effects(
     assert main_build.id == pr_build.id
     await drain_effect_items(orchestrator, project, pool)
     assert ran == ["deploy"]
+    assert await effect_statuses(pool, pr_build.id) == {"deploy": "succeeded"}
     # Effects ran for the main merge, so their statuses belong on the
     # main commit -- not the build's stored PR-head commit (pr_sha).
     sha_events = ("effect-started", "effects-started", "effects-finished")

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -1603,10 +1603,17 @@ def test_build_page_shows_effects(client: WebHarness) -> None:
             """,
             build_id,
         )
+        pr_build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 3")
+        await ctx.pool.execute(
+            "INSERT INTO build_effects (build_id, name, status, finished_at) "
+            "VALUES ($1, 'deploy', 'skipped', now())",
+            pr_build_id,
+        )
 
     client.loop.run_until_complete(seed_effects())
     text = client.get("/repos/github/acme/widget/builds/2").text
     assert "Effects" in text
+    assert 'id="effects-status" class="status running"' in text
     assert "deploy" in text
     assert "ssh: connection refused" in text
     # Both finished-with-log and running effects link to the viewer.
@@ -1614,6 +1621,10 @@ def test_build_page_shows_effects(client: WebHarness) -> None:
     assert "logs/effect:notify" in text
     # Builds without effects don't render the section.
     assert "Effects" not in client.get("/repos/github/acme/widget/builds/1").text
+    pr_text = client.get("/repos/github/acme/widget/builds/3").text
+    assert 'id="effects-status" class="status skipped"' in pr_text
+    assert "not run for pull requests" in pr_text
+    assert "effects/restart" not in pr_text
 
 
 def test_effect_log_raw_text(client: WebHarness, tmp_path: Path) -> None:

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -82,24 +82,6 @@ ATTR_GROUPS: dict[str, tuple[str, ...]] = {
     "ignored": ("ignored_failure",),
 }
 INLINE_GROUPS = ("failed", "building")
-# Worst first: the display order and the precedence of the overall status.
-EFFECT_STATUS_ORDER = (
-    "failed",
-    "dependency_failed",
-    "running",
-    "pending",
-    "succeeded",
-    "skipped",
-)
-
-
-def effects_status(effects: list[dict[str, Any]]) -> str | None:
-    """Running while anything is in flight, else the worst status."""
-    statuses = {e["status"] for e in effects}
-    if "running" in statuses or ("pending" in statuses and len(statuses) > 1):
-        return "running"
-    worst = next((s for s in EFFECT_STATUS_ORDER if s in statuses), None)
-    return "failed" if worst == "dependency_failed" else worst
 
 
 class WebContext:
@@ -468,10 +450,6 @@ class _PageRoutes:
         )
         group_counts, inline = await self._grouped_attributes(build["id"], None)
         total = sum(group_counts.values())
-        effects = sorted(
-            await ctx.queries.effects(build["id"]),
-            key=lambda e: EFFECT_STATUS_ORDER.index(e["status"]),
-        )
         await ctx.queries.attach_eval_queue(
             [build], await ctx.visible_repo_ids(request)
         )
@@ -484,8 +462,8 @@ class _PageRoutes:
             attrs_done=total - group_counts["pending"] - group_counts["building"],
             group_counts=group_counts,
             inline=inline,
-            effects=effects,
-            effects_status=effects_status(effects),
+            effects=await ctx.queries.effects(build["id"]),
+            effects_status=await ctx.queries.effects_status(build["id"]),
             prev_number=prev_number,
             next_number=next_number,
             can_control=await ctx.can_control(request, build),

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -82,6 +82,24 @@ ATTR_GROUPS: dict[str, tuple[str, ...]] = {
     "ignored": ("ignored_failure",),
 }
 INLINE_GROUPS = ("failed", "building")
+# Worst first: the display order and the precedence of the overall status.
+EFFECT_STATUS_ORDER = (
+    "failed",
+    "dependency_failed",
+    "running",
+    "pending",
+    "succeeded",
+    "skipped",
+)
+
+
+def effects_status(effects: list[dict[str, Any]]) -> str | None:
+    """Running while anything is in flight, else the worst status."""
+    statuses = {e["status"] for e in effects}
+    if "running" in statuses or ("pending" in statuses and len(statuses) > 1):
+        return "running"
+    worst = next((s for s in EFFECT_STATUS_ORDER if s in statuses), None)
+    return "failed" if worst == "dependency_failed" else worst
 
 
 class WebContext:
@@ -450,6 +468,10 @@ class _PageRoutes:
         )
         group_counts, inline = await self._grouped_attributes(build["id"], None)
         total = sum(group_counts.values())
+        effects = sorted(
+            await ctx.queries.effects(build["id"]),
+            key=lambda e: EFFECT_STATUS_ORDER.index(e["status"]),
+        )
         await ctx.queries.attach_eval_queue(
             [build], await ctx.visible_repo_ids(request)
         )
@@ -462,7 +484,8 @@ class _PageRoutes:
             attrs_done=total - group_counts["pending"] - group_counts["building"],
             group_counts=group_counts,
             inline=inline,
-            effects=await ctx.queries.effects(build["id"]),
+            effects=effects,
+            effects_status=effects_status(effects),
             prev_number=prev_number,
             next_number=next_number,
             can_control=await ctx.can_control(request, build),

--- a/nixbot/nixbot/web/queries.py
+++ b/nixbot/nixbot/web/queries.py
@@ -8,6 +8,7 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from ..db_gen import builds as builds_gen  # noqa: TID252
 from ..db_gen import web as gen  # noqa: TID252
 
 if TYPE_CHECKING:
@@ -163,6 +164,10 @@ class WebQueries:
 
     async def effects(self, build_id: int) -> list[dict[str, Any]]:
         return _dicts(await gen.web_effects(self.pool, build_id=build_id))
+
+    async def effects_status(self, build_id: int) -> str | None:
+        row = await builds_gen.effects_summary(self.pool, build_id=build_id)
+        return row.status if row else None
 
     async def attribute_counts(
         self, build_id: int, q: str | None = None

--- a/nixbot/nixbot/web/static/style.css
+++ b/nixbot/nixbot/web/static/style.css
@@ -124,7 +124,6 @@ th {
 .failed,
 .failed_eval,
 .dependency_failed,
-.skipped,
 .cached_failure {
 	--status-color: var(--bad);
 }
@@ -133,13 +132,15 @@ th {
 	--status-color: var(--queued);
 }
 .evaluating,
-.building {
+.building,
+.running {
 	--status-color: var(--run);
 }
 .pending {
 	--status-color: var(--queued);
 }
 .cancelled,
+.skipped,
 .skipped_local {
 	--status-color: var(--muted);
 }
@@ -286,7 +287,6 @@ h2 .status-icon {
 .status-icon.failed::before,
 .status-icon.failed_eval::before,
 .status-icon.dependency_failed::before,
-.status-icon.skipped::before,
 .status-icon.cached_failure::before,
 .status-icon.ignored::before,
 .status-icon.ignored_failure::before,
@@ -305,11 +305,13 @@ h2 .status-icon {
 }
 @media (prefers-reduced-motion: reduce) {
 	.status-icon.building,
-	.status-icon.evaluating {
+	.status-icon.evaluating,
+	.status-icon.running {
 		animation: none;
 	}
 }
 .status-icon.cancelled,
+.status-icon.skipped,
 .status-icon.skipped_local {
 	border-style: dashed;
 	opacity: 0.6;
@@ -641,6 +643,10 @@ h2.section {
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
 	margin: 1.5rem 0 0.5rem;
+}
+h2.section .status {
+	text-transform: none;
+	letter-spacing: normal;
 }
 .section-row {
 	display: flex;

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -140,8 +140,8 @@
             {{ status_icon(effects_status, labelled=false) }}Effects
             <span id="effects-status" class="status {{ effects_status }}">
               {{- "not run for pull requests" if effects_status == "skipped" and build.pr_number
-              else "not run on this branch" if effects_status == "skipped"
-              else effects_status -}}
+                else "not run on this branch" if effects_status == "skipped"
+                else effects_status -}}
             </span>
           </h2>
           {% if can_control and build.status == "succeeded" and effects_status != "skipped" %}

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -136,8 +136,15 @@
       <div id="attributes">{% include "_attributes.html" %}</div>
       {% if effects %}
         <div class="section-row">
-          <h2 class="section">Effects</h2>
-          {% if can_control and build.status == "succeeded" %}
+          <h2 class="section">
+            {{ status_icon(effects_status, labelled=false) }}Effects
+            <span id="effects-status" class="status {{ effects_status }}">
+              {{- "not run for pull requests" if effects_status == "skipped" and build.pr_number
+              else "not run on this branch" if effects_status == "skipped"
+              else effects_status -}}
+            </span>
+          </h2>
+          {% if can_control and build.status == "succeeded" and effects_status != "skipped" %}
             <form method="post"
                   action="{{ build_path(project, build.number) }}/effects/restart">
               <button>restart effects</button>
@@ -164,9 +171,9 @@
                   <code>{{ e.name }}</code>
                 {% endif %}
               </td>
-              <td class="attr-duration">{{ e | duration }}</td>
+              <td class="attr-duration">{{ e | duration if e.status != "skipped" }}</td>
               <td class="attr-restart">
-                {% if can_control and build.status == "succeeded" and e.status not in ("pending", "running") %}
+                {% if can_control and build.status == "succeeded" and e.status not in ("pending", "running", "skipped") %}
                   <form method="post"
                         action="{{ build_path(project, build.number) }}/effects/restart?name={{ e.name | urlencode }}">
                     <button class="icon-button"


### PR DESCRIPTION
PR builds had no Effects section, so authors could not see which
effects a merge would run. Discovery now always runs. Gated refs get
`skipped` rows without queue items or `effects_started`, so a
default-branch reuse still runs them. The dependency-failed effect
status is renamed to `dependency_failed` (as attributes call it) to
free `skipped` for this.

`rerun_effects`' single-effect path duplicated the gate, claim, discover
and enqueue pipeline. It is now `maybe_run_effects(only=...)`.

The Effects section gets an overall status like the build header and
rows sorted worst-first. Counts, overall status and ordering come from
one `EffectsSummary` query and `WebEffects` instead of Python, which
also makes the build-reuse replay re-post `dependency_failed` effects
it dropped before.

Fixes #106