### PR TITLE
restart: reset rows in the worker after the live run released them

### DIFF
--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -563,7 +563,7 @@ async def build_attributes(  # noqa: PLR0913
         BuildResult(status, generation, schedule_result.results),
         eval_success=True,
     )
-    o.cancel_events.pop(build.id_, None)
+    o.release_run(build.id_)
 
     if status == BuildStatus.SUCCEEDED:
         await o.refresh_schedules(event)

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -146,9 +146,21 @@ class Orchestrator:
     linked_events: dict[int, list[ChangeEvent]] = field(default_factory=dict)
     # Caps concurrent evaluations to bound memory use.
     eval_slots: asyncio.Semaphore = field(init=False)
+    # Pulsed on every release_run().
+    _run_released: asyncio.Event = field(default_factory=asyncio.Event)
 
     def __post_init__(self) -> None:
         self.eval_slots = asyncio.Semaphore(self.config.eval_concurrency)
+
+    def release_run(self, build_id: int) -> None:
+        self.cancel_events.pop(build_id, None)
+        released, self._run_released = self._run_released, asyncio.Event()
+        released.set()
+
+    async def wait_idle(self, build_id: int) -> None:
+        """Return once no run owns build_id (holds its cancel_events slot)."""
+        while build_id in self.cancel_events:
+            await self._run_released.wait()
 
     def _log_dir(self, build_id: int) -> Path:
         return build_log_dir(self.config.state_dir, build_id)
@@ -339,7 +351,7 @@ class Orchestrator:
         )
         if outcome == RegisterOutcome.STALE:
             if rebuild:
