### PR TITLE
[need #176] Show eval duration in build header, forge status, API, CLI and metrics

### DIFF
--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -270,6 +270,7 @@ async def _record_eval_success(
             success=True,
             warnings=[str(g["message"]) for g in live_warnings.snapshot()],
             jobs=buildable,
+            duration_ms=result.duration_ms,
         ),
     )
 

--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -9,6 +9,7 @@ __all__: collections.abc.Sequence[str] = (
     "MetricsAttributeCountsRow",
     "MetricsBuildCountsRow",
     "MetricsBuildDurationRow",
+    "MetricsEvalDurationRow",
     "MetricsProjectsRow",
     "QueryResults",
     "WebAttributeCountsRow",
@@ -23,6 +24,7 @@ __all__: collections.abc.Sequence[str] = (
     "metrics_attribute_counts",
     "metrics_build_counts",
     "metrics_build_duration",
+    "metrics_eval_duration",
     "metrics_projects",
     "metrics_queue_depth",
     "web_attribute_counts",
@@ -209,6 +211,12 @@ class MetricsBuildDurationRow:
 class MetricsProjectsRow:
     enabled: int
     total: int
+
+
+@dataclasses.dataclass()
+class MetricsEvalDurationRow:
+    total: int
+    count: int
 
 
 WEB_PROJECTS: typing.Final[str] = """-- name: WebProjects :many
@@ -419,6 +427,11 @@ WHERE started_at IS NOT NULL AND finished_at IS NOT NULL
 METRICS_PROJECTS: typing.Final[str] = """-- name: MetricsProjects :one
 SELECT count(*) FILTER (WHERE enabled) AS enabled, count(*) AS total
 FROM projects
+"""
+
+METRICS_EVAL_DURATION: typing.Final[str] = """-- name: MetricsEvalDuration :one
+SELECT coalesce(sum(eval_duration_ms), 0)::float / 1000 AS total, count(*) AS count
+FROM builds WHERE eval_duration_ms IS NOT NULL
 """
 
 
@@ -815,3 +828,10 @@ async def metrics_projects(conn: ConnectionLike) -> MetricsProjectsRow | None:
     if row is None:
         return None
     return MetricsProjectsRow(enabled=row[0], total=row[1])
+
+
+async def metrics_eval_duration(conn: ConnectionLike) -> MetricsEvalDurationRow | None:
+    row = await conn.fetchrow(METRICS_EVAL_DURATION)
+    if row is None:
+        return None
+    return MetricsEvalDurationRow(total=row[0], count=row[1])

--- a/nixbot/nixbot/events.py
+++ b/nixbot/nixbot/events.py
@@ -81,6 +81,7 @@ class EvalReport:
     warnings: list[str] = field(default_factory=list)
     jobs: Sequence[NixEvalJobSuccess] | None = None
     error: str | None = None
+    duration_ms: int | None = None
 
 
 @dataclass(frozen=True)

--- a/nixbot/nixbot/fmt.py
+++ b/nixbot/nixbot/fmt.py
@@ -1,0 +1,12 @@
+"""Human-readable formatting shared by forge statuses and the web UI."""
+
+from __future__ import annotations
+
+
+def format_duration(seconds: float) -> str:
+    secs = int(seconds)
+    if secs >= 3600:  # noqa: PLR2004
+        return f"{secs // 3600}h {secs % 3600 // 60}m"
+    if secs >= 60:  # noqa: PLR2004
+        return f"{secs // 60}m {secs % 60}s"
+    return f"{secs}s"

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -196,3 +196,7 @@ WHERE started_at IS NOT NULL AND finished_at IS NOT NULL;
 -- name: MetricsProjects :one
 SELECT count(*) FILTER (WHERE enabled) AS enabled, count(*) AS total
 FROM projects;
+
+-- name: MetricsEvalDuration :one
+SELECT coalesce(sum(eval_duration_ms), 0)::float / 1000 AS total, count(*) AS count
+FROM builds WHERE eval_duration_ms IS NOT NULL;

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -39,6 +39,7 @@ import httpx
 
 from .ansi import strip_ansi
 from .db_gen import failed as q
+from .fmt import format_duration
 from .forge import ForgeError
 from .forge.retry import retry_after_seconds
 
@@ -385,8 +386,12 @@ def effects_summary_description(failed: int, succeeded: int) -> str:
     return f"{succeeded} effect{'s' if succeeded != 1 else ''} succeeded"
 
 
-def eval_description(success: bool, warnings: list[str]) -> str:
+def eval_description(
+    success: bool, warnings: list[str], duration_ms: int | None = None
+) -> str:
     base = "evaluation succeeded" if success else "evaluation failed"
+    if duration_ms is not None:
+        base += f" in {format_duration(duration_ms / 1000)}"
     if warnings:
         count = len(warnings)
         return f"{base} ({count} warning{'s' if count != 1 else ''})"
@@ -494,7 +499,7 @@ class ForgeStatusReporter:
             build,
             f"{self.context_prefix}/nix-eval",
             StatusState.success if report.success else StatusState.failure,
-            eval_description(report.success, report.warnings),
+            eval_description(report.success, report.warnings, report.duration_ms),
             text=text,
         )
         if report.success:

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -239,6 +239,11 @@ def test_eval_description_warning_count() -> None:
     assert eval_description(True, []) == "evaluation succeeded"
     assert eval_description(True, ["w"]) == "evaluation succeeded (1 warning)"
     assert eval_description(False, ["a", "b"]) == "evaluation failed (2 warnings)"
+    assert (
+        eval_description(True, ["w"], 38_400)
+        == "evaluation succeeded in 38s (1 warning)"
+    )
+    assert eval_description(True, [], 3_723_000) == "evaluation succeeded in 1h 2m"
 
 
 async def test_phase_statuses_and_target_url() -> None:

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -2259,3 +2259,26 @@ def test_api_log_stream_json(client: WebHarness, tmp_path: Path) -> None:
         "/api/repos/github/acme/widget/builds/2/logs/x86_64-linux.bad/stream"
     ).text
     assert finished == "event: done\ndata: {}\n\n"
+
+
+def test_build_eval_stats_surface(client: WebHarness) -> None:
+    async def seed() -> None:
+        pool = client.ctx.pool
+        await pool.execute(
+            "UPDATE builds SET eval_duration_ms = 38400 WHERE number = 2"
+        )
+        await pool.execute(
+            "UPDATE build_attributes a SET eval_wall_ms = 412,"
+            " eval_alloc_bytes = 50331648 FROM builds b"
+            " WHERE a.build_id = b.id AND b.number = 2"
+            " AND a.attr = 'x86_64-linux.bad'"
+        )
+
+    client.loop.run_until_complete(seed())
+    text = client.get("/repos/github/acme/widget/builds/2").text
+    assert "· eval 38s" in text
+    assert "· eval" not in client.get("/repos/github/acme/widget/builds/1").text
+    detail = client.get("/api/repos/github/acme/widget/builds/2").json()
+    assert detail["build"]["eval_duration_ms"] == 38400
+    broken = next(a for a in detail["attributes"] if a["attr"] == "x86_64-linux.bad")
+    assert (broken["eval_wall_ms"], broken["eval_alloc_bytes"]) == (412, 50331648)

--- a/nixbot/nixbot/web/api_routes.py
+++ b/nixbot/nixbot/web/api_routes.py
@@ -81,6 +81,8 @@ class Build(BaseModel):
     created_at: datetime
     started_at: datetime | None
     finished_at: datetime | None
+    # nix-eval-jobs run time. None unless this build evaluated.
+    eval_duration_ms: int | None = None
     eval_queue: EvalQueue | None = None  # only while pending
 
 
@@ -108,6 +110,9 @@ class Attribute(BaseModel):
     finished_at: datetime | None
     log_size: int | None = None
     log_truncated: bool | None = None
+    # Per-attribute cost reported by nix-eval-jobs.
+    eval_wall_ms: int | None = None
+    eval_alloc_bytes: int | None = None
 
 
 class Effect(BaseModel):

--- a/nixbot/nixbot/web/metrics.py
+++ b/nixbot/nixbot/web/metrics.py
@@ -53,6 +53,15 @@ async def render_metrics(pool: asyncpg.Pool) -> str:
     lines.append("# TYPE nixbot_build_duration_seconds_count gauge")
     lines.append(f"nixbot_build_duration_seconds_count {duration.count}")
 
+    eval_duration = expect(await gen.metrics_eval_duration(pool))
+    lines.append(
+        "# HELP nixbot_eval_duration_seconds_sum Total nix-eval-jobs run time."
+    )
+    lines.append("# TYPE nixbot_eval_duration_seconds_sum gauge")
+    lines.append(f"nixbot_eval_duration_seconds_sum {eval_duration.total}")
+    lines.append("# TYPE nixbot_eval_duration_seconds_count gauge")
+    lines.append(f"nixbot_eval_duration_seconds_count {eval_duration.count}")
+
     projects = expect(await gen.metrics_projects(pool))
     lines.append("# HELP nixbot_projects Projects known/enabled.")
     lines.append("# TYPE nixbot_projects gauge")

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -53,6 +53,7 @@
             · <time datetime="{{ build.created_at.isoformat() }}"
        title="{{ build.created_at }}">{{ build.created_at | timeago }}</time>
             · {{ "running for" if build.status in RUNNING_STATUSES else "took" }} {{ build | duration }}
+            {% if build.eval_duration_ms is not none %}· eval {{ (build.eval_duration_ms / 1000) | duration_secs }}{% endif %}
           </p>
         </div>
         <div class="controls">

--- a/nixbot/nixbot/web/templating.py
+++ b/nixbot/nixbot/web/templating.py
@@ -15,6 +15,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from markupsafe import Markup
 
 from ..ansi import strip_ansi  # noqa: TID252
+from ..fmt import format_duration  # noqa: TID252
 from .logs import ansi_to_html
 
 if TYPE_CHECKING:
@@ -78,12 +79,7 @@ def duration(row: dict[str, Any]) -> str:
 def duration_secs(value: float | None) -> str:
     if value is None:
         return "—"
-    seconds = int(value)
-    if seconds >= 3600:  # noqa: PLR2004
-        return f"{seconds // 3600}h {seconds % 3600 // 60}m"
-    if seconds >= 60:  # noqa: PLR2004
-        return f"{seconds // 60}m {seconds % 60}s"
-    return f"{seconds}s"
+    return format_duration(value)
 
 
 def _forge_base(project: dict[str, Any]) -> str | None:

--- a/nixbot_cli/nixbot_cli/main.py
+++ b/nixbot_cli/nixbot_cli/main.py
@@ -23,6 +23,7 @@ from .term import (
     bold,
     cyan,
     dim,
+    fmt_duration,
     green,
     link,
     queue_note,
@@ -226,7 +227,9 @@ def cmd_build_view(client: NixbotClient, args: argparse.Namespace) -> int:
         f"{repo} {cyan(build['branch'])} "
         f"@ {dim(build['commit_sha'][:12])}"
     )
-    print(f"status: {status_str(build['status'])}{queue_note(build)}")
+    eval_ms = build.get("eval_duration_ms")
+    eval_note = f" · eval {fmt_duration(eval_ms / 1000)}" if eval_ms is not None else ""
+    print(f"status: {status_str(build['status'])}{queue_note(build)}{eval_note}")
     if build.get("error"):
         print(f"error: {build['error']}")
     counts: dict[str, int] = {}


### PR DESCRIPTION
Closes #162.
<details>
<summary>
Committer details
</summary>
Local-Branch: eval-stats
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
nix-eval-jobs: bump for per-attribute eval stats (<a href="https://github.com/Mic92/nixbot/pull/175">#175</a>)
</summary>

</details>
<details>
<summary>
Record eval duration and per-attribute eval stats (<a href="https://github.com/Mic92/nixbot/pull/176">#176</a>)
</summary>
nix-eval-jobs now reports wallMs/allocBytes per attribute. Store them
on build_attributes and the nix-eval-jobs runtime on builds so the UI
can answer 'how long did eval take' and 'which attrs are expensive'
(#162).

eval_duration_ms shares eval_completed's lifetime: set in
CommitEvalResult, cleared by SetBuildStatus('pending'), kept across
restarts that rebuild from stored rows, NULL for reused evals.

CompleteAttribute now COALESCEs eval data, which also stops dropping
eval warnings of failed_eval attributes.
</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Show per-attribute eval stats on row tooltip, log page and history (<a href="https://github.com/Mic92/nixbot/pull/178">#178</a>)
</summary>

</details>
<details>
<summary>
Add per-build evaluation page listing attribute eval cost (<a href="https://github.com/Mic92/nixbot/pull/179">#179</a>)
</summary>
Linked from the eval duration in the build header. Sortable by time
or allocation so expensive attributes can be found without adding
columns to the build page.
</details>
</details>
</details>