### PR TITLE
[need #175] Record eval duration and per-attribute eval stats

### DIFF
--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import dataclasses
 import json
 import logging
 import shutil
@@ -54,16 +55,30 @@ logger = logging.getLogger(__name__)
 LIVE_WARNINGS_FLUSH_INTERVAL = 2.0
 
 
-def _job_columns(
-    jobs: Sequence[NixEvalJob],
-) -> tuple[list[str], list[str], list[str], list[str], list[str]]:
+@dataclasses.dataclass
+class _JobColumns:
+    attrs: list[str]
+    systems: list[str]
+    drv_paths: list[str]
+    outputs: list[str]
+    eval_warnings: list[str]
+    # -1 stands for NULL so the arrays stay int-typed for asyncpg.
+    eval_wall_ms: list[int]
+    eval_alloc_bytes: list[int]
+
+
+def _job_columns(jobs: Sequence[NixEvalJob]) -> _JobColumns:
     successes = [job for job in jobs if isinstance(job, NixEvalJobSuccess)]
-    return (
-        [job.attr for job in successes],
-        [job.system for job in successes],
-        [job.drv_path for job in successes],
-        [json.dumps(job.outputs) for job in successes],
-        [json.dumps(job.warnings or None) for job in successes],
+    return _JobColumns(
+        attrs=[job.attr for job in successes],
+        systems=[job.system for job in successes],
+        drv_paths=[job.drv_path for job in successes],
+        outputs=[json.dumps(job.outputs) for job in successes],
+        eval_warnings=[json.dumps(job.warnings or None) for job in successes],
+        eval_wall_ms=[job.stats.wall_ms if job.stats else -1 for job in successes],
+        eval_alloc_bytes=[
+            job.stats.alloc_bytes if job.stats else -1 for job in successes
+        ],
     )
 
 
@@ -72,34 +87,27 @@ async def record_attributes(
 ) -> None:
     """Persist eval results as pending rows so crash recovery can
     resume without a re-eval."""
-    attrs, systems, drv_paths, outputs, warnings = _job_columns(jobs)
-    if not attrs:
+    cols = _job_columns(jobs)
+    if not cols.attrs:
         return
-    await q.record_attributes(
-        pool,
-        build_id=build_id,
-        attrs=attrs,
-        systems=systems,
-        drv_paths=drv_paths,
-        outputs=outputs,
-        eval_warnings=warnings,
-    )
+    await q.record_attributes(pool, build_id=build_id, **dataclasses.asdict(cols))
 
 
 async def commit_eval_result(
-    pool: asyncpg.Pool, build_id: int, jobs: Sequence[NixEvalJob]
+    pool: asyncpg.Pool,
+    build_id: int,
+    jobs: Sequence[NixEvalJob],
+    duration_ms: int | None = None,
 ) -> None:
     """Publish a completed eval: the only operation that may shrink
-    the attribute set."""
-    attrs, systems, drv_paths, outputs, warnings = _job_columns(jobs)
+    the attribute set. duration_ms is None when the jobs were not
+    produced by this build (eval reuse)."""
+    cols = _job_columns(jobs)
     await mq.commit_eval_result(
         pool,
         build_id=build_id,
-        attrs=attrs,
-        systems=systems,
-        drv_paths=drv_paths,
-        outputs=outputs,
-        eval_warnings=warnings,
+        eval_duration_ms=duration_ms,
+        **dataclasses.asdict(cols),
     )
 
 
@@ -243,7 +251,7 @@ async def _record_eval_success(
     o: Orchestrator,
     event: ChangeEvent,
     build: BuildRecord,
-    jobs: Sequence[NixEvalJob],
+    result: EvalResult,
     live_warnings: LiveWarningAggregator,
 ) -> None:
     """Persist a completed evaluation and report it to the forge."""
@@ -251,10 +259,10 @@ async def _record_eval_success(
     # pending forever.
     buildable = [
         job
-        for job in jobs
+        for job in result.jobs
         if isinstance(job, NixEvalJobSuccess) and job.system in o.config.build_systems
     ]
-    await commit_eval_result(o.pool, build.id_, buildable)
+    await commit_eval_result(o.pool, build.id_, buildable, result.duration_ms)
     await o.reporter.eval_finished(
         event,
         build,
@@ -407,7 +415,7 @@ async def _run_build_inner(
                     o.pool, id_=build.id_, warnings=json.dumps(live_warnings.snapshot())
                 )
         await db.set_build_status(o.pool, build.id_, BuildStatus.BUILDING)
-        await _record_eval_success(o, event, build, eval_result.jobs, live_warnings)
+        await _record_eval_success(o, event, build, eval_result, live_warnings)
 
         # Re-send the complete eval result: the scheduler dedupes
         # by attr, so this only schedules jobs a streamed batch

--- a/nixbot/nixbot/db.py
+++ b/nixbot/nixbot/db.py
@@ -22,7 +22,7 @@ import json
 from typing import TYPE_CHECKING
 
 from .db_gen import builds as q
-from .models import CacheStatus, NixEvalJobSuccess
+from .models import CacheStatus, NixEvalJobError, NixEvalJobSuccess
 from .sql_util import expect
 
 if TYPE_CHECKING:
@@ -154,6 +154,11 @@ async def complete_attribute(  # noqa: PLR0913
     metadata together (crash-recovery invariant). With
     if_unfinished, already-terminal rows are left untouched (early
     results must not overwrite settled attributes)."""
+    # failed_eval rows never went through RecordAttributes, so their
+    # eval data arrives here. Successes already have it.
+    job = result.job
+    warnings = job.warnings if isinstance(job, NixEvalJobError) else None
+    stats = job.stats if isinstance(job, NixEvalJobError) else None
     await q.complete_attribute(
         pool,
         build_id=build_id,
@@ -168,11 +173,14 @@ async def complete_attribute(  # noqa: PLR0913
         cached=result.status.value == "skipped_local"
         or (
             result.status.value == "succeeded"
-            and isinstance(result.job, NixEvalJobSuccess)
-            and result.job.cache_status == CacheStatus.cached
+            and isinstance(job, NixEvalJobSuccess)
+            and job.cache_status == CacheStatus.cached
         ),
         log_size=log_size,
         log_truncated=log_truncated,
+        eval_warnings=json.dumps(warnings) if warnings else None,
+        eval_wall_ms=stats.wall_ms if stats else None,
+        eval_alloc_bytes=stats.alloc_bytes if stats else None,
         if_unfinished=if_unfinished,
     )
 

--- a/nixbot/nixbot/db_gen/builds.py
+++ b/nixbot/nixbot/db_gen/builds.py
@@ -99,7 +99,7 @@ SELECT pg_advisory_xact_lock(hashtextextended($1::text, 0))
 """
 
 FIND_REUSABLE_BUILD: typing.Final[str] = """-- name: FindReusableBuild :one
-SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds WHERE project_id = $1 AND tree_hash = $2
+SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms FROM builds WHERE project_id = $1 AND tree_hash = $2
 AND status <> 'cancelled' ORDER BY id DESC LIMIT 1
 """
 
@@ -107,15 +107,15 @@ DETACH_BUILD_FROM_PR: typing.Final[str] = """-- name: DetachBuildFromPr :one
 UPDATE builds SET pr_number = NULL, pr_author = NULL,
     branch = CASE WHEN $2::bigint IS NULL
              THEN $3 ELSE branch END
-WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number
+WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms
 """
 
 ATTACH_BUILD_TO_PR: typing.Final[str] = """-- name: AttachBuildToPr :one
-UPDATE builds SET pr_number = $2, pr_author = $3 WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number
+UPDATE builds SET pr_number = $2, pr_author = $3 WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms
 """
 
 BACKFILL_PR_AUTHOR: typing.Final[str] = """-- name: BackfillPrAuthor :one
-UPDATE builds SET pr_author = $2 WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number
+UPDATE builds SET pr_author = $2 WHERE id = $1 RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms
 """
 
 CREATE_BUILD: typing.Final[str] = """-- name: CreateBuild :one
@@ -130,7 +130,7 @@ SELECT $1::bigint, n.number, $2::text,
        $3::text, $4::text,
        $5::bigint, $6::text
 FROM n
-RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number
+RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms
 """
 
 CREATE_FAILED_BUILD: typing.Final[str] = """-- name: CreateFailedBuild :one
@@ -145,22 +145,28 @@ SELECT $1::bigint, n.number, $2::text,
        $3::text, $4::bigint,
        $5::text, 'failed', $6::text, now()
 FROM n
-RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number
+RETURNING id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms
 """
 
 RECORD_ATTRIBUTES: typing.Final[str] = """-- name: RecordAttributes :exec
-INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, eval_warnings, status)
-SELECT $1::bigint, u.attr, u.system, u.drv_path, u.outputs, NULLIF(u.eval_warnings, 'null'::jsonb), 'pending'
+INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs,
+    eval_warnings, eval_wall_ms, eval_alloc_bytes, status)
+SELECT $1::bigint, u.attr, u.system, u.drv_path, u.outputs,
+    NULLIF(u.eval_warnings, 'null'::jsonb), NULLIF(u.eval_wall_ms, -1), NULLIF(u.eval_alloc_bytes, -1), 'pending'
 FROM (SELECT unnest($2::text[]) AS attr,
              unnest($3::text[]) AS system,
              unnest($4::text[]) AS drv_path,
              unnest($5::jsonb[]) AS outputs,
-             unnest($6::jsonb[]) AS eval_warnings) u
+             unnest($6::jsonb[]) AS eval_warnings,
+             unnest($7::int[]) AS eval_wall_ms,
+             unnest($8::bigint[]) AS eval_alloc_bytes) u
 ON CONFLICT (build_id, attr) DO UPDATE SET
     system = EXCLUDED.system,
     drv_path = EXCLUDED.drv_path,
     outputs = EXCLUDED.outputs,
