### PR TITLE
nix-eval-jobs: bump for per-attribute eval stats

### DIFF
--- a/packages/nix-eval-jobs.nix
+++ b/packages/nix-eval-jobs.nix
@@ -77,8 +77,8 @@ in
 }).overrideAttrs
   (
     _finalAttrs: prevAttrs: {
-      # unreleased main: memory budget scheduler and per-attribute warnings
-      version = "2.35.2-unstable-2026-08-30";
+      # unreleased main: memory budget scheduler, per-attribute warnings and stats
+      version = "2.35.2-unstable-2026-09-01";
       buildInputs = (prevAttrs.buildInputs or [ ]) ++ [ pkgs.mimalloc ];
       # The nix CLI nixbot runs (flake prefetch-inputs/archive) must carry
       # the same patches, so expose it alongside nix-eval-jobs.
@@ -88,8 +88,8 @@ in
       src = fetchFromGitHub {
         owner = "NixOS";
         repo = "nix-eval-jobs";
-        rev = "c026cff507d3f5ea067098d323a2f29e2f634c2f";
-        hash = "sha256-FKXrE2qHTHVA7xOHFH+Grm+EaF9Hk+JrTi6VBHrvSuI=";
+        rev = "55e658518ae417cf26f36643fcfdebe5c5db17aa";
+        hash = "sha256-4z5GnNd9cbkKChaovYghlxuh1k5rYlxNT7wpZeR1oU0=";
       };
     }
   )


### PR DESCRIPTION

<details>
<summary>
Committer details
</summary>
Local-Branch: eval-stats
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Record eval duration and per-attribute eval stats (<a href="https://github.com/Mic92/nixbot/pull/176">#176</a>)
</summary>
nix-eval-jobs now reports wallMs/allocBytes per attribute. Store them
on build_attributes and the nix-eval-jobs runtime on builds so the UI
can answer 'how long did eval take' and 'which attrs are expensive'
(#162).

eval_duration_ms shares eval_completed's lifetime: set in
CommitEvalResult, cleared by SetBuildStatus('pending'), kept across
restarts that rebuild from stored rows, NULL for reused evals.

CompleteAttribute now COALESCEs eval data, which also stops dropping
eval warnings of failed_eval attributes.
</details>
<details>
<summary>
Show eval duration in build header, forge status, API, CLI and metrics (<a href="https://github.com/Mic92/nixbot/pull/177">#177</a>)
</summary>
Closes #162.
</details>
<details>
<summary>
Show per-attribute eval stats on row tooltip, log page and history (<a href="https://github.com/Mic92/nixbot/pull/178">#178</a>)
</summary>

</details>
<details>
<summary>
Add per-build evaluation page listing attribute eval cost (<a href="https://github.com/Mic92/nixbot/pull/179">#179</a>)
</summary>
Linked from the eval duration in the build header. Sortable by time
or allocation so expensive attributes can be found without adding
columns to the build page.
</details>
</details>
</details>