### PR TITLE
web: keep the live log viewer responsive on chatty builds

### DIFF
--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -593,7 +593,7 @@ class StructuredCapture:
 
     def log_line(self, act_id: int, text: str) -> None:
         drv = self._act.get(act_id, self.SETUP)
-        if strip_ansi(text).startswith(_PHASE_ECHO):
+        if _PHASE_ECHO in text and strip_ansi(text).startswith(_PHASE_ECHO):
             # RES_SET_PHASE already records this. Drop stdenv's echo.
             return
         self._w.line(drv, text, ts=self._ts())

--- a/nixbot/nixbot/tests/e2e/test_live.py
+++ b/nixbot/nixbot/tests/e2e/test_live.py
@@ -114,7 +114,8 @@ def test_log_page_keeps_up_with_a_line_burst(page: Page, server: TestServer) -> 
     cap = StructuredCapture()
     writer.capture = cap
     server.registry.register(build_id, ATTR, writer)
-    lines = 5000
+    lines = 8000
+    max_live_rows = 5000  # structured-logs.js MAX_LIVE_ROWS
     # Unbatched: one forced layout per line. Batched: one per frame.
     max_layouts = lines // 20
     cdp = page.context.new_cdp_session(page)
@@ -144,7 +145,9 @@ def test_log_page_keeps_up_with_a_line_burst(page: Page, server: TestServer) -> 
         server.run(burst())
         page.locator(".logline", has_text="burst done").wait_for(timeout=60_000)
         assert layout_count() - before < max_layouts
-        assert page.locator(".log-card .logline").count() == lines + 1
+        rows = page.locator(".log-card .log-lines > *")
+        assert rows.count() == max_live_rows
+        assert "burst done" in rows.last.inner_text()
     finally:
         cdp.detach()
         cap.close()

--- a/nixbot/nixbot/tests/e2e/test_live.py
+++ b/nixbot/nixbot/tests/e2e/test_live.py
@@ -6,6 +6,7 @@ browser. The httpx web tests can only assert the markers exist.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import TYPE_CHECKING
 
@@ -103,4 +104,48 @@ def test_log_page_streams_live_output(page: Page, server: TestServer) -> None:
         card = page.locator(".log-card", has_text="hello-2.12")
         assert "hello from the build" in card.inner_text()
     finally:
+        server.registry.unregister(build_id, ATTR)
+
+
+def test_log_page_keeps_up_with_a_line_burst(page: Page, server: TestServer) -> None:
+    """Mic92/nixbot#98: thousands of lines must not cost a layout each."""
+    build_id = server.run(_build_id(server, 3))
+    writer = LogWriter(path=server.state_dir / "live" / f"{ATTR}-burst.zst")
+    cap = StructuredCapture()
+    writer.capture = cap
+    server.registry.register(build_id, ATTR, writer)
+    lines = 5000
+    # Unbatched: one forced layout per line. Batched: one per frame.
+    max_layouts = lines // 20
+    cdp = page.context.new_cdp_session(page)
+    cdp.send("Performance.enable")
+
+    def layout_count() -> int:
+        metrics = cdp.send("Performance.getMetrics")["metrics"]
+        return next(int(m["value"]) for m in metrics if m["name"] == "LayoutCount")
+
+    async def burst() -> None:
+        cap.start_build(1, "/nix/store/aaa-linux-6.6.drv")
+        for i in range(lines):
+            cap.log_line(1, f"  CC      drivers/gpu/drm/obj_{i}.o")
+            if i % 200 == 0:
+                await asyncio.sleep(0)
+        cap.log_line(1, "burst done")
+
+    try:
+        page.goto(f"/repos/github/acme/widget/builds/3/logs/{ATTR}")
+        deadline = time.monotonic() + 15
+        while not cap._subs:  # noqa: SLF001
+            if time.monotonic() > deadline:
+                msg = "browser never connected to the SSE stream"
+                raise TimeoutError(msg)
+            time.sleep(0.1)
+        before = layout_count()
+        server.run(burst())
+        page.locator(".logline", has_text="burst done").wait_for(timeout=60_000)
+        assert layout_count() - before < max_layouts
+        assert page.locator(".log-card .logline").count() == lines + 1
+    finally:
+        cdp.detach()
+        cap.close()
         server.registry.unregister(build_id, ATTR)

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -1254,9 +1254,10 @@ def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
     # Rows are rendered server-side (ANSI applied), not shipped as raw text.
     assert "d1-L1" in stream
     assert '"text"' not in stream
