### PR TITLE
web: live log view fixes for running builds

### DIFF
--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -557,6 +557,11 @@ class StructuredCapture:
         with contextlib.suppress(ValueError):
             self._subs.remove(q)
 
+    @property
+    def container(self) -> LogContainerWriter:
+        """Reader-shaped access to the retained lines."""
+        return self._w
+
     def state(self, *, with_lines: bool = True) -> list[dict]:
         st = self._w.state(with_lines=with_lines)
         for e in st:

--- a/nixbot/nixbot/logstore.py
+++ b/nixbot/nixbot/logstore.py
@@ -116,6 +116,17 @@ class LogContainerWriter:
         d = self._drvs.get(drv)
         return d.count if d else 0
 
+    def __len__(self) -> int:
+        return len(self._drvs)
+
+    def entry(self, i: int) -> dict:
+        """TOC-shaped entry, the reader's interface for live rendering."""
+        d = list(self._drvs.values())[i]
+        return {"name": d.name, "status": d.status, "ph": d.phases, "n": d.count}
+
+    def lines(self, i: int) -> list[str]:
+        return list(self._drvs.values())[i].lines
+
     def failing(self) -> list[tuple[str, list[str]]]:
         """(name, lines) for derivations left in a failed status."""
         return [(d.name, d.lines) for d in self._drvs.values() if d.status == "failed"]

--- a/nixbot/nixbot/tests/e2e/test_live.py
+++ b/nixbot/nixbot/tests/e2e/test_live.py
@@ -152,3 +152,31 @@ def test_log_page_keeps_up_with_a_line_burst(page: Page, server: TestServer) -> 
         cdp.detach()
         cap.close()
         server.registry.unregister(build_id, ATTR)
+
+
+def test_repeated_activity_keeps_one_card(page: Page, server: TestServer) -> None:
+    """nix starts several activities for one derivation. Mic92/nixbot#168
+    had a card per activity with the rows in only one of them."""
+    build_id = server.run(_build_id(server, 3))
+    writer = LogWriter(path=server.state_dir / "live" / f"{ATTR}-dup.zst")
+    cap = StructuredCapture()
+    writer.capture = cap
+    server.registry.register(build_id, ATTR, writer)
+    drv = "/nix/store/aaa-linux-config-7.1.10.drv"
+
+    async def second_activity() -> None:
+        cap.start_build(2, drv)
+        cap.log_line(2, "from the second activity")
+
+    try:
+        cap.start_build(1, drv)
+        cap.log_line(1, "from the first activity")
+        page.goto(f"/repos/github/acme/widget/builds/3/logs/{ATTR}")
+        cards = page.locator(".log-card", has_text="linux-config-7.1.10")
+        cards.get_by_text("from the first activity").wait_for(timeout=15_000)
+        server.run(second_activity())
+        cards.get_by_text("from the second activity").wait_for(timeout=15_000)
+        assert cards.count() == 1
+    finally:
+        cap.close()
+        server.registry.unregister(build_id, ATTR)

--- a/nixbot/nixbot/tests/e2e/test_live.py
+++ b/nixbot/nixbot/tests/e2e/test_live.py
@@ -145,9 +145,14 @@ def test_log_page_keeps_up_with_a_line_burst(page: Page, server: TestServer) -> 
         server.run(burst())
         page.locator(".logline", has_text="burst done").wait_for(timeout=60_000)
         assert layout_count() - before < max_layouts
-        rows = page.locator(".log-card .log-lines > *")
+        rows = page.locator(".log-card .log-lines > .logline")
         assert rows.count() == max_live_rows
         assert "burst done" in rows.last.inner_text()
+        # Scrolling up to the marker loads the trimmed lines back.
+        marker = page.locator(".log-card .log-lines > .log-elided").first
+        assert "obj_0.o" not in page.content()
+        marker.scroll_into_view_if_needed()
+        page.locator(".logline", has_text="obj_0.o").wait_for(timeout=15_000)
     finally:
         cdp.detach()
         cap.close()

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -174,6 +174,9 @@ def test_build_page(client: WebHarness) -> None:
     assert "x86_64-linux.ok" not in text
     assert "2 succeeded" in text
     assert "attrs?group=succeeded" in text
+    assert "· took " in text
+    # Build 3 is still building: its duration is not final.
+    assert "running for" in client.get("/repos/github/acme/widget/builds/3").text
     # Groups scroll internally so the summaries below stay reachable.
     assert text.count('class="attr-scroll"') >= 2
     # Search queries the server, not just the loaded rows.

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -33,6 +33,7 @@ from nixbot.executor import (
 )
 from nixbot.logstore import LogContainerWriter
 from nixbot.web import events as events_module