-                self.cancel_events.pop(build.id_, None)
+                self.release_run(build.id_)
             if created:
                 await db.set_build_status(self.pool, build.id_, BuildStatus.CANCELLED)
                 await self.reporter.build_finished(
@@ -355,7 +367,7 @@ class Orchestrator:
             await self.run_build(event, build, worktree_path, credentials)
         finally:
             self.canceller.complete(build.id_)
-            self.cancel_events.pop(build.id_, None)
+            self.release_run(build.id_)
             self.linked_events.pop(build.id_, None)
 
     async def run_build(

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -73,17 +73,10 @@ async def rerun_pending_attributes(
     the stored eval results — no re-evaluation (attribute restarts
     and crash recovery)."""
     if build.id_ in o.cancel_events:
-        # Already running. A concurrent rerun would double-write
-        # attribute completions.
-        return
-    # Claim the slot before the first await. Concurrent reruns
-    # must not pass the guard together.
+        msg = f"build {build.id_} still has a live run"
+        raise RuntimeError(msg)
     cancel_event = o.cancel_events[build.id_] = asyncio.Event()
     try:
-        current = await builds_q.get_build(o.pool, id_=build.id_)
-        if current is not None and current.status == "cancelled":
-            # Cancelled between scheduling the rerun and getting here.
-            return
         # Pending rows for systems no longer in build_systems would
         # stay non-terminal forever: the scheduler drops their jobs.
         # Drop the rows too (same as never recording them).
@@ -135,7 +128,7 @@ async def rerun_pending_attributes(
                 await o.refresh_schedules(event)
     finally:
         o.canceller.complete(build.id_)
-        o.cancel_events.pop(build.id_, None)
+        o.release_run(build.id_)
 
 
 async def _rerun_names(
@@ -216,4 +209,4 @@ async def rerun_effects(
         # The enqueued effect items share this build's key and only
         # become claimable once this item finishes.
     finally:
-        o.cancel_events.pop(build.id_, None)
+        o.release_run(build.id_)

--- a/nixbot/nixbot/restart_dispatch.py
+++ b/nixbot/nixbot/restart_dispatch.py
@@ -1,12 +1,12 @@
-"""Build rerun paths driven from the work queue: resuming pending
-attributes from stored eval results, falling back to re-evaluation,
-and effects-only restarts. State resets happen synchronously in the
-service. This module only re-executes.
+"""Build rerun paths driven from the work queue: restarts, resuming
+pending attributes from stored eval results, falling back to
+re-evaluation, and effects-only restarts. A build's rows have a single
+writer, so restart resets happen here once the previous run released
+the build, never from the request handler.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -14,7 +14,7 @@ from . import db
 from .db import BuildStatus
 from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
-from .events import BuildResult, ChangeEvent, EvalReport
+from .events import BuildResult, ChangeEvent, EvalReport, event_for_build
 from .recovery import check_store_paths, find_unfinished_builds
 from .repos import repo_info
 
@@ -27,11 +27,6 @@ if TYPE_CHECKING:
     from .service import CIService
 
 logger = logging.getLogger(__name__)
-
-# Pause before handing a rerun of a still-unwinding build back to
-# the work queue. Bounds the retry cadence without holding the
-# dedup key indefinitely.
-UNWIND_RETRY_SECONDS = 0.5
 
 
 async def restart_effects(s: CIService, build_id: int, name: str | None = None) -> None:
@@ -48,32 +43,38 @@ async def restart_effects(s: CIService, build_id: int, name: str | None = None) 
     await s.orchestrator.rerun_effects(info, build, credentials, only=name)
 
 
-async def rerun(s: CIService, build_id: int) -> bool:
+async def rerun(
+    s: CIService, build_id: int, *, restart: bool = False, attr: str | None = None
+) -> None:
     """Resume the pending attributes of a build from stored eval
-    results, falling back to a re-evaluation. Returns True when the
-    previous run is still unwinding and the rerun must be retried
-    (rerun_pending_attributes would drop it on the floor)."""
-    # Serialized by the work queue's per-build dedup key.
-    if build_id in s.orchestrator.cancel_events:
-        await asyncio.sleep(UNWIND_RETRY_SECONDS)
-        if build_id in s.orchestrator.cancel_events:
-            return True
-    build = await builds_q.get_build(s.orchestrator.pool, id_=build_id)
+    results, falling back to a re-evaluation. With `restart`, first
+    reset the build (or one attribute) to pending."""
+    o = s.orchestrator
+    # Single writer: never reset or rerun under a live run.
+    await o.wait_idle(build_id)
+    build = await builds_q.get_build(o.pool, id_=build_id)
     if build is None:
-        return False
+        return
     project = await s.repo_store.by_id(build.project_id)
     if project is None:
-        return False
+        return
     info = repo_info(project)
+    if restart:
+        await q.reset_build_for_restart(o.pool, build_id=build_id, attr=attr)
+        o.reset_build_logs(build_id, attr)
+        build = await builds_q.get_build(o.pool, id_=build_id)
+        if build is None:
+            return
+        await o.reporter.build_restarted(event_for_build(info, build), build, attr)
     credentials = await s.credentials_provider(info.forge).get(info.clone_url)
     results = await find_unfinished_builds(s.pool, build_id=build_id)
     resumable = results[0] if results else None
     if resumable is None:
-        return False
+        return
     jobs = await _resumable_eval_jobs(s, build, resumable)
     if jobs is not None:
-        await s.orchestrator.rerun_pending_attributes(info, build, jobs, credentials)
-        return False
+        await o.rerun_pending_attributes(info, build, jobs, credentials)
+        return
     # No usable stored eval: re-evaluate rather than rerun an empty set
     # that would aggregate straight to "succeeded".
     try:
@@ -87,7 +88,6 @@ async def rerun(s: CIService, build_id: int) -> bool:
             error="re-evaluation failed; see service logs",
         )
         await _report_interrupted(s, resumable)
-    return False
 
 
 async def _resumable_eval_jobs(
@@ -135,7 +135,7 @@ async def _reeval(
         ):
             await s.orchestrator.run_build(event, build, worktree_path)
     finally:
-        s.orchestrator.cancel_events.pop(build.id_, None)
+        s.orchestrator.release_run(build.id_)
 
 
 async def change_event_for(

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -362,22 +362,19 @@ class CIService:
         await self._restart(build_id, attr=attr)
 
     async def _restart(self, build_id: int, *, attr: str | None) -> None:
-        # Reset synchronously so the build row is the source of truth
-        # for the UI/recovery. The queue item is only a wake-up. Drop
-        # the previous run's logs here too, so the pending row does not
-        # show stale output until the rebuild starts.
-        await q.reset_build_for_restart(self.pool, build_id=build_id, attr=attr)
-        self.orchestrator.reset_build_logs(build_id, attr)
-        # Flip the forge checks to pending now. The async rerun only
-        # posts the terminal status, possibly much later.
-        build = await builds_q.get_build(self.pool, id_=build_id)
-        project = (
-            await self.repo_store.by_id(build.project_id) if build is not None else None
+        # Cancel a live run. The work item resets once it released the build.
+        cancel = (
+            self.orchestrator.cancel_events.get(build_id)
+            if attr is None
+            else self.orchestrator.attr_cancel_events.get((build_id, attr))
         )
-        if build is not None and project is not None:
-            event = event_for_build(repo_info(project), build)
-            await self.orchestrator.reporter.build_restarted(event, build, attr)
-        await self.enqueue_work("rerun", f"build-{build_id}", {"build_id": build_id})
+        if cancel is not None:
+            cancel.set()
+        await self.enqueue_work(
+            "rerun",
+            f"build-{build_id}",
+            {"build_id": build_id, "restart": True, "attr": attr},
+        )
 
     async def restart_effects(self, build_id: int, name: str | None = None) -> None:
         # Per-build dedup key: single-effect and full reruns serialize.
@@ -459,10 +456,12 @@ class CIService:
         if item.kind == "change":
             await self._process_change(ChangeRequest(**payload))
         elif item.kind == "rerun":
-            # Resume pending attributes (restart and crash recovery).
-            if await restart_dispatch.rerun(self, payload["build_id"]):
-                # Previous run still unwinding. Retry, don't drop.
-                await self.enqueue_work("rerun", item.dedup_key, payload)
+            await restart_dispatch.rerun(
+                self,
+                payload["build_id"],
+                restart=payload.get("restart", False),
+                attr=payload.get("attr"),
+            )
         elif item.kind == "effects":
             await restart_dispatch.restart_effects(
                 self, payload["build_id"], payload.get("name")

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -623,9 +623,21 @@ async def test_build_service_composition(postgres_dsn: str, tmp_path: Path) -> N
         await service.pool.close()
 
 
-async def test_restart_removes_stale_logs(postgres_dsn: str, tmp_path: Path) -> None:
+def skip_reeval(monkeypatch: pytest.MonkeyPatch) -> None:
+    """These tests cover the restart reset, not the re-evaluation."""
+
+    async def noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("nixbot.restart_dispatch._reeval", noop)
+
+
+async def test_restart_removes_stale_logs(
+    postgres_dsn: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A restart drops the previous run's log metadata and on-disk file
     at reset time, so the pending row does not show stale output."""
+    skip_reeval(monkeypatch)
     config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
@@ -644,6 +656,7 @@ async def test_restart_removes_stale_logs(postgres_dsn: str, tmp_path: Path) -> 
         log_file.write_bytes(b"stale log")
 
         await service.restart_build(build_id)
+        await service.drain_work()
 
         assert (
             await pool.fetchval(
@@ -656,9 +669,10 @@ async def test_restart_removes_stale_logs(postgres_dsn: str, tmp_path: Path) -> 
         await pool.close()
 
 
-async def test_restart_clears_failed_cache_immediately(
-    postgres_dsn: str, tmp_path: Path
+async def test_restart_clears_failed_cache(
+    postgres_dsn: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    skip_reeval(monkeypatch)
     config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
@@ -679,9 +693,12 @@ async def test_restart_clears_failed_cache_immediately(
             project_id,
         )
 
-        # Reset is synchronous: cache cleared and rows pending
-        # before any worker runs.
         await service.restart_build(build_id)
+        assert (
+            await pool.fetchval("SELECT kind FROM work_queue WHERE status = 'pending'")
+            == "rerun"
+        )
+        await service.drain_work()
         assert await pool.fetchval("SELECT count(*) FROM failed_builds") == 0
         assert (
             await pool.fetchval(
@@ -693,10 +710,6 @@ async def test_restart_clears_failed_cache_immediately(
         assert (
             await pool.fetchval("SELECT status FROM builds WHERE id = $1", build_id)
             == "pending"
-        )
-        assert (
-            await pool.fetchval("SELECT kind FROM work_queue WHERE status = 'pending'")
-            == "rerun"
         )
     finally:
         await pool.close()
@@ -892,10 +905,11 @@ async def test_effect_item_setup_failure_settles_row(
 
 
 async def test_restart_attribute_posts_pending(
-    postgres_dsn: str, tmp_path: Path
+    postgres_dsn: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Re-run on the forge must flip the check to pending immediately,
-    not only when the async rebuild finishes."""
+    """Re-run on the forge must flip the check to pending when the
+    reset lands, not only when the async rebuild finishes."""
+    skip_reeval(monkeypatch)
     config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
     pool = service.pool
@@ -922,6 +936,7 @@ async def test_restart_attribute_posts_pending(
         service.orchestrator.reporter = FakeReporter()
 
         await service.restart_attribute(build_id, "x86_64-linux.a")
+        await service.drain_work()
 
         assert restarts == [(build_id, "x86_64-linux.a")]
     finally:

--- a/nixbot/nixbot/tests/test_service.py
+++ b/nixbot/nixbot/tests/test_service.py
@@ -21,15 +21,22 @@ from nixbot.config import (
     PullBasedRepository,
     resolve_credential_path,
 )
+from nixbot.db_gen import builds as builds_q
 from nixbot.events import BuildResult, NullStatusReporter
 from nixbot.forge import DiscoveredRepo
 from nixbot.schedule_runner import scheduled_worktree_id
 from nixbot.schedules import DueEffect, ScheduleWhen
 from nixbot.status import CheckRunStore
 from nixbot.webhooks import ChangeRequest, CheckRerequested, PrClosed
-from nixbot.work_queue import WorkQueue
 
-from .support import FakeGitlab, git, insert_build, insert_project, make_config
+from .support import (
+    FakeGitlab,
+    git,
+    insert_build,
+    insert_project,
+    make_config,
+    mk_job,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
@@ -332,10 +339,6 @@ async def test_restart_eval_failed_build_reevaluates(
 
     service.orchestrator.run_build = fake_run_build  # type: ignore[method-assign]
     await service.restart_build(build_id)
-    # The reset is synchronous: the build row is the source of
-    # truth before any worker runs (issue #28).
-    status = await pool.fetchval("SELECT status FROM builds WHERE id = $1", build_id)
-    assert status == "pending"
     await service.drain_work()
     await asyncio.gather(*service._tasks)  # noqa: SLF001
 
@@ -425,12 +428,12 @@ async def test_restart_failed_eval_attribute_reevaluates(
 
     reevals = capture_run_build(service)
     await service.restart_build(build_id)
-    status = await pool.fetchval("SELECT status FROM builds WHERE id = $1", build_id)
-    assert status == "pending"
     await service.drain_work()
     await asyncio.gather(*service._tasks)  # noqa: SLF001
 
     assert reevals == [build_id]
+    status = await pool.fetchval("SELECT status FROM builds WHERE id = $1", build_id)
+    assert status == "pending"
     # The stale row survives until a successful eval commits its
     # result. Interrupted re-evals must never lose rows.
     count = await pool.fetchval(
@@ -566,10 +569,9 @@ async def test_restart_while_unwinding_waits_then_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Restart clicked while the old run is still unwinding (e.g.
-    right after a cancel) resets state immediately. The rerun must
-    requeue until the slot clears, not be dropped silently."""
+    right after a cancel) must neither reset rows under that run nor
+    drop the rerun: it waits for the run to release the build."""
     repo, sha = git_repo
-    monkeypatch.setattr("nixbot.restart_dispatch.UNWIND_RETRY_SECONDS", 0.0)
 
     pool = service.pool
     project_id = await seed_project(pool, str(repo))
@@ -599,28 +601,96 @@ async def test_restart_while_unwinding_waits_then_runs(
     # Simulate the cancelled run still unwinding.
     service.orchestrator.cancel_events[build_id] = asyncio.Event()
     await service.restart_build(build_id)
-    # Reset already applied. The UI sees pending without a worker.
+    drain = asyncio.create_task(service.drain_work())
+    await asyncio.sleep(0.05)
+    assert not drain.done()
+    assert rescheduled == []
+    assert (
+        await pool.fetchval("SELECT status FROM builds WHERE id = $1", build_id)
+        == "cancelled"
+    )
+
+    # Old run finished. The waiting rerun now resets and goes through.
+    service.orchestrator.release_run(build_id)
+    await drain
+    await asyncio.gather(*service._tasks)  # noqa: SLF001
+    assert rescheduled == [build_id]
     assert (
         await pool.fetchval("SELECT status FROM builds WHERE id = $1", build_id)
         == "pending"
     )
 
-    queue = WorkQueue(pool)
-    item = await queue.claim_next()
-    assert item is not None
-    assert item.kind == "rerun"
-    await service._execute_work(queue, item)  # noqa: SLF001
-    assert rescheduled == []  # deferred, not executed
-    pending = await pool.fetchval(
-        "SELECT count(*) FROM work_queue WHERE kind = 'rerun' AND status = 'pending'"
-    )
-    assert pending == 1  # the intent survived
 
-    # Old run finished. The queued rerun now goes through.
-    del service.orchestrator.cancel_events[build_id]
-    await service.drain_work()
+async def test_restart_attribute_while_build_running(
+    service: CIService, git_repo: tuple[Path, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Restarting one attribute of a build that is still running must
+    not reset rows under the live run. Otherwise the run finishes onto
+    the reset rows: nothing re-executes and the build ends terminal
+    with started_at NULL ("took \u2014" in the UI)."""
+    from nixbot.repos import repo_info  # noqa: PLC0415
+
+    from .test_orchestrator import FakeExecutor  # noqa: PLC0415
+
+    repo, sha = git_repo
+
+    async def all_valid(paths: list[str]) -> set[str]:
+        return set(paths)
+
+    monkeypatch.setattr("nixbot.restart_dispatch.check_store_paths", all_valid)
+
+    pool = service.pool
+    project_id = await seed_project(pool, str(repo))
+    build_id = await insert_build(
+        pool, project_id, commit_sha=sha, status="pending", eval_completed=True
+    )
+    await pool.execute(
+        "INSERT INTO build_attributes (build_id, attr, system, status, drv_path) "
+        "VALUES ($1, 'a', 'x86_64-linux', 'pending', '/nix/store/a.drv'), "
+        "($1, 'b', 'x86_64-linux', 'pending', '/nix/store/b.drv')",
+        build_id,
+    )
+    executor = FakeExecutor(gate=asyncio.Event())
+    service.orchestrator.executor = executor
+    project = await service.repo_store.by_id(project_id)
+    assert project is not None
+    build = await builds_q.get_build(pool, id_=build_id)
+    assert build is not None
+
+    run = asyncio.create_task(
+        service.orchestrator.rerun_pending_attributes(
+            repo_info(project), build, [mk_job("a"), mk_job("b")]
+        )
+    )
+    await asyncio.wait_for(executor.started.wait(), timeout=10)
+
+    await service.restart_attribute(build_id, "a")
+    drain = asyncio.create_task(service.drain_work())
+    # The restart must not have touched rows owned by the live run.
+    assert (
+        await pool.fetchval("SELECT status FROM builds WHERE id = $1", build_id)
+        == "building"
+    )
+    assert executor.gate is not None
+    executor.gate.set()
+    await run
+    await drain
     await asyncio.gather(*service._tasks)  # noqa: SLF001
-    assert rescheduled == [build_id]
+
+    row = await pool.fetchrow(
+        "SELECT status, started_at, finished_at FROM builds WHERE id = $1", build_id
+    )
+    assert row["status"] == "succeeded"
+    assert row["started_at"] is not None
+    assert row["finished_at"] >= row["started_at"]
+    attr = await pool.fetchrow(
+        "SELECT status, started_at FROM build_attributes "
+        "WHERE build_id = $1 AND attr = 'a'",
+        build_id,
+    )
+    assert (attr["status"], attr["started_at"] is not None) == ("succeeded", True)
+    # 'a' ran in the original run and again for the restart.
+    assert sorted(executor.built) == ["a", "a", "b"]
 
 
 # --- cancel of a non-running build ---------------------------------------


### PR DESCRIPTION
Restarting an attribute of a running build reset its rows underneath the live run, which then finished onto them: nothing re-ran and the build ended with started_at NULL ("took —").

Restart now only cancels the live run and enqueues. The work item waits for release_run() and then resets and reruns, so a build's rows have one writer. Removes the UNWIND_RETRY poll and the in-flight guards in rerun_pending_attributes.