-    eval_warnings = EXCLUDED.eval_warnings
+    eval_warnings = EXCLUDED.eval_warnings,
+    eval_wall_ms = EXCLUDED.eval_wall_ms,
+    eval_alloc_bytes = EXCLUDED.eval_alloc_bytes
 WHERE build_attributes.status IN ('pending', 'building')
 """
 
@@ -183,6 +189,9 @@ SET status = $1,
     error = CASE
         WHEN $1 = 'pending' THEN NULL
         ELSE COALESCE($2, error)
+    END,
+    eval_duration_ms = CASE
+        WHEN $1 = 'pending' THEN NULL ELSE eval_duration_ms
     END,
     eval_warnings = CASE
         WHEN $1 = 'pending' THEN NULL ELSE eval_warnings
@@ -217,7 +226,7 @@ WHERE build_id = $1
 """
 
 GET_BUILD: typing.Final[str] = """-- name: GetBuild :one
-SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds WHERE id = $1
+SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms FROM builds WHERE id = $1
 """
 
 MARK_EFFECTS_STARTED: typing.Final[str] = """-- name: MarkEffectsStarted :one
@@ -249,11 +258,19 @@ RETURNING attr
 COMPLETE_ATTRIBUTE: typing.Final[str] = """-- name: CompleteAttribute :exec
 INSERT INTO build_attributes
     (build_id, attr, system, drv_path, outputs, status, error,
-     cached, log_size, log_truncated, finished_at)
+     cached, log_size, log_truncated, finished_at,
+     eval_warnings, eval_wall_ms, eval_alloc_bytes)
 VALUES ($1, $2, $3, $4, $8::jsonb, $5, $6, $7,
-        $9::bigint, $10::boolean, now())
+        $9::bigint, $10::boolean, now(),
+        $11::jsonb, $12::int,
+        $13::bigint)
 ON CONFLICT (build_id, attr) DO UPDATE SET
     status = EXCLUDED.status,
+    -- Eval data is only known by failed_eval inserts. Build
+    -- completions pass NULL and must keep what the eval recorded.
+    eval_warnings = COALESCE(EXCLUDED.eval_warnings, build_attributes.eval_warnings),
+    eval_wall_ms = COALESCE(EXCLUDED.eval_wall_ms, build_attributes.eval_wall_ms),
+    eval_alloc_bytes = COALESCE(EXCLUDED.eval_alloc_bytes, build_attributes.eval_alloc_bytes),
     -- Eval recorded the full outputs map (multi-output drvs);
     -- merge the freshly-known "out" path into it instead of
     -- replacing it, and never NULL an existing map when no out
@@ -269,7 +286,7 @@ ON CONFLICT (build_id, attr) DO UPDATE SET
     log_size = EXCLUDED.log_size,
     log_truncated = EXCLUDED.log_truncated,
     finished_at = now()
