### PR TITLE
[need #177] Show per-attribute eval stats on row tooltip, log page and history

### DIFF
--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 __all__: collections.abc.Sequence[str] = (
+    "AttributeEvalStatsRow",
     "MetricsAttributeCountsRow",
     "MetricsBuildCountsRow",
     "MetricsBuildDurationRow",
@@ -20,6 +21,7 @@ __all__: collections.abc.Sequence[str] = (
     "WebRecentBuildsRow",
     "WebRepoOverviewRow",
     "attribute_error",
+    "attribute_eval_stats",
     "attribute_status",
     "metrics_attribute_counts",
     "metrics_build_counts",
@@ -187,6 +189,12 @@ class WebQueueRow:
     forge: str
     url: str
     queue_position: int
+
+
+@dataclasses.dataclass()
+class AttributeEvalStatsRow:
+    eval_wall_ms: int | None
+    eval_alloc_bytes: int | None
 
 
 @dataclasses.dataclass()
@@ -397,6 +405,11 @@ ORDER BY b.status = 'pending', b.id
 
 ATTRIBUTE_STATUS: typing.Final[str] = """-- name: AttributeStatus :one
 SELECT status FROM build_attributes WHERE build_id = $1 AND attr = $2
+"""
+
+ATTRIBUTE_EVAL_STATS: typing.Final[str] = """-- name: AttributeEvalStats :one
+SELECT eval_wall_ms, eval_alloc_bytes FROM build_attributes
+WHERE build_id = $1 AND attr = $2
 """
 
 ATTRIBUTE_ERROR: typing.Final[str] = """-- name: AttributeError :one
@@ -786,6 +799,13 @@ async def attribute_status(conn: ConnectionLike, *, build_id: int, attr: str) ->
     if row is None:
         return None
     return row[0]
+
+
+async def attribute_eval_stats(conn: ConnectionLike, *, build_id: int, attr: str) -> AttributeEvalStatsRow | None:
+    row = await conn.fetchrow(ATTRIBUTE_EVAL_STATS, build_id, attr)
+    if row is None:
+        return None
+    return AttributeEvalStatsRow(eval_wall_ms=row[0], eval_alloc_bytes=row[1])
 
 
 async def attribute_error(conn: ConnectionLike, *, build_id: int, attr: str) -> str | None:

--- a/nixbot/nixbot/fmt.py
+++ b/nixbot/nixbot/fmt.py
@@ -10,3 +10,21 @@ def format_duration(seconds: float) -> str:
     if secs >= 60:  # noqa: PLR2004
         return f"{secs // 60}m {secs % 60}s"
     return f"{secs}s"
+
+
+def format_ms(ms: int | None) -> str:
+    if ms is None:
+        return ""
+    if ms < 1000:  # noqa: PLR2004
+        return f"{ms} ms"
+    if ms < 60_000:  # noqa: PLR2004
+        return f"{ms / 1000:.1f} s"
+    return format_duration(ms / 1000)
+
+
+def format_bytes(value: int) -> str:
+    if value < 1 << 20:
+        return f"{value / (1 << 10):.1f} KiB"
+    if value < 1 << 30:
+        return f"{value / (1 << 20):.1f} MiB"
+    return f"{value / (1 << 30):.1f} GiB"

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -173,6 +173,10 @@ ORDER BY b.status = 'pending', b.id;
 -- name: AttributeStatus :one
 SELECT status FROM build_attributes WHERE build_id = $1 AND attr = $2;
 
+-- name: AttributeEvalStats :one
+SELECT eval_wall_ms, eval_alloc_bytes FROM build_attributes
+WHERE build_id = $1 AND attr = $2;
+
 -- name: AttributeError :one
 SELECT error FROM build_attributes WHERE build_id = $1 AND attr = $2;
 

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -2271,14 +2271,20 @@ def test_build_eval_stats_surface(client: WebHarness) -> None:
             "UPDATE build_attributes a SET eval_wall_ms = 412,"
             " eval_alloc_bytes = 50331648 FROM builds b"
             " WHERE a.build_id = b.id AND b.number = 2"
-            " AND a.attr = 'x86_64-linux.bad'"
+            " AND a.attr = 'x86_64-linux.evalfail'"
         )
 
     client.loop.run_until_complete(seed())
-    text = client.get("/repos/github/acme/widget/builds/2").text
+    base = "/repos/github/acme/widget"
+    text = client.get(f"{base}/builds/2").text
     assert "· eval 38s" in text
-    assert "· eval" not in client.get("/repos/github/acme/widget/builds/1").text
-    detail = client.get("/api/repos/github/acme/widget/builds/2").json()
+    assert 'title="eval 412 ms · 48.0 MiB allocated"' in text
+    assert "· eval" not in client.get(f"{base}/builds/1").text
+    log_page = client.get(f"{base}/builds/2/logs/x86_64-linux.evalfail").text
+    assert "eval 412 ms · 48.0 MiB allocated" in log_page
+    history = client.get(f"{base}/attrs/x86_64-linux.evalfail").text
+    assert "412 ms" in history
+    detail = client.get(f"/api{base}/builds/2").json()
     assert detail["build"]["eval_duration_ms"] == 38400
-    broken = next(a for a in detail["attributes"] if a["attr"] == "x86_64-linux.bad")
-    assert (broken["eval_wall_ms"], broken["eval_alloc_bytes"]) == (412, 50331648)
+    row = next(a for a in detail["attributes"] if a["attr"] == "x86_64-linux.evalfail")
+    assert (row["eval_wall_ms"], row["eval_alloc_bytes"]) == (412, 50331648)

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -8,6 +8,7 @@ executor's LogWriter fans out to any number of SSE subscribers.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import functools
 import html
 import json
@@ -991,6 +992,7 @@ class _LogRoutes:
         )
         # Effect statuses live in build_effects, not attributes.
         is_effect = attr.startswith("effect:")
+        eval_stats = None
         if is_effect:
             attr_status = await maint_gen.effect_status(
                 self.ctx.pool,
@@ -999,6 +1001,9 @@ class _LogRoutes:
             )
         else:
             attr_status = await gen.attribute_status(
+                self.ctx.pool, build_id=build["id"], attr=attr
+            )
+            eval_stats = await gen.attribute_eval_stats(
                 self.ctx.pool, build_id=build["id"], attr=attr
             )
         # Live pages render no snapshot: the stream replays full
@@ -1048,6 +1053,7 @@ class _LogRoutes:
             project=project,
             build=build,
             attr_status=attr_status,
+            eval_stats=dataclasses.asdict(eval_stats) if eval_stats else {},
             is_effect=is_effect,
             attr=attr,
             content=content,

--- a/nixbot/nixbot/web/templates/_attr_rows.html
+++ b/nixbot/nixbot/web/templates/_attr_rows.html
@@ -13,7 +13,8 @@
         <ul class="attr-warnings">{% for w in aw %}<li>{{ w | ansi }}</li>{% endfor %}</ul>
       {% endif %}
     </td>
-    <td class="attr-duration">{{ a | duration }}</td>
+    {% set es = a | eval_stats %}
+    <td class="attr-duration"{% if es %} title="{{ es }}"{% endif %}>{{ a | duration }}</td>
   </tr>
   {% if a.error %}{{ error_row(a.error) }}{% endif %}
 {% endfor %}

--- a/nixbot/nixbot/web/templates/attribute_history.html
+++ b/nixbot/nixbot/web/templates/attribute_history.html
@@ -17,6 +17,7 @@
             <th scope="col">branch</th>
             <th scope="col">status</th>
             <th scope="col">commit</th>
+            <th scope="col">eval</th>
             <th scope="col">when</th>
           </tr>
           {% for h in history %}
@@ -27,11 +28,15 @@
               <td>{{ h.branch }}</td>
               <td>{{ status_pill(h.status) }}</td>
               <td>{{ commit_link(project, h.commit_sha) }}</td>
+              <td class="muted"
+                  {% if h.eval_alloc_bytes is not none %} title="{{ h.eval_alloc_bytes | human_bytes }} allocated"{% endif %}>
+                {{ h.eval_wall_ms | eval_ms if h.eval_wall_ms is not none else "" }}
+              </td>
               <td>{{ ago(h.build_created_at) }}</td>
             </tr>
           {% else %}
             <tr>
-              <td colspan="5" class="empty-state">no history</td>
+              <td colspan="6" class="empty-state">no history</td>
             </tr>
           {% endfor %}
         </table>

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -44,6 +44,8 @@
           {% endif %}
         </div>
       </div>
+      {% set es = eval_stats | eval_stats %}
+      {% if es %}<p class="muted eval-stats">{{ es }}</p>{% endif %}
       {% if waiting %}
         <p class="muted">waiting for the build to start…</p>
       {% elif unavailable %}

--- a/nixbot/nixbot/web/templating.py
+++ b/nixbot/nixbot/web/templating.py
@@ -15,7 +15,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from markupsafe import Markup
 
 from ..ansi import strip_ansi  # noqa: TID252
-from ..fmt import format_duration  # noqa: TID252
+from ..fmt import format_bytes, format_duration, format_ms  # noqa: TID252
 from .logs import ansi_to_html
 
 if TYPE_CHECKING:
@@ -80,6 +80,13 @@ def duration_secs(value: float | None) -> str:
     if value is None:
         return "—"
     return format_duration(value)
+
+
+def eval_stats(row: dict[str, Any]) -> str:
+    """Empty when nix-eval-jobs reported no stats for the attribute."""
+    if row.get("eval_wall_ms") is None:
+        return ""
+    return f"eval {format_ms(row['eval_wall_ms'])} · {format_bytes(row['eval_alloc_bytes'])} allocated"
 
 
 def _forge_base(project: dict[str, Any]) -> str | None:
@@ -155,6 +162,9 @@ def make_env() -> Environment:
     env.filters["timeuntil"] = timeuntil
     env.filters["duration"] = duration
     env.filters["duration_secs"] = duration_secs
+    env.filters["eval_ms"] = format_ms
+    env.filters["human_bytes"] = format_bytes
+    env.filters["eval_stats"] = eval_stats
     env.filters["excerpt"] = excerpt
     env.filters["plain"] = strip_ansi
     # asyncpg returns jsonb columns as text.


### PR DESCRIPTION

<details>
<summary>
Committer details
</summary>
Local-Branch: eval-stats
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
nix-eval-jobs: bump for per-attribute eval stats (<a href="https://github.com/Mic92/nixbot/pull/175">#175</a>)
</summary>

</details>
<details>
<summary>
Record eval duration and per-attribute eval stats (<a href="https://github.com/Mic92/nixbot/pull/176">#176</a>)
</summary>
nix-eval-jobs now reports wallMs/allocBytes per attribute. Store them
on build_attributes and the nix-eval-jobs runtime on builds so the UI
can answer 'how long did eval take' and 'which attrs are expensive'
(#162).

eval_duration_ms shares eval_completed's lifetime: set in
CommitEvalResult, cleared by SetBuildStatus('pending'), kept across
restarts that rebuild from stored rows, NULL for reused evals.

CompleteAttribute now COALESCEs eval data, which also stops dropping
eval warnings of failed_eval attributes.
</details>
<details>
<summary>
Show eval duration in build header, forge status, API, CLI and metrics (<a href="https://github.com/Mic92/nixbot/pull/177">#177</a>)
</summary>
Closes #162.
</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add per-build evaluation page listing attribute eval cost (<a href="https://github.com/Mic92/nixbot/pull/179">#179</a>)
</summary>
Linked from the eval duration in the build header. Sortable by time
or allocation so expensive attributes can be found without adding
columns to the build page.
</details>
</details>
</details>