+from nixbot.web import logs as logs_mod
 from nixbot.web.auth_routes import SESSION_COOKIE, create_auth_router
 from nixbot.web.events import EventBroker
 from nixbot.web.logs import (
@@ -878,15 +879,17 @@ def test_structured_log_window_caps_huge_derivation(
     assert "line11999" in capped
     assert "line05000" not in capped  # elided middle
     # The marker auto-loads the gap in bounded chunks.
-    assert 'hx-trigger="revealed"' in capped
-    assert "start=2000&end=4000" in capped
+    assert 'hx-trigger="intersect once"' in capped
+    assert "start=2000&end=9000" in capped  # the whole gap
 
-    chunk = client.get(f"{base}/drv/0?start=2000&end=4000").text
+    # One bounded chunk per request, then a marker for the rest.
+    chunk = client.get(f"{base}/drv/0?start=2000&end=9000").text
     assert 'id="d0-L2001"' in chunk
     assert "line02000" in chunk
     assert 'id="d0-L4000"' in chunk
     assert "line03999" in chunk
-    assert "start=4000" in chunk  # next marker for the remaining gap
+    assert "line04000" not in chunk
+    assert "start=4000&end=9000" in chunk
 
 
 def test_attr_named_dot_txt_not_shadowed_by_raw_route(
@@ -1227,12 +1230,15 @@ def test_openapi_docs(client: WebHarness) -> None:
 # --- live logs ---------------------------------------------------------
 
 
-def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
+def test_structured_live_stream(
+    client: WebHarness, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A running attribute with a capture streams per-derivation deltas;
     the viewer wires the structured client to that stream."""
     ctx = client.ctx
     ctx.state_dir = tmp_path
     registry = client.app.state.log_registry
+    monkeypatch.setattr(logs_mod, "LIVE_TAIL", 3)
 
     async def run() -> tuple[str, str]:
         build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 3")
@@ -1240,6 +1246,8 @@ def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
         cap = StructuredCapture(clock=lambda: 1.0)
         writer.capture = cap
         cap.start_build(1, "/nix/store/aaa-qtbase-5.0.drv")
+        for i in range(1, 6):
+            cap.log_line(1, f"CC early{i}.o")
         cap.log_line(1, "CC main.o")
         registry.register(build_id, "x86_64-linux.ok", writer)
         try:
@@ -1265,7 +1273,7 @@ def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
 
     viewer, stream = client.loop.run_until_complete(run())
     assert "const LIVE = true" in viewer
-    assert "format=structured" in viewer  # data-stream on #drv-list
+    assert "data-base=" in viewer  # #drv-list follows the stream
     # Live page groups cards by status like the finished view.
     assert 'id="failed-cards"' in viewer
     assert 'id="building-cards"' in viewer
@@ -1276,7 +1284,11 @@ def test_structured_live_stream(client: WebHarness, tmp_path: Path) -> None:
     assert "event: state" in stream
     assert '"name":"qtbase-5.0"' in stream  # snapshot burst
     # Rows are rendered server-side (ANSI applied), not shipped as raw text.
-    assert "d1-L1" in stream
+    # The snapshot carries only the tail (#168), numbered absolutely.
+    state_line = next(ln for ln in stream.splitlines() if '"card"' in ln)
+    assert "CC early3.o" not in state_line
+    assert "d1-L4" in state_line
+    assert "drv/1?start=0&end=3" in state_line  # loads them on scroll-up
     assert '"text"' not in stream
     # The phase divider and the line queued behind it coalesce into one
     # rendered delta.

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -1252,9 +1252,8 @@ class _LiveRenderer:
 
     def delta(self, delta: dict) -> dict:
         if delta["t"] == "drv":
-            delta["card"] = self.card(
-                {**delta, "status": "running", "n": 0, "ph": [], "t0": None}
-            )
+            delta["status"] = "running"
+            delta["card"] = self.card({**delta, "n": 0, "ph": [], "t0": None})
         elif delta["t"] == "line":
             idx = delta["idx"]
             delta["html"], self._styles[idx] = render_rows(

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -11,7 +11,7 @@ import asyncio
 import functools
 import html
 import json
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import (
@@ -290,45 +290,53 @@ _RENDER_CAP = _RENDER_HEAD + _RENDER_TAIL
 _RENDER_CHUNK = 2000
 
 
-def _chunk_marker(idx: int, base: str, start: int, end: int) -> str:
-    """A marker that auto-loads lines [start, end) (0-based) once scrolled
-    into view, one bounded chunk at a time. htmx swaps the fetched rows
-    (and the next marker, if any) over it."""
-    nxt = min(start + _RENDER_CHUNK, end)
+def chunk_marker(idx: int, base: str, start: int, end: int) -> str:
+    """A marker standing in for lines [start, end) (0-based). Scrolled
+    into view it fetches that range; the server renders one bounded
+    chunk and a fresh marker for the remainder."""
     return (
         f'<div class="log-elided" role="separator"'
-        f' hx-get="{base}/drv/{idx}?start={start}&end={nxt}"'
-        f' hx-trigger="revealed" hx-target="this" hx-swap="outerHTML">'
+        f' hx-get="{base}/drv/{idx}?start={start}&end={end}"'
+        f' hx-trigger="intersect once" hx-target="this" hx-swap="outerHTML">'
         f"loading {end - start:,} hidden lines…</div>"
     )
 
 
+class _DrvLines(Protocol):
+    """Finished container reader or live capture writer."""
+
+    def __len__(self) -> int: ...
+    def entry(self, i: int) -> dict: ...
+    def lines(self, i: int) -> list[str]: ...
+
+
 def render_drv_window(
-    reader: LogContainerReader,
+    reader: _DrvLines,
     idx: int,
     base: str,
     start: int | None = None,
     end: int | None = None,
 ) -> str:
     """A derivation's log as anchored rows. The initial view (no range)
-    is capped to a head+tail window with a load-more marker spanning the
-    gap. A range request renders lines [start, end) plus another marker
-    if more of the gap remains before the tail."""
+    is capped to a head+tail window with a marker spanning the gap. A
+    range request renders the first chunk of [start, end) plus a marker
+    for what remains of it."""
     lines = reader.lines(idx)
     ph = _phase_at(reader.entry(idx)["ph"])
     n = len(lines)
-    gap_end = n - _RENDER_TAIL  # tail starts here. Never render past it
     if start is None:
         if n <= _RENDER_CAP:
             return render_rows(idx, 1, lines, phases=ph)[0]
+        gap_end = n - _RENDER_TAIL
         head = render_rows(idx, 1, lines[:_RENDER_HEAD], phases=ph)[0]
         tail = render_rows(idx, gap_end + 1, lines[gap_end:], phases=ph)[0]
-        return head + _chunk_marker(idx, base, _RENDER_HEAD, gap_end) + tail
+        return head + chunk_marker(idx, base, _RENDER_HEAD, gap_end) + tail
     start = max(0, start)
-    end = min(end if end is not None else start + _RENDER_CHUNK, gap_end)
-    rows = render_rows(idx, start + 1, lines[start:end], phases=ph)[0]
-    if end < gap_end:
-        rows += _chunk_marker(idx, base, end, gap_end)
+    end = min(end if end is not None else n, n)
+    chunk_end = min(start + _RENDER_CHUNK, end)
+    rows = render_rows(idx, start + 1, lines[start:chunk_end], phases=ph)[0]
+    if chunk_end < end:
+        rows += chunk_marker(idx, base, chunk_end, end)
     return rows
 
 
@@ -832,8 +840,11 @@ class _LogRoutes:
     ) -> HTMLResponse:
         """One derivation's log as anchored HTML rows. ?start&end pulls a
         bounded slice of the elided middle for the load-more marker."""
-        _, _, path = await self._resolve(request, forge, owner, name, number, attr)
-        reader = await _load_container(path)
+        _, build, path = await self._resolve(request, forge, owner, name, number, attr)
+        capture = self._capture(build, attr)
+        reader: _DrvLines | None = (
+            capture.container if capture is not None else await _load_container(path)
+        )
         if reader is None or not (0 <= idx < len(reader)):
             raise HTTPException(status_code=404)
         base = request.url.path.rsplit("/drv/", 1)[0]
@@ -1043,6 +1054,7 @@ class _LogRoutes:
             toc=toc,
             live=live,
             live_structured=live_structured,
+            live_tail=LIVE_TAIL,
             waiting=waiting,
             unavailable=unavailable,
             prev_number=prev_number,
@@ -1207,6 +1219,10 @@ def _coalesce_lines(deltas: Iterable[dict]) -> list[dict]:
     return out
 
 
+# The live view follows the tail. The finished page has the full log.
+LIVE_TAIL = 5000
+
+
 class _LiveRenderer:
     """Renders card shells (drv_card macro) and rows for the live stream,
     carrying each derivation's trailing SGR style into the next batch."""
@@ -1224,9 +1240,13 @@ class _LiveRenderer:
 
     def state(self, state: list[dict]) -> list[dict]:
         for e in state:
+            lines = e.pop("lines")
+            skipped = max(0, len(lines) - LIVE_TAIL)
             e["html"], self._styles[e["idx"]] = render_rows(
-                e["idx"], 1, e.pop("lines"), phases=_phase_at(e["ph"])
+                e["idx"], skipped + 1, lines[skipped:], phases=_phase_at(e["ph"])
             )
+            if skipped:
+                e["html"] = chunk_marker(e["idx"], self._base, 0, skipped) + e["html"]
             e["card"] = self.card(e)
         return state
 

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -236,7 +236,9 @@
     function apply(delta) {
       const c = cards.get(delta.idx);
       if (delta.t === "drv") {
-        addCard(delta.idx, "running", delta.card ?? "");
+        // Repeated for each activity on an already known derivation.
+        if (c) setStatus(c, "running");
+        else addCard(delta.idx, "running", delta.card ?? "");
       } else if (delta.t === "line") {
         addRows(c, delta.html);
       } else if (delta.t === "status" && c && delta.status) {

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -10,6 +10,8 @@
  * @typedef {{idx:number,status:string,html?:string,card?:string}} Drv
  * @typedef {{t:string,idx:number,status?:string,html?:string,card?:string}} Delta
  */
+/** @param {Element|null} el */
+const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
 
 (() => {
   /** @param {string} id @returns {HTMLElement|null} */
@@ -21,7 +23,7 @@
     return el;
   };
   const list = must("drv-list");
-  const STREAM = list.dataset.stream; // set only while the build runs
+  const BASE = list.dataset.base; // set only while the build runs
 
   /** @param {ParentNode} el @param {string} sel @returns {HTMLElement} */
   const pick = (el, sel) => {
@@ -55,7 +57,7 @@
     }
   });
 
-  if (STREAM) return runLive();
+  if (BASE) return runLive();
 
   // Track cards whose rows are loaded so a jump fires now or waits.
   /** @type {WeakSet<HTMLElement>} */
@@ -176,7 +178,6 @@
       const c = { el, vp: pick(el, ".log-lines"), status };
       cards.set(idx, c);
       setStatus(c, status);
-      return c;
     }
 
     /** @param {Card} c @param {string} status */
@@ -194,38 +195,57 @@
 
     // Flushed once per frame: a per-line insert + scrollHeight read is a
     // forced layout per line (Mic92/nixbot#98).
-    /** @type {Map<Card, string[]>} */
+    /** @type {Map<number, string[]>} */
     const pendingRows = new Map();
     let flushScheduled = false;
-    // The finished page has the full log. Live only needs the tail.
-    const MAX_LIVE_ROWS = 5000;
+    const MAX_LIVE_ROWS = Number(list.dataset.tail);
+
+    /** Keep the last MAX_LIVE_ROWS; a marker loads the rest on scroll-up.
+     * @param {number} idx @param {Card} c */
+    function trim(idx, c) {
+      const excess = c.vp.childElementCount - MAX_LIVE_ROWS;
+      if (excess <= 0) return;
+      const first = c.vp.children[excess];
+      const m = /^d\d+-L(\d+)$/.exec(first.id);
+      if (!m) return;
+      const range = document.createRange();
+      range.setStartBefore(/** @type {Node} */ (c.vp.firstChild));
+      range.setEndBefore(first);
+      range.deleteContents();
+      const hidden = Number(m[1]) - 1;
+      c.vp.insertAdjacentHTML(
+        "afterbegin",
+        `<div class="log-elided" role="separator" hx-get="${BASE}/drv/${idx}?start=0&end=${hidden}" hx-trigger="intersect once" hx-target="this" hx-swap="outerHTML">loading ${
+          hidden.toLocaleString("en")
+        } hidden lines…</div>`,
+      );
+      hx(c.vp.firstElementChild);
+    }
 
     function flush() {
       flushScheduled = false;
-      for (const [c, chunks] of pendingRows) {
-        // Follow the tail only when already at the bottom, so scrolling up
-        // to read pauses following and scrolling back resumes it.
+      for (const [idx, chunks] of pendingRows) {
+        const c = cards.get(idx);
+        if (!c) continue;
+        // Scrolling up pauses following and trimming.
         const atBottom =
           c.vp.scrollHeight - c.vp.scrollTop - c.vp.clientHeight < 40;
-        c.vp.insertAdjacentHTML("beforeend", chunks.join(""));
-        const excess = c.vp.childElementCount - MAX_LIVE_ROWS;
-        if (excess > 0) {
-          const range = document.createRange();
-          range.setStartBefore(/** @type {Node} */ (c.vp.firstChild));
-          range.setEndAfter(/** @type {Node} */ (c.vp.children[excess - 1]));
-          range.deleteContents();
-        }
-        if (c.el.open && atBottom) c.vp.scrollTop = c.vp.scrollHeight;
+        const html = chunks.join("");
+        c.vp.insertAdjacentHTML("beforeend", html);
+        if (html.includes("hx-get")) hx(c.vp);
+        if (!atBottom) continue;
+        trim(idx, c);
+        if (c.el.open) c.vp.scrollTop = c.vp.scrollHeight;
       }
       pendingRows.clear();
     }
 
-    /** @param {Card|undefined} c @param {string|undefined} html */
-    function addRows(c, html) {
-      if (!c || !html) return;
-      const chunks = pendingRows.get(c);
+    /** @param {number} idx @param {string|undefined} html */
+    function addRows(idx, html) {
+      if (!html) return;
+      const chunks = pendingRows.get(idx);
       if (chunks) chunks.push(html);
-      else pendingRows.set(c, [html]);
+      else pendingRows.set(idx, [html]);
       if (!flushScheduled) {
         flushScheduled = true;
         requestAnimationFrame(flush);
@@ -240,7 +260,7 @@
         if (c) setStatus(c, "running");
         else addCard(delta.idx, "running", delta.card ?? "");
       } else if (delta.t === "line") {
-        addRows(c, delta.html);
+        addRows(delta.idx, delta.html);
       } else if (delta.t === "status" && c && delta.status) {
         flush();
         setStatus(c, delta.status);
@@ -255,12 +275,13 @@
       pendingRows.clear();
       updateGroups();
       for (const e of state) {
-        addRows(addCard(e.idx, e.status, e.card ?? ""), e.html);
+        addCard(e.idx, e.status, e.card ?? "");
+        addRows(e.idx, e.html);
       }
     }
 
     let errors = 0;
-    const src = new EventSource(/** @type {string} */ (STREAM));
+    const src = new EventSource(`${BASE}/stream?format=structured`);
     src.addEventListener("state", (ev) => {
       errors = 0;
       reset(JSON.parse(ev.data));

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -7,12 +7,8 @@
 "use strict";
 
 /**
- * @typedef {{idx:number,status:string,html?:string,card?:string}} Drv
- * @typedef {{t:string,idx:number,status?:string,html?:string,card?:string}} Delta
+ * @typedef {{t?:string,idx:number,status?:string,html?:string,card?:string}} Delta
  */
-/** @param {Element|null} el */
-const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
-
 (() => {
   /** @param {string} id @returns {HTMLElement|null} */
   const $ = (id) => document.getElementById(id);
@@ -59,9 +55,6 @@ const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
 
   if (BASE) return runLive();
 
-  // Track cards whose rows are loaded so a jump fires now or waits.
-  /** @type {WeakSet<HTMLElement>} */
-  const loaded = new WeakSet();
   const succeeded =
     /** @type {HTMLDetailsElement|null} */ ($("succeeded-panel"));
   /** @type {{card:HTMLElement, idx:number, line:number|null}|null} */
@@ -85,7 +78,6 @@ const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
     vp.removeAttribute("aria-busy");
     const card = /** @type {HTMLElement|null} */ (vp.closest(".log-card"));
     if (!card) return;
-    loaded.add(card);
     if (pending && pending.card === card) {
       jump(card, pending.idx, pending.line);
       pending = null;
@@ -103,8 +95,9 @@ const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
     if (!card) return;
     if (succeeded && succeeded.contains(card)) succeeded.open = true;
     card.open = true; // triggers the htmx fetch if not yet loaded
-    if (loaded.has(card)) jump(card, idx, line);
-    else pending = { card, idx, line }; // afterSwap completes the jump
+    if (pick(card, ".log-lines").hasAttribute("aria-busy")) {
+      pending = { card, idx, line }; // afterSwap completes the jump
+    } else jump(card, idx, line);
   }
 
   // Search results are server-rendered. The client only jumps into a
@@ -138,58 +131,36 @@ const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
   // in arrival order, the running one following its tail. The
   // terminal-status reload swaps to the polished container page.
   function runLive() {
-    /** @typedef {{el: HTMLDetailsElement, vp: HTMLElement, status: string}} Card */
+    /** @typedef {{el: HTMLDetailsElement, vp: HTMLElement}} Card */
     /** @type {Map<number, Card>} */
     const cards = new Map();
+    /** @param {Element|null} el */
+    const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
     /** @param {string} s */
-    const iconState = (s) =>
-      s === "failed" ? "failed" : s === "running" ? "running" : "succeeded";
-
-    // Cards live in the status groups the template renders (Failures /
-    // Building / Succeeded panel), mirroring the finished page.
-    /** @param {string} s @returns {HTMLElement} */
-    const groupFor = (s) =>
-      must(
-        s === "failed"
-          ? "failed-cards"
-          : s === "running"
-          ? "building-cards"
-          : "succeeded-list",
-      );
+    const kind = (s) => s === "failed" || s === "running" ? s : "succeeded";
+    const groups = [...list.querySelectorAll(".live-group")].map((g) => ({
+      el: /** @type {HTMLElement} */ (g),
+      cards: pick(g, ".group-cards"),
+    }));
 
     function updateGroups() {
-      for (const id of ["failed", "building", "succeeded"]) {
-        const group = must(`group-${id}`);
-        const n = pick(group, ".group-cards").childElementCount;
-        group.hidden = n === 0;
-        for (const c of group.querySelectorAll(".count")) {
-          c.textContent = `${n}`;
-        }
+      for (const g of groups) {
+        const n = g.cards.childElementCount;
+        g.el.hidden = n === 0;
+        for (const c of g.el.querySelectorAll(".count")) c.textContent = `${n}`;
       }
-    }
-
-    /** Insert the server-rendered card shell (same drv_card macro as the
-     * finished page).
-     * @param {number} idx @param {string} status @param {string} html */
-    function addCard(idx, status, html) {
-      const target = groupFor(status);
-      target.insertAdjacentHTML("beforeend", html);
-      const el = /** @type {HTMLDetailsElement} */ (target.lastElementChild);
-      const c = { el, vp: pick(el, ".log-lines"), status };
-      cards.set(idx, c);
-      setStatus(c, status);
     }
 
     /** @param {Card} c @param {string} status */
     function setStatus(c, status) {
-      c.status = status;
-      pick(c.el, ".status-icon").className = "status-icon " + iconState(status);
-      c.el.classList.toggle("ok", status !== "failed");
-      pick(c.el, ".meta-status").textContent = status === "running"
+      const k = kind(status);
+      pick(c.el, ".status-icon").className = `status-icon ${k}`;
+      c.el.classList.toggle("ok", k !== "failed");
+      pick(c.el, ".meta-status").textContent = k === "running"
         ? "building…"
         : status;
-      const target = groupFor(status);
-      if (c.el.parentElement !== target) target.appendChild(c.el);
+      const g = groups.find((g) => g.el.dataset.status === k);
+      if (g && c.el.parentElement !== g.cards) g.cards.appendChild(c.el);
       updateGroups();
     }
 
@@ -219,7 +190,6 @@ const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
           hidden.toLocaleString("en")
         } hidden lines…</div>`,
       );
-      hx(c.vp.firstElementChild);
     }
 
     function flush() {
@@ -230,53 +200,42 @@ const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
         // Scrolling up pauses following and trimming.
         const atBottom =
           c.vp.scrollHeight - c.vp.scrollTop - c.vp.clientHeight < 40;
-        const html = chunks.join("");
-        c.vp.insertAdjacentHTML("beforeend", html);
-        if (html.includes("hx-get")) hx(c.vp);
-        if (!atBottom) continue;
-        trim(idx, c);
-        if (c.el.open) c.vp.scrollTop = c.vp.scrollHeight;
+        c.vp.insertAdjacentHTML("beforeend", chunks.join(""));
+        if (atBottom) {
+          trim(idx, c);
+          if (c.el.open) c.vp.scrollTop = c.vp.scrollHeight;
+        }
+        hx(c.vp);
       }
       pendingRows.clear();
     }
 
-    /** @param {number} idx @param {string|undefined} html */
-    function addRows(idx, html) {
-      if (!html) return;
-      const chunks = pendingRows.get(idx);
-      if (chunks) chunks.push(html);
-      else pendingRows.set(idx, [html]);
-      if (!flushScheduled) {
-        flushScheduled = true;
-        requestAnimationFrame(flush);
+    /** A state entry or delta: card shell, status change and/or rows.
+     * @param {Delta} d */
+    function apply(d) {
+      let c = cards.get(d.idx);
+      if (!c && d.card) {
+        list.insertAdjacentHTML("beforeend", d.card);
+        const el = /** @type {HTMLDetailsElement} */ (list.lastElementChild);
+        c = { el, vp: pick(el, ".log-lines") };
+        cards.set(d.idx, c);
       }
-    }
-
-    /** @param {Delta} delta */
-    function apply(delta) {
-      const c = cards.get(delta.idx);
-      if (delta.t === "drv") {
-        // Repeated for each activity on an already known derivation.
-        if (c) setStatus(c, "running");
-        else addCard(delta.idx, "running", delta.card ?? "");
-      } else if (delta.t === "line") {
-        addRows(delta.idx, delta.html);
-      } else if (delta.t === "status" && c && delta.status) {
+      if (!c) return;
+      if (d.status) {
         flush();
-        setStatus(c, delta.status);
-        if (delta.status !== "running") c.el.open = delta.status === "failed";
+        setStatus(c, d.status);
+        if (d.t === "status" && d.status !== "running") {
+          c.el.open = d.status === "failed";
+        }
       }
-    }
-
-    /** @param {Drv[]} state */
-    function reset(state) {
-      for (const c of cards.values()) c.el.remove();
-      cards.clear();
-      pendingRows.clear();
-      updateGroups();
-      for (const e of state) {
-        addCard(e.idx, e.status, e.card ?? "");
-        addRows(e.idx, e.html);
+      if (d.html) {
+        const chunks = pendingRows.get(d.idx);
+        if (chunks) chunks.push(d.html);
+        else pendingRows.set(d.idx, [d.html]);
+        if (!flushScheduled) {
+          flushScheduled = true;
+          requestAnimationFrame(flush);
+        }
       }
     }
 
@@ -284,7 +243,11 @@ const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
     const src = new EventSource(`${BASE}/stream?format=structured`);
     src.addEventListener("state", (ev) => {
       errors = 0;
-      reset(JSON.parse(ev.data));
+      for (const c of cards.values()) c.el.remove();
+      cards.clear();
+      pendingRows.clear();
+      updateGroups();
+      for (const d of JSON.parse(ev.data)) apply(d);
     });
     src.addEventListener("delta", (ev) => apply(JSON.parse(ev.data)));
     src.addEventListener("done", () => src.close());

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -19,7 +19,7 @@
     return el;
   };
   const list = must("drv-list");
-  const BASE = list.dataset.base; // set only while the build runs
+  const LOG_BASE = list.dataset.base; // set only while the build runs
 
   /** @param {ParentNode} el @param {string} sel @returns {HTMLElement} */
   const pick = (el, sel) => {
@@ -53,7 +53,7 @@
     }
   });
 
-  if (BASE) return runLive();
+  if (LOG_BASE) return runLive();
 
   const succeeded =
     /** @type {HTMLDetailsElement|null} */ ($("succeeded-panel"));
@@ -116,8 +116,8 @@
   // A #d{idx}-L{n} permalink can't scroll on its own: the row is fetched
   // lazily, so on load (and on hashchange) resolve it through openAt.
   function jumpToHash() {
-    const m = /^#d(\d+)-L(\d+)$/.exec(location.hash);
-    if (m) openAt(Number(m[1]), Number(m[2]));
+    const match = /^#d(\d+)-L(\d+)$/.exec(location.hash);
+    if (match) openAt(Number(match[1]), Number(match[2]));
   }
   globalThis.addEventListener("hashchange", jumpToHash);
   // Wait for htmx to wire its toggle triggers (on DOMContentLoaded);
@@ -131,36 +131,42 @@
   // in arrival order, the running one following its tail. The
   // terminal-status reload swaps to the polished container page.
   function runLive() {
-    /** @typedef {{el: HTMLDetailsElement, vp: HTMLElement}} Card */
+    /** @typedef {{el: HTMLDetailsElement, viewport: HTMLElement}} Card */
     /** @type {Map<number, Card>} */
     const cards = new Map();
     /** @param {Element|null} el */
-    const hx = (el) => /** @type {any} */ (globalThis).htmx.process(el);
+    const processHtmx = (el) =>
+      /** @type {any} */ (globalThis).htmx.process(el);
     /** @param {string} s */
-    const kind = (s) => s === "failed" || s === "running" ? s : "succeeded";
-    const groups = [...list.querySelectorAll(".live-group")].map((g) => ({
-      el: /** @type {HTMLElement} */ (g),
-      cards: pick(g, ".group-cards"),
+    const statusGroup = (s) =>
+      s === "failed" || s === "running" ? s : "succeeded";
+    const groups = [...list.querySelectorAll(".live-group")].map((group) => ({
+      el: /** @type {HTMLElement} */ (group),
+      cards: pick(group, ".group-cards"),
     }));
 
     function updateGroups() {
-      for (const g of groups) {
-        const n = g.cards.childElementCount;
-        g.el.hidden = n === 0;
-        for (const c of g.el.querySelectorAll(".count")) c.textContent = `${n}`;
+      for (const group of groups) {
+        const n = group.cards.childElementCount;
+        group.el.hidden = n === 0;
+        for (const count of group.el.querySelectorAll(".count")) {
+          count.textContent = `${n}`;
+        }
       }
     }
 
-    /** @param {Card} c @param {string} status */
-    function setStatus(c, status) {
-      const k = kind(status);
-      pick(c.el, ".status-icon").className = `status-icon ${k}`;
-      c.el.classList.toggle("ok", k !== "failed");
-      pick(c.el, ".meta-status").textContent = k === "running"
+    /** @param {Card} card @param {string} status */
+    function setStatus(card, status) {
+      const group = statusGroup(status);
+      pick(card.el, ".status-icon").className = `status-icon ${group}`;
+      card.el.classList.toggle("ok", group !== "failed");
+      pick(card.el, ".meta-status").textContent = group === "running"
         ? "building…"
         : status;
-      const g = groups.find((g) => g.el.dataset.status === k);
-      if (g && c.el.parentElement !== g.cards) g.cards.appendChild(c.el);
+      const target = groups.find((g) => g.el.dataset.status === group)?.cards;
+      if (target && card.el.parentElement !== target) {
+        target.appendChild(card.el);
+      }
       updateGroups();
     }
 
@@ -172,21 +178,21 @@
     const MAX_LIVE_ROWS = Number(list.dataset.tail);
 
     /** Keep the last MAX_LIVE_ROWS; a marker loads the rest on scroll-up.
-     * @param {number} idx @param {Card} c */
-    function trim(idx, c) {
-      const excess = c.vp.childElementCount - MAX_LIVE_ROWS;
+     * @param {number} idx @param {Card} card */
+    function trim(idx, card) {
+      const excess = card.viewport.childElementCount - MAX_LIVE_ROWS;
       if (excess <= 0) return;
-      const first = c.vp.children[excess];
-      const m = /^d\d+-L(\d+)$/.exec(first.id);
-      if (!m) return;
+      const first = card.viewport.children[excess];
+      const lineno = /^d\d+-L(\d+)$/.exec(first.id);
+      if (!lineno) return;
       const range = document.createRange();
-      range.setStartBefore(/** @type {Node} */ (c.vp.firstChild));
+      range.setStartBefore(/** @type {Node} */ (card.viewport.firstChild));
       range.setEndBefore(first);
       range.deleteContents();
-      const hidden = Number(m[1]) - 1;
-      c.vp.insertAdjacentHTML(
+      const hidden = Number(lineno[1]) - 1;
+      card.viewport.insertAdjacentHTML(
         "afterbegin",
-        `<div class="log-elided" role="separator" hx-get="${BASE}/drv/${idx}?start=0&end=${hidden}" hx-trigger="intersect once" hx-target="this" hx-swap="outerHTML">loading ${
+        `<div class="log-elided" role="separator" hx-get="${LOG_BASE}/drv/${idx}?start=0&end=${hidden}" hx-trigger="intersect once" hx-target="this" hx-swap="outerHTML">loading ${
           hidden.toLocaleString("en")
         } hidden lines…</div>`,
       );
@@ -195,43 +201,45 @@
     function flush() {
       flushScheduled = false;
       for (const [idx, chunks] of pendingRows) {
-        const c = cards.get(idx);
-        if (!c) continue;
+        const card = cards.get(idx);
+        if (!card) continue;
         // Scrolling up pauses following and trimming.
-        const atBottom =
-          c.vp.scrollHeight - c.vp.scrollTop - c.vp.clientHeight < 40;
-        c.vp.insertAdjacentHTML("beforeend", chunks.join(""));
+        const atBottom = card.viewport.scrollHeight - card.viewport.scrollTop -
+            card.viewport.clientHeight < 40;
+        card.viewport.insertAdjacentHTML("beforeend", chunks.join(""));
         if (atBottom) {
-          trim(idx, c);
-          if (c.el.open) c.vp.scrollTop = c.vp.scrollHeight;
+          trim(idx, card);
+          if (card.el.open) {
+            card.viewport.scrollTop = card.viewport.scrollHeight;
+          }
         }
-        hx(c.vp);
+        processHtmx(card.viewport);
       }
       pendingRows.clear();
     }
 
     /** A state entry or delta: card shell, status change and/or rows.
-     * @param {Delta} d */
-    function apply(d) {
-      let c = cards.get(d.idx);
-      if (!c && d.card) {
-        list.insertAdjacentHTML("beforeend", d.card);
+     * @param {Delta} delta */
+    function apply(delta) {
+      let card = cards.get(delta.idx);
+      if (!card && delta.card) {
+        list.insertAdjacentHTML("beforeend", delta.card);
         const el = /** @type {HTMLDetailsElement} */ (list.lastElementChild);
-        c = { el, vp: pick(el, ".log-lines") };
-        cards.set(d.idx, c);
+        card = { el, viewport: pick(el, ".log-lines") };
+        cards.set(delta.idx, card);
       }
-      if (!c) return;
-      if (d.status) {
+      if (!card) return;
+      if (delta.status) {
         flush();
-        setStatus(c, d.status);
-        if (d.t === "status" && d.status !== "running") {
-          c.el.open = d.status === "failed";
+        setStatus(card, delta.status);
+        if (delta.t === "status" && delta.status !== "running") {
+          card.el.open = delta.status === "failed";
         }
       }
-      if (d.html) {
-        const chunks = pendingRows.get(d.idx);
-        if (chunks) chunks.push(d.html);
-        else pendingRows.set(d.idx, [d.html]);
+      if (delta.html) {
+        const chunks = pendingRows.get(delta.idx);
+        if (chunks) chunks.push(delta.html);
+        else pendingRows.set(delta.idx, [delta.html]);
         if (!flushScheduled) {
           flushScheduled = true;
           requestAnimationFrame(flush);
@@ -240,14 +248,14 @@
     }
 
     let errors = 0;
-    const src = new EventSource(`${BASE}/stream?format=structured`);
+    const src = new EventSource(`${LOG_BASE}/stream?format=structured`);
     src.addEventListener("state", (ev) => {
       errors = 0;
-      for (const c of cards.values()) c.el.remove();
+      for (const card of cards.values()) card.el.remove();
       cards.clear();
       pendingRows.clear();
       updateGroups();
-      for (const d of JSON.parse(ev.data)) apply(d);
+      for (const delta of JSON.parse(ev.data)) apply(delta);
     });
     src.addEventListener("delta", (ev) => apply(JSON.parse(ev.data)));
     src.addEventListener("done", () => src.close());

--- a/nixbot/nixbot/web/templates/_macros.html
+++ b/nixbot/nixbot/web/templates/_macros.html
@@ -95,7 +95,7 @@
           </span>
         </summary>
         <div class="card-body">
-          {% if d.n == 0 and d.status != "running" %}
+          {% if not live and d.n == 0 and d.status != "running" %}
             <p class="log-empty">no output</p>
           {% else %}
             <div class="log-lines" aria-busy="true"></div>

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -54,7 +54,7 @@
             · commit {{ commit_link(project, build.commit_sha) }}
             · <time datetime="{{ build.created_at.isoformat() }}"
        title="{{ build.created_at }}">{{ build.created_at | timeago }}</time>
-            · took {{ build | duration }}
+            · {{ "running for" if build.status in RUNNING_STATUSES else "took" }} {{ build | duration }}
           </p>
         </div>
         <div class="controls">

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -69,19 +69,19 @@
           {% if live_structured %}
             {# Status groups matching the finished page. The JS moves
                cards between them on status deltas. #}
-            <div class="live-group" id="group-failed" hidden>
+            <div class="live-group" data-status="failed" hidden>
               <h2 class="section">
                 Failures (<span class="count">0</span>)
               </h2>
               <div class="group-cards" id="failed-cards"></div>
             </div>
-            <div class="live-group" id="group-building" hidden>
+            <div class="live-group" data-status="running" hidden>
               <h2 class="section">
                 Building (<span class="count">0</span>)
               </h2>
               <div class="group-cards" id="building-cards"></div>
             </div>
-            <div class="live-group" id="group-succeeded" hidden>
+            <div class="live-group" data-status="succeeded" hidden>
               <h2 class="section">
                 Succeeded (<span class="count">0</span>)
               </h2>

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -65,7 +65,7 @@
           </section>
         {% endif %}
         <div id="drv-list"
-             {% if live_structured %}data-stream="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}/stream?format=structured"{% endif %}>
+             {% if live_structured %}data-base="{{ build_path(project, build.number) }}/logs/{{ attr | urlencode }}" data-tail="{{ live_tail }}"{% endif %}>
           {% if live_structured %}
             {# Status groups matching the finished page. The JS moves
                cards between them on status deltas. #}


### PR DESCRIPTION
Addresses the three problems reported in #168.

**Live cards missing or duplicated.** Two regressions from #161. A card
for a derivation without output yet was rendered without a `.log-lines`
container, so inserting the connect snapshot failed on the setup card
and no cards appeared until later deltas arrived. Separately, nix opens
several activities per derivation and each one added another card
instead of reusing the existing one. An e2e test covers both.

**Slow initial load.** The connect snapshot contained every retained
line (up to 100 000 per derivation) as one SSE event, which the browser
cannot render until fully received, only to keep the last 5000 rows.
The server now sends just that tail, preceded by the same lazy-loading
marker the finished view uses, so earlier lines load on scroll-up.
`/drv/{idx}` serves ranges from the live capture for that.

**Header wording.** A running build reads "running for 1m 36s" rather
than "took 1m 36s".

Fixes #168