-WHERE NOT $11::boolean
+WHERE NOT $14::boolean
     OR build_attributes.status IN ('pending', 'building')
 """
 
@@ -426,6 +443,7 @@ async def find_reusable_build(conn: ConnectionLike, *, project_id: int, tree_has
         effects_commit_sha=row[17],
         effects_branch=row[18],
         effects_pr_number=row[19],
+        eval_duration_ms=row[20],
     )
 
 
@@ -454,6 +472,7 @@ async def detach_build_from_pr(conn: ConnectionLike, *, id_: int, pr_number: int
         effects_commit_sha=row[17],
         effects_branch=row[18],
         effects_pr_number=row[19],
+        eval_duration_ms=row[20],
     )
 
 
@@ -482,6 +501,7 @@ async def attach_build_to_pr(conn: ConnectionLike, *, id_: int, pr_number: int |
         effects_commit_sha=row[17],
         effects_branch=row[18],
         effects_pr_number=row[19],
+        eval_duration_ms=row[20],
     )
 
 
@@ -510,6 +530,7 @@ async def backfill_pr_author(conn: ConnectionLike, *, id_: int, pr_author: str |
         effects_commit_sha=row[17],
         effects_branch=row[18],
         effects_pr_number=row[19],
+        eval_duration_ms=row[20],
     )
 
 
@@ -538,6 +559,7 @@ async def create_build(conn: ConnectionLike, *, project_id: int, tree_hash: str 
         effects_commit_sha=row[17],
         effects_branch=row[18],
         effects_pr_number=row[19],
+        eval_duration_ms=row[20],
     )
 
 
@@ -566,11 +588,23 @@ async def create_failed_build(conn: ConnectionLike, *, project_id: int, commit_s
         effects_commit_sha=row[17],
         effects_branch=row[18],
         effects_pr_number=row[19],
+        eval_duration_ms=row[20],
     )
 
 
-async def record_attributes(conn: ConnectionLike, *, build_id: int, attrs: collections.abc.Sequence[str], systems: collections.abc.Sequence[str], drv_paths: collections.abc.Sequence[str], outputs: collections.abc.Sequence[str], eval_warnings: collections.abc.Sequence[str]) -> None:
-    await conn.execute(RECORD_ATTRIBUTES, build_id, attrs, systems, drv_paths, outputs, eval_warnings)
+async def record_attributes(
+    conn: ConnectionLike,
+    *,
+    build_id: int,
+    attrs: collections.abc.Sequence[str],
+    systems: collections.abc.Sequence[str],
+    drv_paths: collections.abc.Sequence[str],
+    outputs: collections.abc.Sequence[str],
+    eval_warnings: collections.abc.Sequence[str],
+    eval_wall_ms: collections.abc.Sequence[int],
+    eval_alloc_bytes: collections.abc.Sequence[int],
+) -> None:
+    await conn.execute(RECORD_ATTRIBUTES, build_id, attrs, systems, drv_paths, outputs, eval_warnings, eval_wall_ms, eval_alloc_bytes)
 
 
 async def set_eval_warnings(conn: ConnectionLike, *, id_: int, warnings: str) -> None:
@@ -620,6 +654,7 @@ async def get_build(conn: ConnectionLike, *, id_: int) -> models.Build | None:
         effects_commit_sha=row[17],
         effects_branch=row[18],
         effects_pr_number=row[19],
+        eval_duration_ms=row[20],
     )
 
 
@@ -641,8 +676,25 @@ async def mark_attribute_building(conn: ConnectionLike, *, build_id: int, attr: 
     return row[0]
 
 
-async def complete_attribute(conn: ConnectionLike, *, build_id: int, attr: str, system: str | None, drv_path: str | None, status: str, error: str | None, cached: bool, outputs: str | None, log_size: int, log_truncated: bool, if_unfinished: bool) -> None:
-    await conn.execute(COMPLETE_ATTRIBUTE, build_id, attr, system, drv_path, status, error, cached, outputs, log_size, log_truncated, if_unfinished)
+async def complete_attribute(
+    conn: ConnectionLike,
+    *,
+    build_id: int,
+    attr: str,
+    system: str | None,
+    drv_path: str | None,
+    status: str,
+    error: str | None,
+    cached: bool,
+    outputs: str | None,
+    log_size: int,
+    log_truncated: bool,
+    eval_warnings: str | None,
+    eval_wall_ms: int | None,
+    eval_alloc_bytes: int | None,
+    if_unfinished: bool,
+) -> None:
+    await conn.execute(COMPLETE_ATTRIBUTE, build_id, attr, system, drv_path, status, error, cached, outputs, log_size, log_truncated, eval_warnings, eval_wall_ms, eval_alloc_bytes, if_unfinished)
 
 
 async def start_effect(conn: ConnectionLike, *, build_id: int, name: str, status: str) -> None:

--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -130,25 +130,33 @@ WHERE build_id = $1 AND status IN ('pending', 'building')
 
 COMMIT_EVAL_RESULT: typing.Final[str] = """-- name: CommitEvalResult :exec
 WITH new_rows AS (
-    INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, eval_warnings, status)
-    SELECT $1::bigint, u.attr, u.system, u.drv_path, u.outputs, NULLIF(u.eval_warnings, 'null'::jsonb), 'pending'
-    FROM (SELECT unnest($2::text[]) AS attr,
-                 unnest($3::text[]) AS system,
-                 unnest($4::text[]) AS drv_path,
-                 unnest($5::jsonb[]) AS outputs,
-                 unnest($6::jsonb[]) AS eval_warnings) u
+    INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs,
+        eval_warnings, eval_wall_ms, eval_alloc_bytes, status)
+    SELECT $2::bigint, u.attr, u.system, u.drv_path, u.outputs,
+        NULLIF(u.eval_warnings, 'null'::jsonb), NULLIF(u.eval_wall_ms, -1), NULLIF(u.eval_alloc_bytes, -1), 'pending'
+    FROM (SELECT unnest($3::text[]) AS attr,
+                 unnest($4::text[]) AS system,
+                 unnest($5::text[]) AS drv_path,
+                 unnest($6::jsonb[]) AS outputs,
+                 unnest($7::jsonb[]) AS eval_warnings,
+                 unnest($8::int[]) AS eval_wall_ms,
+                 unnest($9::bigint[]) AS eval_alloc_bytes) u
     ON CONFLICT (build_id, attr) DO UPDATE SET
         system = EXCLUDED.system,
         drv_path = EXCLUDED.drv_path,
         outputs = EXCLUDED.outputs,
-        eval_warnings = EXCLUDED.eval_warnings
+        eval_warnings = EXCLUDED.eval_warnings,
+        eval_wall_ms = EXCLUDED.eval_wall_ms,
+        eval_alloc_bytes = EXCLUDED.eval_alloc_bytes
     WHERE build_attributes.status IN ('pending', 'building')
 ), pruned AS (
-    DELETE FROM build_attributes WHERE build_id = $1
-    AND attr != ALL($2::text[])
+    DELETE FROM build_attributes WHERE build_id = $2
+    AND attr != ALL($3::text[])
     AND (status IN ('pending', 'building') OR drv_path IS NULL)
 )
-UPDATE builds SET eval_completed = TRUE WHERE builds.id = $1
+UPDATE builds SET eval_completed = TRUE,
+    eval_duration_ms = $1::bigint
+WHERE builds.id = $2
 """
 
 DELETE_ATTRIBUTES_BY_NAME: typing.Final[str] = """-- name: DeleteAttributesByName :exec
@@ -157,7 +165,7 @@ AND attr = ANY($2::text[])
 """
 
 FIND_UNFINISHED_BUILDS: typing.Final[str] = """-- name: FindUnfinishedBuilds :many
-SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds WHERE status = ANY($1::text[])
+SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms FROM builds WHERE status = ANY($1::text[])
 AND ($2::bigint IS NULL OR id = $2)
 ORDER BY id
 """
@@ -335,8 +343,20 @@ async def count_unfinished_attributes(conn: ConnectionLike, *, build_id: int) ->
     return row[0]
 
 
-async def commit_eval_result(conn: ConnectionLike, *, build_id: int, attrs: collections.abc.Sequence[str], systems: collections.abc.Sequence[str], drv_paths: collections.abc.Sequence[str], outputs: collections.abc.Sequence[str], eval_warnings: collections.abc.Sequence[str]) -> None:
-    await conn.execute(COMMIT_EVAL_RESULT, build_id, attrs, systems, drv_paths, outputs, eval_warnings)
+async def commit_eval_result(
+    conn: ConnectionLike,
+    *,
+    eval_duration_ms: int | None,
+    build_id: int,
+    attrs: collections.abc.Sequence[str],
+    systems: collections.abc.Sequence[str],
+    drv_paths: collections.abc.Sequence[str],
+    outputs: collections.abc.Sequence[str],
+    eval_warnings: collections.abc.Sequence[str],
+    eval_wall_ms: collections.abc.Sequence[int],
+    eval_alloc_bytes: collections.abc.Sequence[int],
+) -> None:
+    await conn.execute(COMMIT_EVAL_RESULT, eval_duration_ms, build_id, attrs, systems, drv_paths, outputs, eval_warnings, eval_wall_ms, eval_alloc_bytes)
 
 
 async def delete_attributes_by_name(conn: ConnectionLike, *, build_id: int, attrs: collections.abc.Sequence[str]) -> None:
@@ -366,6 +386,7 @@ def find_unfinished_builds(conn: ConnectionLike, *, statuses: collections.abc.Se
             effects_commit_sha=row[17],
             effects_branch=row[18],
             effects_pr_number=row[19],
+            eval_duration_ms=row[20],
         )
 
     return QueryResults(conn, FIND_UNFINISHED_BUILDS, _decode_hook, statuses, build_id)

--- a/nixbot/nixbot/db_gen/models.py
+++ b/nixbot/nixbot/db_gen/models.py
@@ -42,6 +42,7 @@ class Build:
     effects_commit_sha: str | None
     effects_branch: str | None
     effects_pr_number: int | None
+    eval_duration_ms: int | None
 
 
 @dataclasses.dataclass()
@@ -60,6 +61,8 @@ class BuildAttribute:
     log_size: int
     log_truncated: bool
     eval_warnings: str | None
+    eval_wall_ms: int | None
+    eval_alloc_bytes: int | None
 
 
 @dataclasses.dataclass()

--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -107,6 +107,7 @@ class WebRecentBuildsRow:
     effects_commit_sha: str | None
     effects_branch: str | None
     effects_pr_number: int | None
+    eval_duration_ms: int | None
     owner: str
     project_name: str
     forge: str
@@ -142,6 +143,8 @@ class WebAttributeHistoryRow:
     log_size: int
     log_truncated: bool
     eval_warnings: str | None
+    eval_wall_ms: int | None
+    eval_alloc_bytes: int | None
     build_number: int
     branch: str
     commit_sha: str
@@ -176,6 +179,7 @@ class WebQueueRow:
     effects_commit_sha: str | None
     effects_branch: str | None
     effects_pr_number: int | None
+    eval_duration_ms: int | None
     owner: str
     project_name: str
     forge: str
@@ -232,7 +236,7 @@ SELECT p.id, p.forge, p.forge_repo_id, p.owner, p.name, p.default_branch, p.url,
        h.history, m.median_secs, m.pass_rate
 FROM projects p
 LEFT JOIN LATERAL (
-    SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds b WHERE b.project_id = p.id
+    SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms FROM builds b WHERE b.project_id = p.id
       AND b.pr_number IS NULL AND b.branch = p.default_branch
     ORDER BY b.number DESC LIMIT 1
 ) lb ON true
@@ -278,7 +282,7 @@ ORDER BY p.owner, p.name
 """
 
 WEB_RECENT_BUILDS: typing.Final[str] = """-- name: WebRecentBuilds :many
-SELECT b.id, b.project_id, b.number, b.tree_hash, b.commit_sha, b.branch, b.pr_number, b.pr_author, b.status, b.status_generation, b.effects_started, b.error, b.created_at, b.started_at, b.finished_at, b.eval_warnings, b.eval_completed, b.effects_commit_sha, b.effects_branch, b.effects_pr_number, p.owner, p.name AS project_name, p.forge, p.url
+SELECT b.id, b.project_id, b.number, b.tree_hash, b.commit_sha, b.branch, b.pr_number, b.pr_author, b.status, b.status_generation, b.effects_started, b.error, b.created_at, b.started_at, b.finished_at, b.eval_warnings, b.eval_completed, b.effects_commit_sha, b.effects_branch, b.effects_pr_number, b.eval_duration_ms, p.owner, p.name AS project_name, p.forge, p.url
 FROM builds b JOIN projects p ON p.id = b.project_id
 WHERE ($1::bigint[] IS NULL OR b.project_id = ANY($1))
   AND ($2::bigint IS NULL OR b.id < $2)
@@ -286,7 +290,7 @@ ORDER BY b.id DESC LIMIT $3::bigint
 """
 
 WEB_BUILDS_FOR_REPO: typing.Final[str] = """-- name: WebBuildsForRepo :many
-SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds
+SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms FROM builds
 WHERE project_id = $1
   AND ($2::text IS NULL OR status = $2)
   AND ($3::text IS NULL OR branch = $3)
@@ -298,7 +302,7 @@ ORDER BY number DESC LIMIT $8 OFFSET $7
 """
 
 WEB_BUILD_BY_NUMBER: typing.Final[str] = """-- name: WebBuildByNumber :one
-SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number FROM builds WHERE project_id = $1 AND number = $2
+SELECT id, project_id, number, tree_hash, commit_sha, branch, pr_number, pr_author, status, status_generation, effects_started, error, created_at, started_at, finished_at, eval_warnings, eval_completed, effects_commit_sha, effects_branch, effects_pr_number, eval_duration_ms FROM builds WHERE project_id = $1 AND number = $2
 """
 
 WEB_NEIGHBOR_NUMBERS: typing.Final[str] = """-- name: WebNeighborNumbers :one
@@ -308,7 +312,7 @@ FROM builds WHERE project_id = $1
 """
 
 WEB_ATTRIBUTES: typing.Final[str] = """-- name: WebAttributes :many
-SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated, a.eval_warnings FROM build_attributes a
+SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated, a.eval_warnings, a.eval_wall_ms, a.eval_alloc_bytes FROM build_attributes a
 WHERE a.build_id = $1
 ORDER BY CASE
     WHEN a.status IN ('failed', 'failed_eval', 'dependency_failed',
@@ -321,7 +325,7 @@ END, a.attr
 """
 
 WEB_ATTRIBUTES_FINISHED_AFTER: typing.Final[str] = """-- name: WebAttributesFinishedAfter :many
-SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated, a.eval_warnings FROM build_attributes a
+SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated, a.eval_warnings, a.eval_wall_ms, a.eval_alloc_bytes FROM build_attributes a
 WHERE a.build_id = $1 AND a.finished_at IS NOT NULL
   AND ($2::timestamptz IS NULL
        OR (a.finished_at, a.id) > ($2::timestamptz,
@@ -345,7 +349,7 @@ GROUP BY status
 """
 
 WEB_ATTRIBUTE_PAGE: typing.Final[str] = """-- name: WebAttributePage :many
-SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated, a.eval_warnings FROM build_attributes a
+SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated, a.eval_warnings, a.eval_wall_ms, a.eval_alloc_bytes FROM build_attributes a
 WHERE a.build_id = $1 AND a.status = ANY($2::text[])
   AND ($3::text IS NULL OR a.attr ILIKE $3)
 ORDER BY (a.eval_warnings IS NULL), a.attr
@@ -353,7 +357,7 @@ LIMIT $5::bigint OFFSET $4::bigint
 """
 
 WEB_ATTRIBUTE_HISTORY: typing.Final[str] = """-- name: WebAttributeHistory :many
-SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated, a.eval_warnings, b.number AS build_number, b.branch, b.commit_sha,
+SELECT a.id, a.build_id, a.attr, a.system, a.drv_path, a.outputs, a.status, a.cached, a.error, a.started_at, a.finished_at, a.log_size, a.log_truncated, a.eval_warnings, a.eval_wall_ms, a.eval_alloc_bytes, b.number AS build_number, b.branch, b.commit_sha,
        b.created_at AS build_created_at
 FROM build_attributes a
 JOIN builds b ON b.id = a.build_id
@@ -370,7 +374,7 @@ WHERE b.project_id = $1 AND a.attr = $2
 """
 
 WEB_QUEUE: typing.Final[str] = """-- name: WebQueue :many
-SELECT b.id, b.project_id, b.number, b.tree_hash, b.commit_sha, b.branch, b.pr_number, b.pr_author, b.status, b.status_generation, b.effects_started, b.error, b.created_at, b.started_at, b.finished_at, b.eval_warnings, b.eval_completed, b.effects_commit_sha, b.effects_branch, b.effects_pr_number, p.owner, p.name AS project_name, p.forge, p.url,
+SELECT b.id, b.project_id, b.number, b.tree_hash, b.commit_sha, b.branch, b.pr_number, b.pr_author, b.status, b.status_generation, b.effects_started, b.error, b.created_at, b.started_at, b.finished_at, b.eval_warnings, b.eval_completed, b.effects_commit_sha, b.effects_branch, b.effects_pr_number, b.eval_duration_ms, p.owner, p.name AS project_name, p.forge, p.url,
        q.queue_position
 FROM builds b
 JOIN projects p ON p.id = b.project_id
@@ -534,10 +538,11 @@ def web_recent_builds(conn: ConnectionLike, *, project_ids: collections.abc.Sequ
             effects_commit_sha=row[17],
             effects_branch=row[18],
             effects_pr_number=row[19],
-            owner=row[20],
-            project_name=row[21],
-            forge=row[22],
-            url=row[23],
+            eval_duration_ms=row[20],
+            owner=row[21],
+            project_name=row[22],
+            forge=row[23],
+            url=row[24],
         )
 
     return QueryResults(conn, WEB_RECENT_BUILDS, _decode_hook, project_ids, before, limit_)
@@ -566,6 +571,7 @@ def web_builds_for_repo(conn: ConnectionLike, *, project_id: int, status: str | 
             effects_commit_sha=row[17],
             effects_branch=row[18],
             effects_pr_number=row[19],
+            eval_duration_ms=row[20],
         )
 
     return QueryResults(conn, WEB_BUILDS_FOR_REPO, _decode_hook, project_id, status, branch, pr_number, commit_prefix, before, offset, limit)
@@ -596,6 +602,7 @@ async def web_build_by_number(conn: ConnectionLike, *, project_id: int, number: 
         effects_commit_sha=row[17],
         effects_branch=row[18],
         effects_pr_number=row[19],
+        eval_duration_ms=row[20],
     )
 
 
@@ -608,14 +615,48 @@ async def web_neighbor_numbers(conn: ConnectionLike, *, project_id: int, number:
 
 def web_attributes(conn: ConnectionLike, *, build_id: int) -> QueryResults[models.BuildAttribute]:
     def _decode_hook(row: asyncpg.Record) -> models.BuildAttribute:
-        return models.BuildAttribute(id_=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], log_size=row[11], log_truncated=row[12], eval_warnings=row[13])
+        return models.BuildAttribute(
+            id_=row[0],
+            build_id=row[1],
+            attr=row[2],
+            system=row[3],
+            drv_path=row[4],
+            outputs=row[5],
+            status=row[6],
+            cached=row[7],
+            error=row[8],
+            started_at=row[9],
+            finished_at=row[10],
+            log_size=row[11],
+            log_truncated=row[12],
+            eval_warnings=row[13],
+            eval_wall_ms=row[14],
+            eval_alloc_bytes=row[15],
+        )
 
     return QueryResults(conn, WEB_ATTRIBUTES, _decode_hook, build_id)
 
 
 def web_attributes_finished_after(conn: ConnectionLike, *, build_id: int, after: datetime.datetime | None, after_id: int) -> QueryResults[models.BuildAttribute]:
     def _decode_hook(row: asyncpg.Record) -> models.BuildAttribute:
-        return models.BuildAttribute(id_=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], log_size=row[11], log_truncated=row[12], eval_warnings=row[13])
+        return models.BuildAttribute(
+            id_=row[0],
+            build_id=row[1],
+            attr=row[2],
+            system=row[3],
+            drv_path=row[4],
+            outputs=row[5],
+            status=row[6],
+            cached=row[7],
+            error=row[8],
+            started_at=row[9],
+            finished_at=row[10],
+            log_size=row[11],
+            log_truncated=row[12],
+            eval_warnings=row[13],
+            eval_wall_ms=row[14],
+            eval_alloc_bytes=row[15],
+        )
 
     return QueryResults(conn, WEB_ATTRIBUTES_FINISHED_AFTER, _decode_hook, build_id, after, after_id)
 
@@ -636,7 +677,24 @@ def web_attribute_counts(conn: ConnectionLike, *, build_id: int, pattern: str | 
 
 def web_attribute_page(conn: ConnectionLike, *, build_id: int, statuses: collections.abc.Sequence[str], pattern: str | None, offset_: int, limit_: int) -> QueryResults[models.BuildAttribute]:
     def _decode_hook(row: asyncpg.Record) -> models.BuildAttribute:
-        return models.BuildAttribute(id_=row[0], build_id=row[1], attr=row[2], system=row[3], drv_path=row[4], outputs=row[5], status=row[6], cached=row[7], error=row[8], started_at=row[9], finished_at=row[10], log_size=row[11], log_truncated=row[12], eval_warnings=row[13])
+        return models.BuildAttribute(
+            id_=row[0],
+            build_id=row[1],
+            attr=row[2],
+            system=row[3],
+            drv_path=row[4],
+            outputs=row[5],
+            status=row[6],
+            cached=row[7],
+            error=row[8],
+            started_at=row[9],
+            finished_at=row[10],
+            log_size=row[11],
+            log_truncated=row[12],
+            eval_warnings=row[13],
+            eval_wall_ms=row[14],
+            eval_alloc_bytes=row[15],
+        )
 
     return QueryResults(conn, WEB_ATTRIBUTE_PAGE, _decode_hook, build_id, statuses, pattern, offset_, limit_)
 
@@ -658,10 +716,12 @@ def web_attribute_history(conn: ConnectionLike, *, project_id: int, attr: str, l
             log_size=row[11],
             log_truncated=row[12],
             eval_warnings=row[13],
-            build_number=row[14],
-            branch=row[15],
-            commit_sha=row[16],
-            build_created_at=row[17],
+            eval_wall_ms=row[14],
+            eval_alloc_bytes=row[15],
+            build_number=row[16],
+            branch=row[17],
+            commit_sha=row[18],
+            build_created_at=row[19],
         )
 
     return QueryResults(conn, WEB_ATTRIBUTE_HISTORY, _decode_hook, project_id, attr, limit_)
@@ -697,11 +757,12 @@ def web_queue(conn: ConnectionLike, *, project_ids: collections.abc.Sequence[int
             effects_commit_sha=row[17],
             effects_branch=row[18],
             effects_pr_number=row[19],
-            owner=row[20],
-            project_name=row[21],
-            forge=row[22],
-            url=row[23],
-            queue_position=row[24],
+            eval_duration_ms=row[20],
+            owner=row[21],
+            project_name=row[22],
+            forge=row[23],
+            url=row[24],
+            queue_position=row[25],
         )
 
     return QueryResults(conn, WEB_QUEUE, _decode_hook, project_ids)

--- a/nixbot/nixbot/migrations/0027_eval_stats.sql
+++ b/nixbot/nixbot/migrations/0027_eval_stats.sql
@@ -1,0 +1,6 @@
+-- Wall time of the nix-eval-jobs run. Same lifetime as eval_completed.
+ALTER TABLE builds ADD COLUMN eval_duration_ms BIGINT;
+-- Per-attribute "stats" from nix-eval-jobs.
+ALTER TABLE build_attributes
+    ADD COLUMN eval_wall_ms INTEGER,
+    ADD COLUMN eval_alloc_bytes BIGINT;

--- a/nixbot/nixbot/models.py
+++ b/nixbot/nixbot/models.py
@@ -14,6 +14,16 @@ class CacheStatus(StrEnum):
     not_built = "notBuilt"
 
 
+class EvalStats(BaseModel):
+    """Per-attribute cost from nix-eval-jobs > 2.35.2. Shared values are
+    billed to the first attribute that forces them."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    wall_ms: int = Field(validation_alias="wallMs")
+    alloc_bytes: int = Field(validation_alias="allocBytes")
+
+
 class NixEvalJobError(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -22,6 +32,7 @@ class NixEvalJobError(BaseModel):
     attr_path: list[str] = Field(validation_alias="attrPath")
     warnings: list[str] = Field(default_factory=list)
     traces: list[str] = Field(default_factory=list)
+    stats: EvalStats | None = None
 
 
 class NixEvalJobSuccess(BaseModel):
@@ -40,6 +51,7 @@ class NixEvalJobSuccess(BaseModel):
     # this attribute (nix-eval-jobs > 2.35.2).
     warnings: list[str] = Field(default_factory=list)
     traces: list[str] = Field(default_factory=list)
+    stats: EvalStats | None = None
     # nix-eval-jobs emits null output paths for impure and some
     # content-addressed derivations: it cannot know their store paths
     # without actually building them. Accept None so the whole eval step

--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -24,6 +24,7 @@ import logging
 import os
 import re
 import signal
+import time
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -107,6 +108,8 @@ class EvalSettings:
 @dataclass
 class EvalResult:
     jobs: list[NixEvalJob]
+    # nix-eval-jobs process lifetime, excluding prefetch and slot wait.
+    duration_ms: int
 
 
 _NIX_DIR = Path(__file__).parent / "nix"
@@ -605,6 +608,7 @@ class EvalRunner:
             "starting evaluation",
             extra={"worktree": str(worktree_path), "argv0": cmd[0]},
         )
