### PR TITLE
docs: add workload identity

### DIFF
--- a/packages/docs.nix
+++ b/packages/docs.nix
@@ -34,6 +34,7 @@ let
         "EFFECTS.md"
         "OIDC.md"
         "CLI.md"
+        "WORKLOAD_IDENTITY.md"
       ];
     }
     {


### PR DESCRIPTION
Workload identity wasn't published to https://mic92.github.io/nixbot.