-    assert "event: delta" in stream
-    assert '"t":"phase"' in stream  # live delta after subscribe
-    assert '"t":"line"' in stream  # rendered delta
+    # The phase divider and the line queued behind it coalesce into one
+    # rendered delta.
+    assert stream.count("event: delta") == 1
+    assert "phase-sep" in stream
     assert "ansi-red" in stream
     assert "event: done" in stream
 

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -1177,6 +1177,69 @@ async def _stream_events(
             writer.unsubscribe(queue)
 
 
+async def _drain(queue: asyncio.Queue[dict | None]) -> list[dict | None]:
+    """Everything already queued (at least one item). One SSE event per
+    burst instead of one per line keeps chatty builds cheap on both ends."""
+    batch = [await asyncio.wait_for(queue.get(), timeout=30)]
+    while batch[-1] is not None and not queue.empty():
+        batch.append(queue.get_nowait())
+    return batch
+
+
+def _coalesce_lines(deltas: Iterable[dict]) -> list[dict]:
+    """Merge runs of rendered line deltas of one derivation."""
+    out: list[dict] = []
+    for delta in deltas:
+        prev = out[-1] if out else None
+        if prev and delta["t"] == "line" == prev["t"] and prev["idx"] == delta["idx"]:
+            prev["html"] += delta["html"]
+        else:
+            out.append(delta)
+    return out
+
+
+class _LiveRenderer:
+    """Renders card shells (drv_card macro) and rows for the live stream,
+    carrying each derivation's trailing SGR style into the next batch."""
+
+    def __init__(self, drv_card: Callable[..., str], base: str) -> None:
+        self._drv_card = drv_card
+        self._base = base
+        self._styles: dict[int, _Style] = {}
+
+    def card(self, d: dict) -> str:
+        # live=True: rows arrive over the SSE, so no htmx fetch attrs and
+        # no raw link (the container behind it does not exist yet).
+        live = d["status"] in ("running", "failed")
+        return str(self._drv_card(d, self._base, open=live, live=True))
+
+    def state(self, state: list[dict]) -> list[dict]:
+        for e in state:
+            e["html"], self._styles[e["idx"]] = render_rows(
+                e["idx"], 1, e.pop("lines"), phases=_phase_at(e["ph"])
+            )
+            e["card"] = self.card(e)
+        return state
+
+    def delta(self, delta: dict) -> dict:
+        if delta["t"] == "drv":
+            delta["card"] = self.card(
+                {**delta, "status": "running", "n": 0, "ph": [], "t0": None}
+            )
+        elif delta["t"] == "line":
+            idx = delta["idx"]
+            delta["html"], self._styles[idx] = render_rows(
+                idx, delta["from"], [delta.pop("text")], self._styles.get(idx, _RESET)
+            )
+        elif delta["t"] == "phase":
+            delta = {
+                "t": "line",
+                "idx": delta["idx"],
+                "html": phase_sep(delta["phase"]),
+            }
+        return delta
+
+
 async def _structured_events(
     capture: StructuredCapture | None,
     drv_card: Callable[..., str],
@@ -1184,54 +1247,28 @@ async def _structured_events(
 ) -> AsyncGenerator[str, None]:
     """Live per-derivation stream: a full-state burst on connect, then
     JSON deltas until the build finishes. A finished/absent capture just
-    signals done so the client reloads into the container page.
-
-    Card shells (via the drv_card macro) and log rows are rendered here;
-    the client only inserts HTML. Each drv carries its trailing SGR style
-    so a later line delta continues the same color."""
-
-    def card(d: dict) -> str:
-        # live=True: rows arrive over the SSE, so no htmx fetch attrs and
-        # no raw link (the container behind it does not exist yet).
-        return str(
-            drv_card(d, base, open=d["status"] in ("running", "failed"), live=True)
-        )
-
+    signals done so the client reloads into the container page."""
     if capture is None:
         yield "event: done\ndata: \n\n"
         return
+    render = _LiveRenderer(drv_card, base)
     queue = capture.subscribe()
-    state = capture.state()  # atomic with subscribe: no await between
-    styles: dict[int, _Style] = {}
-    for e in state:
-        html_rows, styles[e["idx"]] = render_rows(
-            e["idx"], 1, e.pop("lines"), phases=_phase_at(e["ph"])
-        )
-        e["html"] = html_rows
-        e["card"] = card(e)
+    state = render.state(capture.state())  # atomic with subscribe: no await
     yield f"event: state\ndata: {json.dumps(state, separators=(',', ':'))}\n\n"
     try:
         while True:
             try:
-                delta = await asyncio.wait_for(queue.get(), timeout=30)
+                batch = await _drain(queue)
             except TimeoutError:
                 yield ": keepalive\n\n"
                 continue
-            if delta is None:
+            for delta in _coalesce_lines(
+                render.delta(d) for d in batch if d is not None
+            ):
+                yield f"event: delta\ndata: {json.dumps(delta, separators=(',', ':'))}\n\n"
+            if batch[-1] is None:
                 yield "event: done\ndata: \n\n"
                 return
-            if delta["t"] == "drv":
-                delta["card"] = card(
-                    {**delta, "status": "running", "n": 0, "ph": [], "t0": None}
-                )
-            elif delta["t"] == "line":
-                idx = delta["idx"]
-                delta["html"], styles[idx] = render_rows(
-                    idx, delta["from"], [delta.pop("text")], styles.get(idx, _RESET)
-                )
-            elif delta["t"] == "phase":
-                delta["html"] = phase_sep(delta["phase"])
-            yield f"event: delta\ndata: {json.dumps(delta, separators=(',', ':'))}\n\n"
     finally:
         capture.unsubscribe(queue)
 

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import functools
 import html
 import json
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -131,25 +132,33 @@ def _apply_osc(payload: str, style: _Style) -> _Style:
     return style._replace(href=uri or None)
 
 
+@functools.lru_cache(maxsize=256)
+def _wrap(style: _Style) -> tuple[str, str]:
+    pre = post = ""
+    classes = " ".join(c for c in (style.fg, "ansi-bold" if style.bold else None) if c)
+    if classes:
+        pre, post = f'<span class="{classes}">', "</span>"
+    if style.href:
+        pre = f'<a href="{html.escape(style.href, quote=True)}" rel="nofollow">{pre}'
+        post += "</a>"
+    return pre, post
+
+
 def _render_segment(segment: str, style: _Style) -> str:
     if not segment:
         return ""
     # Stripping C0 before tokenizing would eat OSC's BEL terminator.
     out = html.escape(CTRL_RE.sub("", segment))
-    classes = " ".join(c for c in (style.fg, "ansi-bold" if style.bold else None) if c)
-    if classes:
-        out = f'<span class="{classes}">{out}</span>'
-    if style.href:
-        out = (
-            f'<a href="{html.escape(style.href, quote=True)}" rel="nofollow">{out}</a>'
-        )
-    return out
+    pre, post = _wrap(style)
+    return f"{pre}{out}{post}"
 
 
 def _ansi_convert(text: str, style: _Style) -> tuple[str, _Style]:
     """Convert SGR colors to spans and OSC 8 to links. Strip every
     other sequence. `style` carries in from the previous chunk/line;
     the style left open at the end is returned for the next one."""
+    if "\x1b" not in text:
+        return _render_segment(text, style), style
     out: list[str] = []
     pos = 0
     for match in ANSI_TOKEN_RE.finditer(text):

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -7,7 +7,7 @@
 "use strict";
 
 /**
- * @typedef {{idx:number,name:string,status:string,n:number,t0?:number|null,t1?:number|null,html?:string,card?:string}} Drv
+ * @typedef {{idx:number,name:string,status:string,html?:string,card?:string}} Drv
  * @typedef {{t:string,idx:number,name?:string,status?:string,from?:number,html?:string,card?:string}} Delta
  */
 
@@ -197,19 +197,38 @@
       return el;
     }
 
-    /** Append server-rendered rows (ANSI already applied).
-     * @param {number} idx @param {number} n @param {string} html */
-    function addLines(idx, n, html) {
-      const d = byIdx.get(idx);
-      if (!d || !html) return;
-      const el = ensureCard(d);
-      const vp = pick(el, ".log-lines");
-      // Follow the tail only when already at the bottom, so scrolling up
-      // to read pauses following and scrolling back resumes it.
-      const atBottom = vp.scrollHeight - vp.scrollTop - vp.clientHeight < 40;
-      vp.insertAdjacentHTML("beforeend", html);
-      d.n = n;
-      if (el.open && atBottom) vp.scrollTop = vp.scrollHeight;
+    // Flushed once per frame: a per-line insert + scrollHeight read is a
+    // forced layout per line (Mic92/nixbot#98).
+    /** @type {Map<number, string[]>} */
+    const pendingRows = new Map();
+    let flushScheduled = false;
+
+    function flush() {
+      flushScheduled = false;
+      for (const [idx, chunks] of pendingRows) {
+        const d = byIdx.get(idx);
+        if (!d) continue;
+        const el = ensureCard(d);
+        const vp = pick(el, ".log-lines");
+        // Follow the tail only when already at the bottom, so scrolling up
+        // to read pauses following and scrolling back resumes it.
+        const atBottom = vp.scrollHeight - vp.scrollTop - vp.clientHeight < 40;
+        vp.insertAdjacentHTML("beforeend", chunks.join(""));
+        if (el.open && atBottom) vp.scrollTop = vp.scrollHeight;
+      }
+      pendingRows.clear();
+    }
+
+    /** @param {number} idx @param {string} html */
+    function addRows(idx, html) {
+      if (!html || !byIdx.has(idx)) return;
+      const chunks = pendingRows.get(idx);
+      if (chunks) chunks.push(html);
+      else pendingRows.set(idx, [html]);
+      if (!flushScheduled) {
+        flushScheduled = true;
+        requestAnimationFrame(flush);
+      }
     }
 
     /** @param {Delta} delta */
@@ -220,20 +239,14 @@
           idx: delta.idx,
           name: delta.name ?? "",
           status: "running",
-          n: 0,
           card: delta.card,
         };
         byIdx.set(nd.idx, nd);
         setMeta(nd);
-      } else if (delta.t === "line") {
-        addLines(delta.idx, delta.from ?? 1, delta.html ?? "");
-      } else if (delta.t === "phase" && d) {
-        // The divider is a normal row appended before the phase's output.
-        pick(ensureCard(d), ".log-lines").insertAdjacentHTML(
-          "beforeend",
-          delta.html ?? "",
-        );
+      } else if (delta.t === "line" || delta.t === "phase") {
+        addRows(delta.idx, delta.html ?? "");
       } else if (delta.t === "status" && d) {
+        flush();
         d.status = delta.status ?? d.status;
         const el = setMeta(d);
         if (delta.status === "failed") el.open = true;
@@ -246,18 +259,18 @@
       for (const el of list.querySelectorAll(".log-card")) el.remove();
       byIdx.clear();
       cardOf.clear();
+      pendingRows.clear();
       updateGroups();
       for (const e of state) {
         const d = {
           idx: e.idx,
           name: e.name,
           status: e.status,
-          n: e.n,
           card: e.card,
         };
         byIdx.set(d.idx, d);
         setMeta(d);
-        addLines(d.idx, e.n, e.html || "");
+        addRows(d.idx, e.html || "");
       }
     }
 

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -197,6 +197,8 @@
     /** @type {Map<Card, string[]>} */
     const pendingRows = new Map();
     let flushScheduled = false;
+    // The finished page has the full log. Live only needs the tail.
+    const MAX_LIVE_ROWS = 5000;
 
     function flush() {
       flushScheduled = false;
@@ -206,6 +208,13 @@
         const atBottom =
           c.vp.scrollHeight - c.vp.scrollTop - c.vp.clientHeight < 40;
         c.vp.insertAdjacentHTML("beforeend", chunks.join(""));
+        const excess = c.vp.childElementCount - MAX_LIVE_ROWS;
+        if (excess > 0) {
+          const range = document.createRange();
+          range.setStartBefore(/** @type {Node} */ (c.vp.firstChild));
+          range.setEndAfter(/** @type {Node} */ (c.vp.children[excess - 1]));
+          range.deleteContents();
+        }
         if (c.el.open && atBottom) c.vp.scrollTop = c.vp.scrollHeight;
       }
       pendingRows.clear();
@@ -228,7 +237,7 @@
       const c = cards.get(delta.idx);
       if (delta.t === "drv") {
         addCard(delta.idx, "running", delta.card ?? "");
-      } else if (delta.t === "line" || delta.t === "phase") {
+      } else if (delta.t === "line") {
         addRows(c, delta.html);
       } else if (delta.t === "status" && c && delta.status) {
         flush();

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -7,8 +7,8 @@
 "use strict";
 
 /**
- * @typedef {{idx:number,name:string,status:string,html?:string,card?:string}} Drv
- * @typedef {{t:string,idx:number,name?:string,status?:string,from?:number,html?:string,card?:string}} Delta
+ * @typedef {{idx:number,status:string,html?:string,card?:string}} Drv
+ * @typedef {{t:string,idx:number,status?:string,html?:string,card?:string}} Delta
  */
 
 (() => {
@@ -136,10 +136,9 @@
   // in arrival order, the running one following its tail. The
   // terminal-status reload swaps to the polished container page.
   function runLive() {
-    /** @type {Map<number, Drv>} */
-    const byIdx = new Map();
-    /** @type {Map<number, HTMLDetailsElement>} */
-    const cardOf = new Map();
+    /** @typedef {{el: HTMLDetailsElement, vp: HTMLElement, status: string}} Card */
+    /** @type {Map<number, Card>} */
+    const cards = new Map();
     /** @param {string} s */
     const iconState = (s) =>
       s === "failed" ? "failed" : s === "running" ? "running" : "succeeded";
@@ -169,62 +168,55 @@
 
     /** Insert the server-rendered card shell (same drv_card macro as the
      * finished page).
-     * @param {Drv} d @returns {HTMLDetailsElement} */
-    function ensureCard(d) {
-      const existing = cardOf.get(d.idx);
-      if (existing) return existing;
-      const target = groupFor(d.status);
-      target.insertAdjacentHTML("beforeend", d.card ?? "");
+     * @param {number} idx @param {string} status @param {string} html */
+    function addCard(idx, status, html) {
+      const target = groupFor(status);
+      target.insertAdjacentHTML("beforeend", html);
       const el = /** @type {HTMLDetailsElement} */ (target.lastElementChild);
-      cardOf.set(d.idx, el);
-      updateGroups();
-      return el;
+      const c = { el, vp: pick(el, ".log-lines"), status };
+      cards.set(idx, c);
+      setStatus(c, status);
+      return c;
     }
 
-    /** @param {Drv} d @returns {HTMLDetailsElement} */
-    function setMeta(d) {
-      const el = ensureCard(d);
-      pick(el, ".status-icon").className = "status-icon " + iconState(d.status);
-      el.classList.toggle("ok", d.status !== "failed");
-      pick(el, ".meta-status").textContent = d.status === "running"
+    /** @param {Card} c @param {string} status */
+    function setStatus(c, status) {
+      c.status = status;
+      pick(c.el, ".status-icon").className = "status-icon " + iconState(status);
+      c.el.classList.toggle("ok", status !== "failed");
+      pick(c.el, ".meta-status").textContent = status === "running"
         ? "building…"
-        : d.status;
-      const target = groupFor(d.status);
-      if (el.parentElement !== target) {
-        target.appendChild(el);
-        updateGroups();
-      }
-      return el;
+        : status;
+      const target = groupFor(status);
+      if (c.el.parentElement !== target) target.appendChild(c.el);
+      updateGroups();
     }
 
     // Flushed once per frame: a per-line insert + scrollHeight read is a
     // forced layout per line (Mic92/nixbot#98).
-    /** @type {Map<number, string[]>} */
+    /** @type {Map<Card, string[]>} */
     const pendingRows = new Map();
     let flushScheduled = false;
 
     function flush() {
       flushScheduled = false;
-      for (const [idx, chunks] of pendingRows) {
-        const d = byIdx.get(idx);
-        if (!d) continue;
-        const el = ensureCard(d);
-        const vp = pick(el, ".log-lines");
+      for (const [c, chunks] of pendingRows) {
         // Follow the tail only when already at the bottom, so scrolling up
         // to read pauses following and scrolling back resumes it.
-        const atBottom = vp.scrollHeight - vp.scrollTop - vp.clientHeight < 40;
-        vp.insertAdjacentHTML("beforeend", chunks.join(""));
-        if (el.open && atBottom) vp.scrollTop = vp.scrollHeight;
+        const atBottom =
+          c.vp.scrollHeight - c.vp.scrollTop - c.vp.clientHeight < 40;
+        c.vp.insertAdjacentHTML("beforeend", chunks.join(""));
+        if (c.el.open && atBottom) c.vp.scrollTop = c.vp.scrollHeight;
       }
       pendingRows.clear();
     }
 
-    /** @param {number} idx @param {string} html */
-    function addRows(idx, html) {
-      if (!html || !byIdx.has(idx)) return;
-      const chunks = pendingRows.get(idx);
+    /** @param {Card|undefined} c @param {string|undefined} html */
+    function addRows(c, html) {
+      if (!c || !html) return;
+      const chunks = pendingRows.get(c);
       if (chunks) chunks.push(html);
-      else pendingRows.set(idx, [html]);
+      else pendingRows.set(c, [html]);
       if (!flushScheduled) {
         flushScheduled = true;
         requestAnimationFrame(flush);
@@ -233,44 +225,26 @@
 
     /** @param {Delta} delta */
     function apply(delta) {
-      const d = byIdx.get(delta.idx);
+      const c = cards.get(delta.idx);
       if (delta.t === "drv") {
-        const nd = {
-          idx: delta.idx,
-          name: delta.name ?? "",
-          status: "running",
-          card: delta.card,
-        };
-        byIdx.set(nd.idx, nd);
-        setMeta(nd);
+        addCard(delta.idx, "running", delta.card ?? "");
       } else if (delta.t === "line" || delta.t === "phase") {
-        addRows(delta.idx, delta.html ?? "");
-      } else if (delta.t === "status" && d) {
+        addRows(c, delta.html);
+      } else if (delta.t === "status" && c && delta.status) {
         flush();
-        d.status = delta.status ?? d.status;
-        const el = setMeta(d);
-        if (delta.status === "failed") el.open = true;
-        else if (delta.status !== "running") el.open = false;
+        setStatus(c, delta.status);
+        if (delta.status !== "running") c.el.open = delta.status === "failed";
       }
     }
 
     /** @param {Drv[]} state */
     function reset(state) {
-      for (const el of list.querySelectorAll(".log-card")) el.remove();
-      byIdx.clear();
-      cardOf.clear();
+      for (const c of cards.values()) c.el.remove();
+      cards.clear();
       pendingRows.clear();
       updateGroups();
       for (const e of state) {
-        const d = {
-          idx: e.idx,
-          name: e.name,
-          status: e.status,
-          card: e.card,
-        };
-        byIdx.set(d.idx, d);
-        setMeta(d);
-        addRows(d.idx, e.html || "");
+        addRows(addCard(e.idx, e.status, e.card ?? ""), e.html);
       }
     }
 


### PR DESCRIPTION
A kernel build streaming thousands of lines froze the log page in
Chromium and Firefox alike.

- Client: rows were inserted one per SSE event with a `scrollHeight`
  read each time, i.e. one forced layout per line. Rows are now queued
  per card and flushed once per animation frame, and the live view
  keeps only the last 5000 rows per card (the finished page has the
  full log). Card bookkeeping folded into one map.
- Server: the stream drains the subscriber queue and coalesces
  consecutive rows of a derivation into one delta. Plain lines skip
  the ANSI tokenizer and `log_line` no longer regex-strips every line.

40k-line burst: ~70s → 1s in the browser, 40k → 25 layouts,
320k DOM nodes / 86 MB → 40k / 3 MB, 40k SSE events → ~200.
An e2e test asserts the layout count and row cap.

Fixes #98