+        t0 = time.monotonic()
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             cwd=worktree_path,
@@ -635,6 +639,7 @@ class EvalRunner:
                     _read_stderr_tail(proc.stderr, on_line=on_stderr_line),
                 )
                 returncode = await proc.wait()
+                duration_ms = int((time.monotonic() - t0) * 1000)
         except BaseException as e:
             # Timeout, cancellation, or a reader bug: kill the evaluator
             # instead of leaking it (possibly blocked on a full pipe).
@@ -664,4 +669,4 @@ class EvalRunner:
         if parse_errors:
             msg = "; ".join(parse_errors)
             raise EvalError(msg)
-        return EvalResult(jobs=jobs)
+        return EvalResult(jobs=jobs, duration_ms=duration_ms)

--- a/nixbot/nixbot/queries/builds.sql
+++ b/nixbot/nixbot/queries/builds.sql
@@ -58,18 +58,24 @@ RETURNING *;
 -- name: RecordAttributes :exec
 -- Streaming inserts while the eval runs. Rows only grow or refresh
 -- here, they shrink solely in CommitEvalResult.
-INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, eval_warnings, status)
-SELECT sqlc.arg(build_id)::bigint, u.attr, u.system, u.drv_path, u.outputs, NULLIF(u.eval_warnings, 'null'::jsonb), 'pending'
+INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs,
+    eval_warnings, eval_wall_ms, eval_alloc_bytes, status)
+SELECT sqlc.arg(build_id)::bigint, u.attr, u.system, u.drv_path, u.outputs,
+    NULLIF(u.eval_warnings, 'null'::jsonb), NULLIF(u.eval_wall_ms, -1), NULLIF(u.eval_alloc_bytes, -1), 'pending'
 FROM (SELECT unnest(sqlc.arg(attrs)::text[]) AS attr,
              unnest(sqlc.arg(systems)::text[]) AS system,
              unnest(sqlc.arg(drv_paths)::text[]) AS drv_path,
              unnest(sqlc.arg(outputs)::jsonb[]) AS outputs,
-             unnest(sqlc.arg(eval_warnings)::jsonb[]) AS eval_warnings) u
+             unnest(sqlc.arg(eval_warnings)::jsonb[]) AS eval_warnings,
+             unnest(sqlc.arg(eval_wall_ms)::int[]) AS eval_wall_ms,
+             unnest(sqlc.arg(eval_alloc_bytes)::bigint[]) AS eval_alloc_bytes) u
 ON CONFLICT (build_id, attr) DO UPDATE SET
     system = EXCLUDED.system,
     drv_path = EXCLUDED.drv_path,
     outputs = EXCLUDED.outputs,
