### PR TITLE
Tolerate missing outputs when re-registering gcroots on build reuse

### DIFF
--- a/nixbot/nixbot/build_reuse.py
+++ b/nixbot/nixbot/build_reuse.py
@@ -20,6 +20,7 @@ from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
 from .effects_run import post_effects_summary
 from .events import BuildResult, EvalReport
+from .gcroots import GcrootRegistrationError
 from .gitrepo import GitError, run_git
 
 if TYPE_CHECKING:
@@ -204,7 +205,15 @@ async def post_process_skipped(
         # Forge-scoped paths: the same owner/repo on two forges
         # must not share gc-roots or outputs files.
         if branches.do_register_gcroot(repo.default_branch, event.branch):
-            await o.register_gcroot(o.config.gcroots_dir, repo.key, attr, out_path)
+            try:
+                await o.register_gcroot(o.config.gcroots_dir, repo.key, attr, out_path)
+            except GcrootRegistrationError as e:
+                # A recorded output may be gone (remote-built, GC'd). Not
+                # worth failing the reuse or the remaining attrs over.
+                logger.warning(
+                    "gcroot not registered",
+                    extra={"attr": attr, "out_path": out_path, "error": str(e)[:200]},
+                )
         if o.config.outputs_path is not None and branches.do_update_outputs(
             repo.default_branch, event.branch
         ):

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -28,6 +28,7 @@ from nixbot.db_gen import builds as builds_q
 from nixbot.effects import EffectMeta, EffectsContext
 from nixbot.events import BuildResult, ChangeEvent, EvalReport, RepoInfo
 from nixbot.executor import attribute_log_path, effect_log_path
+from nixbot.gcroots import GcrootRegistrationError
 from nixbot.gitrepo import FetchCredentials, RepoManager
 from nixbot.memory import EvalWorkerConfig
 from nixbot.models import CacheStatus
@@ -2291,3 +2292,38 @@ async def test_reuse_post_process_error_still_reports_status(
     finished = [e for e in reporter.events if e[0] == "finished"]
     assert finished
     assert finished[-1][2] == BuildStatus.SUCCEEDED
+
+
+async def test_reuse_with_missing_output_still_post_processes(
+    make_env: EnvFactory, upstream: Path, pool: asyncpg.Pool
+) -> None:
+    """An output that is gone from the local store (remote-built,
+    GC'd) must not abort the reuse: the rest of post-processing
+    (schedules, events) still happens."""
+    add_commit(upstream, "reuse-gone")
+    sha = git(upstream, "rev-parse", "HEAD")
+    orchestrator, _reporter, project = await make_env(
+        FakeEvalRunner([mk_job("a"), mk_job("b")]),
+        FakeExecutor(),
+        name="reuse-gone",
+    )
+    assert await orchestrator.handle_change_event(
+        ChangeEvent(repo=project, branch="main", commit_sha=sha)
+    )
+    registered: list[str] = []
+
+    async def gone(gcroots_dir: Path, proj: str, attr: str, out: str) -> None:
+        if attr == "a":
+            msg = "don't know how to build these paths"
+            raise GcrootRegistrationError(msg)
+        registered.append(attr)
+
+    orchestrator.register_gcroot = gone
+    await pool.execute("DELETE FROM work_queue WHERE kind = 'refresh-schedules'")
+    assert await orchestrator.handle_change_event(
+        ChangeEvent(repo=project, branch="main", commit_sha=sha)
+    )
+    assert registered == ["b"]
+    assert await pool.fetchval(
+        "SELECT count(*) FROM work_queue WHERE kind = 'refresh-schedules'"
+    )


### PR DESCRIPTION
A reused build's recorded output may have been built remotely or collected since. nix-store -r then failed and aborted the rest of the reuse post-processing on every redelivery.