### PR TITLE
[need #178] Add per-build evaluation page listing attribute eval cost

### DIFF
--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __all__: collections.abc.Sequence[str] = (
-    "AttributeEvalStatsRow",
+    "AttributeStatusRow",
     "MetricsAttributeCountsRow",
     "MetricsBuildCountsRow",
     "MetricsBuildDurationRow",
@@ -16,12 +16,12 @@ __all__: collections.abc.Sequence[str] = (
     "WebAttributeCountsRow",
     "WebAttributeHistoryRow",
     "WebAttributeNeighborNumbersRow",
+    "WebEvalStatsRow",
     "WebNeighborNumbersRow",
     "WebQueueRow",
     "WebRecentBuildsRow",
     "WebRepoOverviewRow",
     "attribute_error",
-    "attribute_eval_stats",
     "attribute_status",
     "metrics_attribute_counts",
     "metrics_build_counts",
@@ -38,6 +38,7 @@ __all__: collections.abc.Sequence[str] = (
     "web_build_by_number",
     "web_builds_for_repo",
     "web_effects",
+    "web_eval_stats",
     "web_neighbor_numbers",
     "web_projects",
     "web_queue",
@@ -192,7 +193,8 @@ class WebQueueRow:
 
 
 @dataclasses.dataclass()
-class AttributeEvalStatsRow:
+class AttributeStatusRow:
+    status: str
     eval_wall_ms: int | None
     eval_alloc_bytes: int | None
 
@@ -225,6 +227,14 @@ class MetricsProjectsRow:
 class MetricsEvalDurationRow:
     total: int
     count: int
+
+
+@dataclasses.dataclass()
+class WebEvalStatsRow:
+    attr: str
+    status: str
+    eval_wall_ms: int | None
+    eval_alloc_bytes: int | None
 
 
 WEB_PROJECTS: typing.Final[str] = """-- name: WebProjects :many
@@ -404,11 +414,7 @@ ORDER BY b.status = 'pending', b.id
 """
 
 ATTRIBUTE_STATUS: typing.Final[str] = """-- name: AttributeStatus :one
-SELECT status FROM build_attributes WHERE build_id = $1 AND attr = $2
-"""
-
-ATTRIBUTE_EVAL_STATS: typing.Final[str] = """-- name: AttributeEvalStats :one
-SELECT eval_wall_ms, eval_alloc_bytes FROM build_attributes
+SELECT status, eval_wall_ms, eval_alloc_bytes FROM build_attributes
 WHERE build_id = $1 AND attr = $2
 """
 
@@ -445,6 +451,14 @@ FROM projects
 METRICS_EVAL_DURATION: typing.Final[str] = """-- name: MetricsEvalDuration :one
 SELECT coalesce(sum(eval_duration_ms), 0)::float / 1000 AS total, count(*) AS count
 FROM builds WHERE eval_duration_ms IS NOT NULL
+"""
+
+WEB_EVAL_STATS: typing.Final[str] = """-- name: WebEvalStats :many
+SELECT attr, status, eval_wall_ms, eval_alloc_bytes FROM build_attributes
+WHERE build_id = $1 AND eval_wall_ms IS NOT NULL
+ORDER BY CASE WHEN $2::boolean
+    THEN eval_alloc_bytes ELSE eval_wall_ms END DESC, attr
+LIMIT $3::bigint
 """
 
 
@@ -794,18 +808,11 @@ def web_queue(conn: ConnectionLike, *, project_ids: collections.abc.Sequence[int
     return QueryResults(conn, WEB_QUEUE, _decode_hook, project_ids)
 
 
-async def attribute_status(conn: ConnectionLike, *, build_id: int, attr: str) -> str | None:
+async def attribute_status(conn: ConnectionLike, *, build_id: int, attr: str) -> AttributeStatusRow | None:
     row = await conn.fetchrow(ATTRIBUTE_STATUS, build_id, attr)
     if row is None:
         return None
-    return row[0]
-
-
-async def attribute_eval_stats(conn: ConnectionLike, *, build_id: int, attr: str) -> AttributeEvalStatsRow | None:
-    row = await conn.fetchrow(ATTRIBUTE_EVAL_STATS, build_id, attr)
-    if row is None:
-        return None
-    return AttributeEvalStatsRow(eval_wall_ms=row[0], eval_alloc_bytes=row[1])
+    return AttributeStatusRow(status=row[0], eval_wall_ms=row[1], eval_alloc_bytes=row[2])
 
 
 async def attribute_error(conn: ConnectionLike, *, build_id: int, attr: str) -> str | None:
@@ -855,3 +862,10 @@ async def metrics_eval_duration(conn: ConnectionLike) -> MetricsEvalDurationRow 
     if row is None:
         return None
     return MetricsEvalDurationRow(total=row[0], count=row[1])
+
+
+def web_eval_stats(conn: ConnectionLike, *, build_id: int, by_alloc: bool, limit_: int) -> QueryResults[WebEvalStatsRow]:
+    def _decode_hook(row: asyncpg.Record) -> WebEvalStatsRow:
+        return WebEvalStatsRow(attr=row[0], status=row[1], eval_wall_ms=row[2], eval_alloc_bytes=row[3])
+
+    return QueryResults(conn, WEB_EVAL_STATS, _decode_hook, build_id, by_alloc, limit_)

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -171,10 +171,7 @@ WHERE b.status IN ('pending', 'evaluating', 'building')
 ORDER BY b.status = 'pending', b.id;
 
 -- name: AttributeStatus :one
-SELECT status FROM build_attributes WHERE build_id = $1 AND attr = $2;
-
--- name: AttributeEvalStats :one
-SELECT eval_wall_ms, eval_alloc_bytes FROM build_attributes
+SELECT status, eval_wall_ms, eval_alloc_bytes FROM build_attributes
 WHERE build_id = $1 AND attr = $2;
 
 -- name: AttributeError :one
@@ -204,3 +201,11 @@ FROM projects;
 -- name: MetricsEvalDuration :one
 SELECT coalesce(sum(eval_duration_ms), 0)::float / 1000 AS total, count(*) AS count
 FROM builds WHERE eval_duration_ms IS NOT NULL;
+
+-- name: WebEvalStats :many
+-- Attributes with eval stats, most expensive first.
+SELECT attr, status, eval_wall_ms, eval_alloc_bytes FROM build_attributes
+WHERE build_id = $1 AND eval_wall_ms IS NOT NULL
+ORDER BY CASE WHEN sqlc.arg(by_alloc)::boolean
+    THEN eval_alloc_bytes ELSE eval_wall_ms END DESC, attr
+LIMIT sqlc.arg(limit_)::bigint;

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -2277,9 +2277,14 @@ def test_build_eval_stats_surface(client: WebHarness) -> None:
     client.loop.run_until_complete(seed())
     base = "/repos/github/acme/widget"
     text = client.get(f"{base}/builds/2").text
-    assert "· eval 38s" in text
+    assert ">eval 38s</a>" in text
     assert 'title="eval 412 ms · 48.0 MiB allocated"' in text
-    assert "· eval" not in client.get(f"{base}/builds/1").text
+    assert f'href="{base}/builds/2/eval"' in text
+    assert "/eval" not in client.get(f"{base}/builds/1").text
+    stats = client.get(f"{base}/builds/2/eval?sort=alloc").text
+    assert "x86_64-linux.evalfail" in stats
+    assert "48.0 MiB" in stats
+    assert client.get(f"{base}/builds/2/eval?sort=bogus").status_code == 404
     log_page = client.get(f"{base}/builds/2/logs/x86_64-linux.evalfail").text
     assert "eval 412 ms · 48.0 MiB allocated" in log_page
     history = client.get(f"{base}/attrs/x86_64-linux.evalfail").text

--- a/nixbot/nixbot/web/app.py
+++ b/nixbot/nixbot/web/app.py
@@ -590,6 +590,32 @@ class _PageRoutes:
             history=await ctx.queries.attribute_history(project["id"], attr),
         )
 
+    async def eval_page(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        sort: str = "time",
+    ) -> HTMLResponse:
+        """Per-attribute eval cost as reported by nix-eval-jobs."""
+        ctx = self.ctx
+        if sort not in ("time", "alloc"):
+            raise HTTPException(status_code=404)
+        project = await ctx.repo_or_404(forge, owner, name, request)
+        build = await ctx.queries.build_by_number(project["id"], number)
+        if build is None:
+            raise HTTPException(status_code=404)
+        return await ctx.render(
+            "eval.html",
+            request=request,
+            project=project,
+            build=build,
+            sort=sort,
+            rows=await ctx.queries.eval_stats(build["id"], by_alloc=sort == "alloc"),
+        )
+
     async def badge(
         self, request: Request, forge: str, owner: str, name: str, branch: str = ""
     ) -> Response:
@@ -640,6 +666,10 @@ def create_router(ctx: WebContext) -> APIRouter:
         (
             "/repos/{forge}/{owner:owner}/{name:segment}/builds/{number}/attrs",
             pages.attribute_rows,
+        ),
+        (
+            "/repos/{forge}/{owner:owner}/{name:segment}/builds/{number}/eval",
+            pages.eval_page,
         ),
         # :path — attribute names may contain slashes.
         (

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -8,7 +8,6 @@ executor's LogWriter fans out to any number of SSE subscribers.
 from __future__ import annotations
 
 import asyncio
-import dataclasses
 import functools
 import html
 import json
@@ -741,11 +740,10 @@ class _LogRoutes:
         served from the live capture; logs without per-derivation
         structure appear as a single synthetic entry."""
         _, build, path = await self._resolve(request, forge, owner, name, number, attr)
-        attr_status = await gen.attribute_status(
-            self.ctx.pool, build_id=build["id"], attr=attr
-        )
-        if attr_status is None:
+        row = await gen.attribute_status(self.ctx.pool, build_id=build["id"], attr=attr)
+        if row is None:
             raise HTTPException(status_code=404, detail="unknown attribute")
+        attr_status = row.status
         capture = self._capture(build, attr)
         if capture is not None:
             entries = capture.state(with_lines=False)
@@ -992,7 +990,7 @@ class _LogRoutes:
         )
         # Effect statuses live in build_effects, not attributes.
         is_effect = attr.startswith("effect:")
-        eval_stats = None
+        attr_row: dict[str, Any] = {}
         if is_effect:
             attr_status = await maint_gen.effect_status(
                 self.ctx.pool,
@@ -1000,12 +998,11 @@ class _LogRoutes:
                 name=attr.removeprefix("effect:"),
             )
         else:
-            attr_status = await gen.attribute_status(
+            row = await gen.attribute_status(
                 self.ctx.pool, build_id=build["id"], attr=attr
             )
-            eval_stats = await gen.attribute_eval_stats(
-                self.ctx.pool, build_id=build["id"], attr=attr
-            )
+            attr_row = row_dict(row) if row else {}
+            attr_status = row.status if row else None
         # Live pages render no snapshot: the stream replays full
         # history on connect, the client would throw it away.
         writer = self.registry.get(build["id"], attr)
@@ -1053,7 +1050,7 @@ class _LogRoutes:
             project=project,
             build=build,
             attr_status=attr_status,
-            eval_stats=dataclasses.asdict(eval_stats) if eval_stats else {},
+            attr_row=attr_row,
             is_effect=is_effect,
             attr=attr,
             content=content,

--- a/nixbot/nixbot/web/queries.py
+++ b/nixbot/nixbot/web/queries.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     import asyncpg
 
 PAGE_SIZE = 50
+EVAL_STATS_LIMIT = 500
 
 
 @dataclass
@@ -162,6 +163,16 @@ class WebQueries:
 
     async def effects(self, build_id: int) -> list[dict[str, Any]]:
         return _dicts(await gen.web_effects(self.pool, build_id=build_id))
+
+    async def eval_stats(
+        self, build_id: int, *, by_alloc: bool
+    ) -> list[dict[str, Any]]:
+        """Most expensive attributes to evaluate."""
+        return _dicts(
+            await gen.web_eval_stats(
+                self.pool, build_id=build_id, by_alloc=by_alloc, limit_=EVAL_STATS_LIMIT
+            )
+        )
 
     async def effects_status(self, build_id: int) -> str | None:
         row = await builds_gen.effects_summary(self.pool, build_id=build_id)

--- a/nixbot/nixbot/web/templates/_attr_rows.html
+++ b/nixbot/nixbot/web/templates/_attr_rows.html
@@ -13,8 +13,7 @@
         <ul class="attr-warnings">{% for w in aw %}<li>{{ w | ansi }}</li>{% endfor %}</ul>
       {% endif %}
     </td>
-    {% set es = a | eval_stats %}
-    <td class="attr-duration"{% if es %} title="{{ es }}"{% endif %}>{{ a | duration }}</td>
+    <td class="attr-duration" title="{{ a | eval_stats }}">{{ a | duration }}</td>
   </tr>
   {% if a.error %}{{ error_row(a.error) }}{% endif %}
 {% endfor %}

--- a/nixbot/nixbot/web/templates/attribute_history.html
+++ b/nixbot/nixbot/web/templates/attribute_history.html
@@ -28,10 +28,7 @@
               <td>{{ h.branch }}</td>
               <td>{{ status_pill(h.status) }}</td>
               <td>{{ commit_link(project, h.commit_sha) }}</td>
-              <td class="muted"
-                  {% if h.eval_alloc_bytes is not none %} title="{{ h.eval_alloc_bytes | human_bytes }} allocated"{% endif %}>
-                {{ h.eval_wall_ms | eval_ms if h.eval_wall_ms is not none else "" }}
-              </td>
+              <td class="muted" title="{{ h | eval_stats }}">{{ h.eval_wall_ms | eval_ms }}</td>
               <td>{{ ago(h.build_created_at) }}</td>
             </tr>
           {% else %}

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -53,7 +53,9 @@
             · <time datetime="{{ build.created_at.isoformat() }}"
        title="{{ build.created_at }}">{{ build.created_at | timeago }}</time>
             · {{ "running for" if build.status in RUNNING_STATUSES else "took" }} {{ build | duration }}
-            {% if build.eval_duration_ms is not none %}· eval {{ (build.eval_duration_ms / 1000) | duration_secs }}{% endif %}
+            {% if build.eval_duration_ms is not none %}
+              · <a href="{{ build_path(project, build.number) }}/eval">eval {{ (build.eval_duration_ms / 1000) | duration_secs }}</a>
+            {% endif %}
           </p>
         </div>
         <div class="controls">

--- a/nixbot/nixbot/web/templates/eval.html
+++ b/nixbot/nixbot/web/templates/eval.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% from "_macros.html" import status_icon %}
+{% block title %}
+  {{ repo_name(project.owner, project.name) }} #{{ build.number }} eval
+{% endblock title %}
+{% block body %}
+  <main id="main">
+    <section class="content">
+      <div class="build-header">
+        <div>
+          <h2>
+            {{ status_icon(build.status, labelled=false) }}<a href="{{ repo_path(project) }}">{{ repo_name(project.owner, project.name) }}</a>
+            <a href="{{ build_path(project, build.number) }}">build #{{ build.number }}</a>
+            evaluation
+          </h2>
+          <p class="build-meta">
+            {% if build.eval_duration_ms is not none %}took {{ (build.eval_duration_ms / 1000) | duration_secs }} ·{% endif %}
+            {{ rows | length }} attribute{{ "s" if rows | length != 1 }}
+            · measured per nix-eval-jobs worker, shared work counts towards the first attribute that needs it
+          </p>
+        </div>
+      </div>
+      <form method="get" class="filters">
+        <select name="sort" aria-label="sort by" onchange="this.form.submit()">
+          <option value="time" {% if sort == "time" %}selected{% endif %}>slowest first</option>
+          <option value="alloc" {% if sort == "alloc" %}selected{% endif %}>largest first</option>
+        </select>
+      </form>
+      <div class="table-scroll">
+        <table class="attrs">
+          <thead class="visually-hidden">
+            <tr>
+              <th scope="col">status</th>
+              <th scope="col">attribute</th>
+              <th scope="col">time</th>
+              <th scope="col">allocated</th>
+            </tr>
+          </thead>
+          {% for a in rows %}
+            <tr>
+              <td class="attr-status">{{ status_icon(a.status) }}</td>
+              <td class="attr-name">
+                <a href="{{ build_path(project, build.number) }}/logs/{{ a.attr | urlencode }}"><code>{{ a.attr }}</code></a>
+              </td>
+              <td class="attr-duration">{{ a.eval_wall_ms | eval_ms }}</td>
+              <td class="attr-duration">{{ a.eval_alloc_bytes | human_bytes }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="4" class="empty-state">no eval stats recorded</td>
+            </tr>
+          {% endfor %}
+        </table>
+      </div>
+    </section>
+  </main>
+{% endblock body %}

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -13,6 +13,7 @@
           <small>
             <a href="{{ build_path(project, build.number) }}">build #{{ build.number }}</a>
             · <a href="{{ build_path(project, build.number) }}/logs/raw/{{ attr | urlencode }}">raw</a>
+            {% if attr_row | eval_stats %}· {{ attr_row | eval_stats }}{% endif %}
             {% if prev_number %}
               · <a href="{{ build_path(project, prev_number) }}/logs/{{ attr | urlencode }}"
     rel="prev">‹ #{{ prev_number }}</a>
@@ -44,8 +45,6 @@
           {% endif %}
         </div>
       </div>
-      {% set es = eval_stats | eval_stats %}
-      {% if es %}<p class="muted eval-stats">{{ es }}</p>{% endif %}
       {% if waiting %}
         <p class="muted">waiting for the build to start…</p>
       {% elif unavailable %}


### PR DESCRIPTION
Linked from the eval duration in the build header. Sortable by time
or allocation so expensive attributes can be found without adding
columns to the build page.
<details>
<summary>
Committer details
</summary>
Local-Branch: eval-stats
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
nix-eval-jobs: bump for per-attribute eval stats (<a href="https://github.com/Mic92/nixbot/pull/175">#175</a>)
</summary>

</details>
<details>
<summary>
Record eval duration and per-attribute eval stats (<a href="https://github.com/Mic92/nixbot/pull/176">#176</a>)
</summary>
nix-eval-jobs now reports wallMs/allocBytes per attribute. Store them
on build_attributes and the nix-eval-jobs runtime on builds so the UI
can answer 'how long did eval take' and 'which attrs are expensive'
(#162).

eval_duration_ms shares eval_completed's lifetime: set in
CommitEvalResult, cleared by SetBuildStatus('pending'), kept across
restarts that rebuild from stored rows, NULL for reused evals.

CompleteAttribute now COALESCEs eval data, which also stops dropping
eval warnings of failed_eval attributes.
</details>
<details>
<summary>
Show eval duration in build header, forge status, API, CLI and metrics (<a href="https://github.com/Mic92/nixbot/pull/177">#177</a>)
</summary>
Closes #162.
</details>
<details>
<summary>
Show per-attribute eval stats on row tooltip, log page and history (<a href="https://github.com/Mic92/nixbot/pull/178">#178</a>)
</summary>

</details>
</details>
</details>