-    eval_warnings = EXCLUDED.eval_warnings
+    eval_warnings = EXCLUDED.eval_warnings,
+    eval_wall_ms = EXCLUDED.eval_wall_ms,
+    eval_alloc_bytes = EXCLUDED.eval_alloc_bytes
 WHERE build_attributes.status IN ('pending', 'building');
 
 -- name: SetEvalWarnings :exec
@@ -93,6 +99,9 @@ SET status = sqlc.arg(status),
     error = CASE
         WHEN sqlc.arg(status) = 'pending' THEN NULL
         ELSE COALESCE(sqlc.narg(error), error)
+    END,
+    eval_duration_ms = CASE
+        WHEN sqlc.arg(status) = 'pending' THEN NULL ELSE eval_duration_ms
     END,
     eval_warnings = CASE
         WHEN sqlc.arg(status) = 'pending' THEN NULL ELSE eval_warnings
@@ -158,11 +167,19 @@ RETURNING attr;
 -- rows are left untouched (the upsert returns no row).
 INSERT INTO build_attributes
     (build_id, attr, system, drv_path, outputs, status, error,
-     cached, log_size, log_truncated, finished_at)
+     cached, log_size, log_truncated, finished_at,
+     eval_warnings, eval_wall_ms, eval_alloc_bytes)
 VALUES ($1, $2, $3, $4, sqlc.narg(outputs)::jsonb, $5, $6, $7,
-        sqlc.arg(log_size)::bigint, sqlc.arg(log_truncated)::boolean, now())
+        sqlc.arg(log_size)::bigint, sqlc.arg(log_truncated)::boolean, now(),
+        sqlc.narg(eval_warnings)::jsonb, sqlc.narg(eval_wall_ms)::int,
+        sqlc.narg(eval_alloc_bytes)::bigint)
 ON CONFLICT (build_id, attr) DO UPDATE SET
     status = EXCLUDED.status,
