### PR TITLE
herculesCI: deploy via the generic flakelet-deploy user

### DIFF
--- a/herculesCI/default.nix
+++ b/herculesCI/default.nix
@@ -14,39 +14,32 @@ in
   onPush.default.outputs = {
     # Fire-and-forget: the target enqueues a detached flakelet update,
     # which restarts nixbot and with it this effect runner.
-    # flakelet until the branch merges to main
-    effects.deploy =
-      hci-effects.runIf
-        (builtins.elem (primaryRepo.branch or null) [
-          "main"
-          "flakelet"
-        ])
-        (
-          hci-effects.mkEffect {
-            name = "deploy";
-            idTokenAudiences = [ "step-ca-ssh" ];
-            inputs = [
-              pkgs.step-cli
-              pkgs.openssh
-            ];
-            effectScript = ''
-              export STEPPATH=$PWD/.step
-              step ca bootstrap --ca-url https://ca.r \
-                --fingerprint 759759ea7dc7d635d761ce19a07bc0b3ab02212318e05b49d2b194c60414b84a
+    effects.deploy = hci-effects.runIf (primaryRepo.branch or null == "main") (
+      hci-effects.mkEffect {
+        name = "deploy";
+        idTokenAudiences = [ "step-ca-ssh" ];
+        inputs = [
+          pkgs.step-cli
+          pkgs.openssh
+        ];
+        effectScript = ''
+          export STEPPATH=$PWD/.step
+          step ca bootstrap --ca-url https://ca.r \
+            --fingerprint 759759ea7dc7d635d761ce19a07bc0b3ab02212318e05b49d2b194c60414b84a
 
-              ssh-keygen -t ed25519 -N "" -q -f ./id_deploy
-              step ssh certificate --sign --provisioner nixbot \
-                --token "$(nixbot-id-token step-ca-ssh)" \
-                deploy ./id_deploy.pub
+          ssh-keygen -t ed25519 -N "" -q -f ./id_deploy
+          step ssh certificate --sign --provisioner nixbot \
+            --token "$(nixbot-id-token step-ca-ssh)" \
+            deploy ./id_deploy.pub
 
-              ssh -i ./id_deploy \
-                -o CertificateFile=./id_deploy-cert.pub \
-                -o UserKnownHostsFile=$PWD/known_hosts \
-                -o StrictHostKeyChecking=accept-new \
-                nixbot-deploy@eve.r deploy
-            '';
-          }
-        );
+          ssh -i ./id_deploy \
+            -o CertificateFile=./id_deploy-cert.pub \
+            -o UserKnownHostsFile=$PWD/known_hosts \
+            -o StrictHostKeyChecking=accept-new \
+            flakelet-deploy@eve.r
+        '';
+      }
+    );
     # Dogfood effects: publish the docs site to the gh-pages branch.
     effects.gh-pages = hci-effects.runIf (primaryRepo.branch or null == "main") (
       hci-effects.mkEffect {


### PR DESCRIPTION
eve now has a generic flakelet-deploy ssh user (dotfiles nixosModules/flakelet-deploy.nix). Merge after that is deployed on eve.