+    -- Eval data is only known by failed_eval inserts. Build
+    -- completions pass NULL and must keep what the eval recorded.
+    eval_warnings = COALESCE(EXCLUDED.eval_warnings, build_attributes.eval_warnings),
+    eval_wall_ms = COALESCE(EXCLUDED.eval_wall_ms, build_attributes.eval_wall_ms),
+    eval_alloc_bytes = COALESCE(EXCLUDED.eval_alloc_bytes, build_attributes.eval_alloc_bytes),
     -- Eval recorded the full outputs map (multi-output drvs);
     -- merge the freshly-known "out" path into it instead of
     -- replacing it, and never NULL an existing map when no out

--- a/nixbot/nixbot/queries/maintenance.sql
+++ b/nixbot/nixbot/queries/maintenance.sql
@@ -65,25 +65,33 @@ WHERE build_id = $1 AND status IN ('pending', 'building');
 -- rows, prunes rows the eval no longer produced, publishes via
 -- eval_completed, atomically.
 WITH new_rows AS (
-    INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs, eval_warnings, status)
-    SELECT sqlc.arg(build_id)::bigint, u.attr, u.system, u.drv_path, u.outputs, NULLIF(u.eval_warnings, 'null'::jsonb), 'pending'
+    INSERT INTO build_attributes (build_id, attr, system, drv_path, outputs,
+        eval_warnings, eval_wall_ms, eval_alloc_bytes, status)
+    SELECT sqlc.arg(build_id)::bigint, u.attr, u.system, u.drv_path, u.outputs,
+        NULLIF(u.eval_warnings, 'null'::jsonb), NULLIF(u.eval_wall_ms, -1), NULLIF(u.eval_alloc_bytes, -1), 'pending'
     FROM (SELECT unnest(sqlc.arg(attrs)::text[]) AS attr,
                  unnest(sqlc.arg(systems)::text[]) AS system,
                  unnest(sqlc.arg(drv_paths)::text[]) AS drv_path,
                  unnest(sqlc.arg(outputs)::jsonb[]) AS outputs,
-                 unnest(sqlc.arg(eval_warnings)::jsonb[]) AS eval_warnings) u
+                 unnest(sqlc.arg(eval_warnings)::jsonb[]) AS eval_warnings,
+                 unnest(sqlc.arg(eval_wall_ms)::int[]) AS eval_wall_ms,
+                 unnest(sqlc.arg(eval_alloc_bytes)::bigint[]) AS eval_alloc_bytes) u
     ON CONFLICT (build_id, attr) DO UPDATE SET
         system = EXCLUDED.system,
         drv_path = EXCLUDED.drv_path,
         outputs = EXCLUDED.outputs,
-        eval_warnings = EXCLUDED.eval_warnings
+        eval_warnings = EXCLUDED.eval_warnings,
+        eval_wall_ms = EXCLUDED.eval_wall_ms,
+        eval_alloc_bytes = EXCLUDED.eval_alloc_bytes
     WHERE build_attributes.status IN ('pending', 'building')
 ), pruned AS (
     DELETE FROM build_attributes WHERE build_id = sqlc.arg(build_id)
     AND attr != ALL(sqlc.arg(attrs)::text[])
     AND (status IN ('pending', 'building') OR drv_path IS NULL)
 )
-UPDATE builds SET eval_completed = TRUE WHERE builds.id = sqlc.arg(build_id);
+UPDATE builds SET eval_completed = TRUE,
+    eval_duration_ms = sqlc.narg(eval_duration_ms)::bigint
+WHERE builds.id = sqlc.arg(build_id);
 
 -- name: DeleteAttributesByName :exec
 DELETE FROM build_attributes WHERE build_id = $1

--- a/nixbot/nixbot/tests/test_db.py
+++ b/nixbot/nixbot/tests/test_db.py
@@ -15,9 +15,10 @@ from nixbot import build_run, db
 from nixbot import migrations as migrations_mod
 from nixbot.build_scheduler import AttributeResult, AttributeStatus
 from nixbot.db_gen import builds as builds_q
+from nixbot.db_gen import maintenance as maintenance_q
 from nixbot.failed_builds import PostgresFailedBuildCache
 from nixbot.migrations import apply_migrations, load_migrations
-from nixbot.models import CacheStatus
+from nixbot.models import CacheStatus, EvalStats, NixEvalJobError
 from nixbot.status import CheckRunStore, FailedStatusStore
 
 from .support import attribute_statuses, db_pool, insert_build, insert_project, mk_job
@@ -683,3 +684,60 @@ async def test_failed_build_cache_scoped_per_project(pool: asyncpg.Pool) -> None
     entry = await PostgresFailedBuildCache(pool, p1).check(drv)
     assert entry is not None
     assert entry.url == "http://ci/one/1"
+
+
+async def test_eval_stats_lifecycle(pool: asyncpg.Pool) -> None:
+    """Per-attr stats survive build completion. failed_eval inserts
+    carry warnings and stats. Build duration follows eval_completed."""
+    project_id = await insert_project(pool, "eval-stats")
+    build, _ = await db.get_or_create_build(pool, project_id, "tree-es", "sha", "main")
+    stats = EvalStats(wall_ms=412, alloc_bytes=48 << 20)
+    job = mk_job("a").model_copy(update={"stats": stats})
+    await build_run.record_attributes(pool, build.id_, [job, mk_job("b")])
+    await build_run.commit_eval_result(pool, build.id_, [job, mk_job("b")], 38_000)
+    await db.complete_attribute(
+        pool,
+        build.id_,
+        AttributeResult(attr="a", status=AttributeStatus.succeeded, job=job),
+    )
+    broken = NixEvalJobError(
+        error="boom",
+        attr="c",
+        attr_path=["c"],
+        warnings=["c warns"],
+        stats=EvalStats(wall_ms=7, alloc_bytes=9),
+    )
+    await db.complete_attribute(
+        pool,
+        build.id_,
+        AttributeResult(
+            attr="c", status=AttributeStatus.failed_eval, job=broken, error="boom"
+        ),
+    )
+
+    rows = {
+        r["attr"]: (r["eval_wall_ms"], r["eval_alloc_bytes"], r["eval_warnings"])
+        for r in await pool.fetch(
+            "SELECT attr, eval_wall_ms, eval_alloc_bytes, eval_warnings"
+            " FROM build_attributes WHERE build_id = $1",
+            build.id_,
+        )
+    }
+    assert rows["a"] == (412, 48 << 20, None)
+    assert rows["b"] == (None, None, None)
+    assert rows["c"][:2] == (7, 9)
+    assert json.loads(rows["c"][2]) == ["c warns"]
+
+    async def duration() -> tuple[bool, int | None]:
+        row = await pool.fetchrow(
+            "SELECT eval_completed, eval_duration_ms FROM builds WHERE id = $1",
+            build.id_,
+        )
+        assert row is not None
+        return row["eval_completed"], row["eval_duration_ms"]
+
+    assert await duration() == (True, 38_000)
+    await maintenance_q.reset_build_for_restart(pool, build_id=build.id_, attr=None)
+    assert await duration() == (True, 38_000)
+    await db.set_build_status(pool, build.id_, db.BuildStatus.PENDING)
+    assert await duration() == (False, None)

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -237,6 +237,9 @@ async def test_eval_runner_integration(tmp_path: Path) -> None:
     job = result.jobs[0]
     assert job.attr == "checks.x86_64-linux.ok"  # type: ignore[union-attr]
     assert any("eval warning here" in line for line in seen)
+    assert result.duration_ms > 0
+    assert job.stats is not None
+    assert job.stats.alloc_bytes > 0
 
     # Dotted attribute config selects the nested path.
     result = await EvalRunner().run(

--- a/nixbot/nixbot/tests/test_nix_eval_job.py
+++ b/nixbot/nixbot/tests/test_nix_eval_job.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from nixbot.models import NixEvalJobModel, NixEvalJobSuccess
+from nixbot.models import EvalStats, NixEvalJobError, NixEvalJobModel, NixEvalJobSuccess
 
 
 def test_impure_job_with_null_out_parses() -> None:
@@ -31,3 +31,17 @@ def test_impure_job_with_null_out_parses() -> None:
     assert job.outputs == {"out": None}
     # Downstream code does `job.outputs["out"] or None`. Ensure that still works.
     assert (job.outputs["out"] or None) is None
+
+
+def test_stats_parse() -> None:
+    raw = {
+        "attr": "a",
+        "attrPath": ["a"],
+        "error": "boom",
+        "stats": {"wallMs": 412, "allocBytes": 7632},
+    }
+    job = NixEvalJobModel.validate_python(raw)
+    assert isinstance(job, NixEvalJobError)
+    assert job.stats == EvalStats(wall_ms=412, alloc_bytes=7632)
+    del raw["stats"]
+    assert NixEvalJobModel.validate_python(raw).stats is None

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -72,6 +72,7 @@ class FakeEvalRunner:
     # Deliver jobs via on_jobs before raising, like the incremental
     # eval stream that fails mid-way.
     stream_jobs: bool = False
+    duration_ms: int = 1500
 
     async def run(
         self,
@@ -95,7 +96,7 @@ class FakeEvalRunner:
         if callable(on_stderr_line):
             for warning in self.warnings:
                 await on_stderr_line(f"warning: {warning}")
-        return EvalResult(jobs=list(self.jobs))
+        return EvalResult(jobs=list(self.jobs), duration_ms=self.duration_ms)
 
 
 @dataclass
@@ -369,6 +370,12 @@ async def build_status(pool: asyncpg.Pool, build_id: int) -> str:
     return await pool.fetchval("SELECT status FROM builds WHERE id = $1", build_id)
 
 
+async def eval_duration(pool: asyncpg.Pool, build_id: int) -> int | None:
+    return await pool.fetchval(
+        "SELECT eval_duration_ms FROM builds WHERE id = $1", build_id
+    )
+
+
 # --- tests --------------------------------------------------------------------
 
 
@@ -496,6 +503,8 @@ async def test_eval_reuse_from_cancelled_build(
         "a": "succeeded",
         "b": "succeeded",
     }
+    # This build did not evaluate, so it has no eval duration.
+    assert await eval_duration(pool, build2.id_) is None
 
 
 async def test_eval_reuse_skipped_when_drvs_gone(
@@ -508,6 +517,7 @@ async def test_eval_reuse_skipped_when_drvs_gone(
     )
     assert eval_runner.calls == 2  # re-evaluated
     assert await build_status(pool, build2.id_) == BuildStatus.SUCCEEDED
+    assert await eval_duration(pool, build2.id_) == eval_runner.duration_ms
 
 
 async def test_main_push_promotes_reused_pr_build(

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -120,6 +120,7 @@ BUILD = BuildRecord(
     effects_commit_sha=None,
     effects_branch=None,
     effects_pr_number=None,
+    eval_duration_ms=None,
 )
 
 


### PR DESCRIPTION
nix-eval-jobs now reports wallMs/allocBytes per attribute. Store them
on build_attributes and the nix-eval-jobs runtime on builds so the UI
can answer 'how long did eval take' and 'which attrs are expensive'
(#162).

eval_duration_ms shares eval_completed's lifetime: set in
CommitEvalResult, cleared by SetBuildStatus('pending'), kept across
restarts that rebuild from stored rows, NULL for reused evals.

CompleteAttribute now COALESCEs eval data, which also stops dropping
eval warnings of failed_eval attributes.
<details>
<summary>
Committer details
</summary>
Local-Branch: eval-stats
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
nix-eval-jobs: bump for per-attribute eval stats (<a href="https://github.com/Mic92/nixbot/pull/175">#175</a>)
</summary>

</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Show eval duration in build header, forge status, API, CLI and metrics (<a href="https://github.com/Mic92/nixbot/pull/177">#177</a>)
</summary>
Closes #162.
</details>
<details>
<summary>
Show per-attribute eval stats on row tooltip, log page and history (<a href="https://github.com/Mic92/nixbot/pull/178">#178</a>)
</summary>

</details>
<details>
<summary>
Add per-build evaluation page listing attribute eval cost (<a href="https://github.com/Mic92/nixbot/pull/179">#179</a>)
</summary>
Linked from the eval duration in the build header. Sortable by time
or allocation so expensive attributes can be found without adding
columns to the build page.
</details>
</details>
</details>