### PR TITLE
Unify effect run storage, inject effects backend

### DIFF
--- a/nixbot/nixbot/build_reuse.py
+++ b/nixbot/nixbot/build_reuse.py
@@ -20,6 +20,7 @@ from .db_gen import builds as builds_q
 from .db_gen import maintenance as q
 from .effects_run import post_effects_summary
 from .events import BuildResult, EvalReport
+from .gcroots import GcrootRegistrationError
 from .gitrepo import GitError, run_git
 
 if TYPE_CHECKING:
@@ -204,7 +205,15 @@ async def post_process_skipped(
         # Forge-scoped paths: the same owner/repo on two forges
         # must not share gc-roots or outputs files.
         if branches.do_register_gcroot(repo.default_branch, event.branch):
-            await o.register_gcroot(o.config.gcroots_dir, repo.key, attr, out_path)
+            try:
+                await o.register_gcroot(o.config.gcroots_dir, repo.key, attr, out_path)
+            except GcrootRegistrationError as e:
+                # A recorded output may be gone (remote-built, GC'd). Not
+                # worth failing the reuse or the remaining attrs over.
+                logger.warning(
+                    "gcroot not registered",
+                    extra={"attr": attr, "out_path": out_path, "error": str(e)[:200]},
+                )
         if o.config.outputs_path is not None and branches.do_update_outputs(
             repo.default_branch, event.branch
         ):

--- a/nixbot/nixbot/db_gen/builds.py
+++ b/nixbot/nixbot/db_gen/builds.py
@@ -176,10 +176,10 @@ UPDATE builds SET eval_warnings = $2::jsonb WHERE id = $1
 
 SET_BUILD_STATUS: typing.Final[str] = """-- name: SetBuildStatus :exec
 WITH failed_effects AS (
-    UPDATE build_effects SET status = 'failed',
+    UPDATE effect_runs SET status = 'failed',
         error = 'build did not succeed', finished_at = now()
-    WHERE build_effects.build_id = $4::bigint
-      AND build_effects.status = 'pending'
+    WHERE effect_runs.build_id = $4::bigint
+      AND effect_runs.status = 'pending'
       AND $1::text IN ('failed', 'cancelled')
 )
 UPDATE builds
@@ -290,40 +290,46 @@ WHERE NOT $14::boolean
     OR build_attributes.status IN ('pending', 'building')
 """
 
-START_EFFECT: typing.Final[str] = """-- name: StartEffect :exec
-INSERT INTO build_effects (build_id, name, status) VALUES ($1, $2, $3)
-ON CONFLICT (build_id, name) DO UPDATE SET
-    status = $3, error = NULL, log_size = 0,
+START_EFFECT: typing.Final[str] = """-- name: StartEffect :one
+INSERT INTO effect_runs (project_id, kind, build_id, name, status)
+SELECT b.project_id, 'push', b.id, $1::text, $2::text
+FROM builds b WHERE b.id = $3::bigint
+ON CONFLICT (build_id, kind, name) DO UPDATE SET
+    status = EXCLUDED.status, error = NULL, log_size = 0,
     log_truncated = FALSE, started_at = now(), finished_at = NULL
+RETURNING id
 """
 
 START_PENDING_EFFECTS: typing.Final[str] = """-- name: StartPendingEffects :exec
-INSERT INTO build_effects (build_id, name, status, deps)
-SELECT $1::bigint, u.name, 'pending', u.deps::jsonb
-FROM (SELECT unnest($2::text[]) AS name,
-             unnest($3::text[]) AS deps) AS u
-ON CONFLICT (build_id, name) DO UPDATE SET
+INSERT INTO effect_runs (project_id, kind, build_id, name, status, deps)
+SELECT b.project_id, 'push', b.id, u.name, 'pending', u.deps::jsonb
+FROM builds b,
+     (SELECT unnest($1::text[]) AS name,
+             unnest($2::text[]) AS deps) AS u
+WHERE b.id = $3::bigint
+ON CONFLICT (build_id, kind, name) DO UPDATE SET
     status = 'pending', error = NULL, log_size = 0,
     log_truncated = FALSE, started_at = now(), finished_at = NULL,
     deps = EXCLUDED.deps
 """
 
 RECORD_SKIPPED_EFFECTS: typing.Final[str] = """-- name: RecordSkippedEffects :exec
-INSERT INTO build_effects (build_id, name, status, finished_at)
-SELECT $1::bigint, u.name, 'skipped', now()
-FROM unnest($2::text[]) AS u(name)
-ON CONFLICT (build_id, name) DO NOTHING
+INSERT INTO effect_runs (project_id, kind, build_id, name, status, finished_at)
+SELECT b.project_id, 'push', b.id, u.name, 'skipped', now()
+FROM builds b, unnest($1::text[]) AS u(name)
+WHERE b.id = $2::bigint
+ON CONFLICT (build_id, kind, name) DO NOTHING
 """
 
 EFFECT_DEP_STATUSES: typing.Final[str] = """-- name: EffectDepStatuses :many
-SELECT d.name, d.status FROM build_effects e
-JOIN build_effects d ON d.build_id = e.build_id
+SELECT d.name, d.status FROM effect_runs e
+JOIN effect_runs d ON d.build_id = e.build_id
     AND d.name IN (SELECT jsonb_array_elements_text(e.deps))
 WHERE e.build_id = $1 AND e.name = $2
 """
 
 FINISH_EFFECT: typing.Final[str] = """-- name: FinishEffect :exec
-UPDATE build_effects SET
+UPDATE effect_runs SET
     status = $3, error = $6,
     log_size = $4, log_truncated = $5, finished_at = now()
 WHERE build_id = $1 AND name = $2
@@ -342,12 +348,12 @@ SELECT
         WHEN bool_or(status = 'succeeded') THEN 'succeeded'
         ELSE 'skipped'
     END::text AS status
-FROM build_effects WHERE build_id = $1
+FROM effect_runs WHERE build_id = $1
 HAVING count(*) > 0
 """
 
 EFFECTS_FOR_BUILD: typing.Final[str] = """-- name: EffectsForBuild :many
-SELECT id, build_id, name, status, error, log_size, log_truncated, started_at, finished_at, deps FROM build_effects WHERE build_id = $1 ORDER BY name
+SELECT id, project_id, kind, build_id, schedule_name, name, status, error, deps, log_size, log_truncated, started_at, finished_at FROM effect_runs WHERE build_id = $1 ORDER BY name
 """
 
 ATTRIBUTE_STATUSES: typing.Final[str] = """-- name: AttributeStatuses :many
@@ -697,39 +703,42 @@ async def complete_attribute(
     await conn.execute(COMPLETE_ATTRIBUTE, build_id, attr, system, drv_path, status, error, cached, outputs, log_size, log_truncated, eval_warnings, eval_wall_ms, eval_alloc_bytes, if_unfinished)
 
 
-async def start_effect(conn: ConnectionLike, *, build_id: int, name: str, status: str) -> None:
-    await conn.execute(START_EFFECT, build_id, name, status)
+async def start_effect(conn: ConnectionLike, *, name: str, status: str, build_id: int) -> int | None:
+    row = await conn.fetchrow(START_EFFECT, name, status, build_id)
+    if row is None:
+        return None
+    return row[0]
 
 
-async def start_pending_effects(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str], deps: collections.abc.Sequence[str]) -> None:
-    await conn.execute(START_PENDING_EFFECTS, build_id, names, deps)
+async def start_pending_effects(conn: ConnectionLike, *, names: collections.abc.Sequence[str], deps: collections.abc.Sequence[str], build_id: int) -> None:
+    await conn.execute(START_PENDING_EFFECTS, names, deps, build_id)
 
 
-async def record_skipped_effects(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str]) -> None:
-    await conn.execute(RECORD_SKIPPED_EFFECTS, build_id, names)
+async def record_skipped_effects(conn: ConnectionLike, *, names: collections.abc.Sequence[str], build_id: int) -> None:
+    await conn.execute(RECORD_SKIPPED_EFFECTS, names, build_id)
 
 
-def effect_dep_statuses(conn: ConnectionLike, *, build_id: int, name: str) -> QueryResults[EffectDepStatusesRow]:
+def effect_dep_statuses(conn: ConnectionLike, *, build_id: int | None, name: str) -> QueryResults[EffectDepStatusesRow]:
     def _decode_hook(row: asyncpg.Record) -> EffectDepStatusesRow:
         return EffectDepStatusesRow(name=row[0], status=row[1])
 
     return QueryResults(conn, EFFECT_DEP_STATUSES, _decode_hook, build_id, name)
 
 
-async def finish_effect(conn: ConnectionLike, *, build_id: int, name: str, status: str, log_size: int, log_truncated: bool, error: str | None) -> None:
+async def finish_effect(conn: ConnectionLike, *, build_id: int | None, name: str, status: str, log_size: int, log_truncated: bool, error: str | None) -> None:
     await conn.execute(FINISH_EFFECT, build_id, name, status, log_size, log_truncated, error)
 
 
-async def effects_summary(conn: ConnectionLike, *, build_id: int) -> EffectsSummaryRow | None:
+async def effects_summary(conn: ConnectionLike, *, build_id: int | None) -> EffectsSummaryRow | None:
     row = await conn.fetchrow(EFFECTS_SUMMARY, build_id)
     if row is None:
         return None
     return EffectsSummaryRow(failed=row[0], succeeded=row[1], status=row[2])
 
 
-def effects_for_build(conn: ConnectionLike, *, build_id: int) -> QueryResults[models.BuildEffect]:
-    def _decode_hook(row: asyncpg.Record) -> models.BuildEffect:
-        return models.BuildEffect(id_=row[0], build_id=row[1], name=row[2], status=row[3], error=row[4], log_size=row[5], log_truncated=row[6], started_at=row[7], finished_at=row[8], deps=row[9])
+def effects_for_build(conn: ConnectionLike, *, build_id: int | None) -> QueryResults[models.EffectRun]:
+    def _decode_hook(row: asyncpg.Record) -> models.EffectRun:
+        return models.EffectRun(id_=row[0], project_id=row[1], kind=row[2], build_id=row[3], schedule_name=row[4], name=row[5], status=row[6], error=row[7], deps=row[8], log_size=row[9], log_truncated=row[10], started_at=row[11], finished_at=row[12])
 
     return QueryResults(conn, EFFECTS_FOR_BUILD, _decode_hook, build_id)
 

--- a/nixbot/nixbot/db_gen/maintenance.py
+++ b/nixbot/nixbot/db_gen/maintenance.py
@@ -14,6 +14,7 @@ __all__: collections.abc.Sequence[str] = (
     "all_build_ids",
     "attribute_known",
     "attributes_for_builds",
+    "build_effect_run_ids",
     "cancel_attribute",
     "cancel_build",
     "cleanup_old_rows",
@@ -24,7 +25,6 @@ __all__: collections.abc.Sequence[str] = (
     "drop_removed_effects",
     "effect_status",
     "fail_interrupted_effects",
-    "fail_interrupted_scheduled_runs",
     "find_unfinished_builds",
     "project_has_builds",
     "reset_build_for_restart",
@@ -63,7 +63,7 @@ class AttributesForBuildsRow:
 
 @dataclasses.dataclass()
 class FailInterruptedEffectsRow:
-    build_id: int
+    build_id: int | None
     name: str
 
 
@@ -100,7 +100,7 @@ WITH cleared_failures AS (
     WHERE build_id = $2::bigint
       AND ($1::text IS NULL OR attr = $1)
 ), reset_effect_rows AS (
-    UPDATE build_effects SET status = 'pending', error = NULL,
+    UPDATE effect_runs SET status = 'pending', error = NULL,
         finished_at = NULL, log_size = 0, log_truncated = FALSE
     WHERE build_id = $2::bigint
       AND $1::text IS NULL
@@ -116,7 +116,7 @@ RESET_EFFECTS_STATE: typing.Final[str] = """-- name: ResetEffectsState :exec
 WITH flag AS (
     UPDATE builds SET effects_started = FALSE WHERE id = $1
 )
-UPDATE build_effects SET status = 'pending', error = NULL,
+UPDATE effect_runs SET status = 'pending', error = NULL,
     finished_at = NULL, log_size = 0,
     log_truncated = FALSE
 WHERE build_id = $1
@@ -176,16 +176,10 @@ FROM build_attributes WHERE build_id = ANY($1::bigint[])
 """
 
 FAIL_INTERRUPTED_EFFECTS: typing.Final[str] = """-- name: FailInterruptedEffects :many
-UPDATE build_effects SET status = 'failed',
+UPDATE effect_runs SET status = 'failed',
     error = 'interrupted by a service restart', finished_at = now()
 WHERE status = 'running' AND started_at < $1
 RETURNING build_id, name
-"""
-
-FAIL_INTERRUPTED_SCHEDULED_RUNS: typing.Final[str] = """-- name: FailInterruptedScheduledRuns :exec
-UPDATE scheduled_effect_runs SET status = 'failed',
-    error = 'interrupted by a service restart', finished_at = now()
-WHERE status = 'running' AND started_at < $1
 """
 
 CLEANUP_OLD_ROWS: typing.Final[str] = """-- name: CleanupOldRows :many
@@ -198,10 +192,10 @@ WITH del_builds AS (
       AND status IN ('succeeded', 'failed', 'cancelled')
     RETURNING builds.id
 ), del_runs AS (
-    DELETE FROM scheduled_effect_runs
-    WHERE finished_at IS NOT NULL
+    DELETE FROM effect_runs
+    WHERE build_id IS NULL AND finished_at IS NOT NULL
       AND finished_at < now() - make_interval(days => $1::int)
-    RETURNING scheduled_effect_runs.id
+    RETURNING effect_runs.id
 ), pruned_statuses AS (
     DELETE FROM failed_statuses
     WHERE to_timestamp(timestamp)
@@ -217,7 +211,10 @@ WITH del_builds AS (
 )
 SELECT 'build' AS kind, del_builds.id FROM del_builds
 UNION ALL
-SELECT 'scheduled_run' AS kind, del_runs.id FROM del_runs
+SELECT 'effect_run' AS kind, del_runs.id FROM del_runs
+UNION ALL
+SELECT 'effect_run' AS kind, r.id FROM effect_runs r
+WHERE r.build_id IN (SELECT del_builds.id FROM del_builds)
 """
 
 ALL_BUILD_IDS: typing.Final[str] = """-- name: AllBuildIds :many
@@ -252,12 +249,17 @@ SELECT cancelled.status_generation FROM cancelled
 """
 
 DROP_REMOVED_EFFECTS: typing.Final[str] = """-- name: DropRemovedEffects :exec
-DELETE FROM build_effects WHERE build_id = $1
+DELETE FROM effect_runs WHERE build_id = $1
 AND NOT (name = ANY($2::text[]))
 """
 
 EFFECT_STATUS: typing.Final[str] = """-- name: EffectStatus :one
-SELECT status FROM build_effects WHERE build_id = $1 AND name = $2
+SELECT status FROM effect_runs WHERE build_id = $1 AND kind = 'push' AND name = $2
+"""
+
+BUILD_EFFECT_RUN_IDS: typing.Final[str] = """-- name: BuildEffectRunIds :many
+SELECT id FROM effect_runs WHERE build_id = $1
+  AND ($2::text[] IS NULL OR name = ANY($2::text[]))
 """
 
 SUCCEEDED_ATTRIBUTE_OUTPUTS: typing.Final[str] = """-- name: SucceededAttributeOutputs :many
@@ -332,7 +334,7 @@ async def reset_build_for_restart(conn: ConnectionLike, *, attr: str | None, bui
     await conn.execute(RESET_BUILD_FOR_RESTART, attr, build_id)
 
 
-async def reset_effects_state(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str] | None) -> None:
+async def reset_effects_state(conn: ConnectionLike, *, build_id: int | None, names: collections.abc.Sequence[str] | None) -> None:
     await conn.execute(RESET_EFFECTS_STATE, build_id, names)
 
 
@@ -406,10 +408,6 @@ def fail_interrupted_effects(conn: ConnectionLike, *, started_before: datetime.d
     return QueryResults(conn, FAIL_INTERRUPTED_EFFECTS, _decode_hook, started_before)
 
 
-async def fail_interrupted_scheduled_runs(conn: ConnectionLike, *, started_before: datetime.datetime) -> None:
-    await conn.execute(FAIL_INTERRUPTED_SCHEDULED_RUNS, started_before)
-
-
 def cleanup_old_rows(conn: ConnectionLike, *, retention_days: int) -> QueryResults[CleanupOldRowsRow]:
     def _decode_hook(row: asyncpg.Record) -> CleanupOldRowsRow:
         return CleanupOldRowsRow(kind=row[0], id_=row[1])
@@ -437,15 +435,19 @@ async def cancel_build(conn: ConnectionLike, *, id_: int) -> int | None:
     return row[0]
 
 
-async def drop_removed_effects(conn: ConnectionLike, *, build_id: int, names: collections.abc.Sequence[str]) -> None:
+async def drop_removed_effects(conn: ConnectionLike, *, build_id: int | None, names: collections.abc.Sequence[str]) -> None:
     await conn.execute(DROP_REMOVED_EFFECTS, build_id, names)
 
 
-async def effect_status(conn: ConnectionLike, *, build_id: int, name: str) -> str | None:
+async def effect_status(conn: ConnectionLike, *, build_id: int | None, name: str) -> str | None:
     row = await conn.fetchrow(EFFECT_STATUS, build_id, name)
     if row is None:
         return None
     return row[0]
+
+
+def build_effect_run_ids(conn: ConnectionLike, *, build_id: int | None, names: collections.abc.Sequence[str] | None) -> QueryResults[int]:
+    return QueryResults(conn, BUILD_EFFECT_RUN_IDS, operator.itemgetter(0), build_id, names)
 
 
 def succeeded_attribute_outputs(conn: ConnectionLike, *, build_id: int) -> QueryResults[SucceededAttributeOutputsRow]:

--- a/nixbot/nixbot/db_gen/models.py
+++ b/nixbot/nixbot/db_gen/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 __all__: collections.abc.Sequence[str] = (
     "Build",
     "BuildAttribute",
-    "BuildEffect",
+    "EffectRun",
     "Project",
     "ScheduledEffect",
 )
@@ -66,17 +66,20 @@ class BuildAttribute:
 
 
 @dataclasses.dataclass()
-class BuildEffect:
+class EffectRun:
     id_: int
-    build_id: int
+    project_id: int
+    kind: str
+    build_id: int | None
+    schedule_name: str | None
     name: str
     status: str
     error: str | None
+    deps: str | None
     log_size: int
     log_truncated: bool
     started_at: datetime.datetime
     finished_at: datetime.datetime | None
-    deps: str | None
 
 
 @dataclasses.dataclass()

--- a/nixbot/nixbot/db_gen/scheduled.py
+++ b/nixbot/nixbot/db_gen/scheduled.py
@@ -9,7 +9,6 @@ __all__: collections.abc.Sequence[str] = (
     "LatestScheduledRunsRow",
     "ProjectSchedulesRow",
     "QueryResults",
-    "ScheduledRunDetailRow",
     "ScheduledRunsForEffectRow",
     "SchedulesForUpdateRow",
     "delete_project_schedules",
@@ -19,8 +18,6 @@ __all__: collections.abc.Sequence[str] = (
     "latest_scheduled_runs",
     "mark_schedule_run",
     "project_schedules",
-    "scheduled_run_detail",
-    "scheduled_run_exists",
     "scheduled_runs_for_effect",
     "schedules_for_update",
     "start_scheduled_run",
@@ -53,7 +50,7 @@ class SchedulesForUpdateRow:
 @dataclasses.dataclass()
 class LatestScheduledRunsRow:
     id_: int
-    schedule_name: str
+    schedule_name: str | None
     effect: str
     status: str
     error: str | None
@@ -70,20 +67,9 @@ class ProjectSchedulesRow:
 
 
 @dataclasses.dataclass()
-class ScheduledRunDetailRow:
-    id_: int
-    schedule_name: str
-    effect: str
-    status: str
-    error: str | None
-    started_at: datetime.datetime
-    finished_at: datetime.datetime | None
-
-
-@dataclasses.dataclass()
 class ScheduledRunsForEffectRow:
     id_: int
-    schedule_name: str
+    schedule_name: str | None
     effect: str
     status: str
     error: str | None
@@ -120,21 +106,23 @@ WHERE last_run IS NULL
 """
 
 START_SCHEDULED_RUN: typing.Final[str] = """-- name: StartScheduledRun :one
-INSERT INTO scheduled_effect_runs (project_id, schedule_name, effect)
-VALUES ($1, $2, $3) RETURNING id
+INSERT INTO effect_runs (project_id, kind, schedule_name, name)
+VALUES ($1, 'schedule', $2, $3) RETURNING id
 """
 
 FINISH_SCHEDULED_RUN: typing.Final[str] = """-- name: FinishScheduledRun :exec
-UPDATE scheduled_effect_runs
-SET status = $2, error = $3, finished_at = now() WHERE id = $1
+UPDATE effect_runs
+SET status = $2, error = $5, log_size = $3, log_truncated = $4,
+    finished_at = now()
+WHERE id = $1
 """
 
 LATEST_SCHEDULED_RUNS: typing.Final[str] = """-- name: LatestScheduledRuns :many
-SELECT DISTINCT ON (schedule_name, effect)
-       id, schedule_name, effect, status, error,
+SELECT DISTINCT ON (schedule_name, name)
+       id, schedule_name, name AS effect, status, error,
        started_at, finished_at
-FROM scheduled_effect_runs WHERE project_id = $1
-ORDER BY schedule_name, effect, started_at DESC
+FROM effect_runs WHERE project_id = $1 AND kind = 'schedule'
+ORDER BY schedule_name, name, started_at DESC
 """
 
 PROJECT_SCHEDULES: typing.Final[str] = """-- name: ProjectSchedules :many
@@ -148,21 +136,13 @@ UPDATE scheduled_effects SET last_run = $4
 WHERE project_id = $1 AND schedule_name = $2 AND effect = $3
 """
 
-SCHEDULED_RUN_EXISTS: typing.Final[str] = """-- name: ScheduledRunExists :one
-SELECT id FROM scheduled_effect_runs WHERE id = $1 AND project_id = $2
-"""
-
-SCHEDULED_RUN_DETAIL: typing.Final[str] = """-- name: ScheduledRunDetail :one
-SELECT id, schedule_name, effect, status, error, started_at, finished_at
-FROM scheduled_effect_runs WHERE id = $1 AND project_id = $2
-"""
-
 SCHEDULED_RUNS_FOR_EFFECT: typing.Final[str] = """-- name: ScheduledRunsForEffect :many
-SELECT id, schedule_name, effect, status, error, started_at, finished_at
-FROM scheduled_effect_runs
+SELECT id, schedule_name, name AS effect, status, error, started_at, finished_at
+FROM effect_runs
 WHERE project_id = $1
+  AND kind = 'schedule'
   AND schedule_name = $2
-  AND effect = $3
+  AND name = $3
   AND ($4::bigint IS NULL OR id < $4)
 ORDER BY id DESC LIMIT $5::bigint
 """
@@ -232,15 +212,15 @@ def due_schedule_rows(conn: ConnectionLike, *, now: datetime.datetime) -> QueryR
     return QueryResults(conn, DUE_SCHEDULE_ROWS, _decode_hook, now)
 
 
-async def start_scheduled_run(conn: ConnectionLike, *, project_id: int, schedule_name: str, effect: str) -> int | None:
-    row = await conn.fetchrow(START_SCHEDULED_RUN, project_id, schedule_name, effect)
+async def start_scheduled_run(conn: ConnectionLike, *, project_id: int, schedule_name: str | None, name: str) -> int | None:
+    row = await conn.fetchrow(START_SCHEDULED_RUN, project_id, schedule_name, name)
     if row is None:
         return None
     return row[0]
 
 
-async def finish_scheduled_run(conn: ConnectionLike, *, id_: int, status: str, error: str | None) -> None:
-    await conn.execute(FINISH_SCHEDULED_RUN, id_, status, error)
+async def finish_scheduled_run(conn: ConnectionLike, *, id_: int, status: str, log_size: int, log_truncated: bool, error: str | None) -> None:
+    await conn.execute(FINISH_SCHEDULED_RUN, id_, status, log_size, log_truncated, error)
 
 
 def latest_scheduled_runs(conn: ConnectionLike, *, project_id: int) -> QueryResults[LatestScheduledRunsRow]:
@@ -261,21 +241,7 @@ async def mark_schedule_run(conn: ConnectionLike, *, project_id: int, schedule_n
     await conn.execute(MARK_SCHEDULE_RUN, project_id, schedule_name, effect, last_run)
 
 
-async def scheduled_run_exists(conn: ConnectionLike, *, id_: int, project_id: int) -> int | None:
-    row = await conn.fetchrow(SCHEDULED_RUN_EXISTS, id_, project_id)
-    if row is None:
-        return None
-    return row[0]
-
-
-async def scheduled_run_detail(conn: ConnectionLike, *, id_: int, project_id: int) -> ScheduledRunDetailRow | None:
-    row = await conn.fetchrow(SCHEDULED_RUN_DETAIL, id_, project_id)
-    if row is None:
-        return None
-    return ScheduledRunDetailRow(id_=row[0], schedule_name=row[1], effect=row[2], status=row[3], error=row[4], started_at=row[5], finished_at=row[6])
-
-
-def scheduled_runs_for_effect(conn: ConnectionLike, *, project_id: int, schedule_name: str, effect: str, before: int | None, limit_: int) -> QueryResults[ScheduledRunsForEffectRow]:
+def scheduled_runs_for_effect(conn: ConnectionLike, *, project_id: int, schedule_name: str | None, effect: str, before: int | None, limit_: int) -> QueryResults[ScheduledRunsForEffectRow]:
     def _decode_hook(row: asyncpg.Record) -> ScheduledRunsForEffectRow:
         return ScheduledRunsForEffectRow(id_=row[0], schedule_name=row[1], effect=row[2], status=row[3], error=row[4], started_at=row[5], finished_at=row[6])
 

--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 __all__: collections.abc.Sequence[str] = (
     "AttributeStatusRow",
+    "EffectRunDetailRow",
     "MetricsAttributeCountsRow",
     "MetricsBuildCountsRow",
     "MetricsBuildDurationRow",
@@ -23,6 +24,8 @@ __all__: collections.abc.Sequence[str] = (
     "WebRepoOverviewRow",
     "attribute_error",
     "attribute_status",
+    "effect_run_detail",
+    "effect_run_id",
     "metrics_attribute_counts",
     "metrics_build_counts",
     "metrics_build_duration",
@@ -123,6 +126,20 @@ class WebRecentBuildsRow:
 class WebNeighborNumbersRow:
     prev: int
     next: int
+
+
+@dataclasses.dataclass()
+class EffectRunDetailRow:
+    id_: int
+    kind: str
+    build_id: int | None
+    schedule_name: str | None
+    effect: str
+    status: str
+    error: str | None
+    started_at: datetime.datetime
+    finished_at: datetime.datetime | None
+    build_number: int | None
 
 
 @dataclasses.dataclass()
@@ -359,8 +376,19 @@ WHERE a.build_id = $1 AND a.finished_at IS NOT NULL
 ORDER BY a.finished_at, a.id
 """
 
+EFFECT_RUN_DETAIL: typing.Final[str] = """-- name: EffectRunDetail :one
+SELECT r.id, r.kind, r.build_id, r.schedule_name, r.name AS effect, r.status,
+       r.error, r.started_at, r.finished_at, b.number AS build_number
+FROM effect_runs r LEFT JOIN builds b ON b.id = r.build_id
+WHERE r.id = $1 AND r.project_id = $2
+"""
+
+EFFECT_RUN_ID: typing.Final[str] = """-- name: EffectRunId :one
+SELECT id FROM effect_runs WHERE build_id = $1 AND kind = 'push' AND name = $2
+"""
+
 WEB_EFFECTS: typing.Final[str] = """-- name: WebEffects :many
-SELECT id, build_id, name, status, error, log_size, log_truncated, started_at, finished_at, deps FROM build_effects WHERE build_id = $1
+SELECT id, project_id, kind, build_id, schedule_name, name, status, error, deps, log_size, log_truncated, started_at, finished_at FROM effect_runs WHERE build_id = $1
 ORDER BY array_position(
     ARRAY['failed', 'dependency_failed', 'running', 'pending', 'succeeded', 'skipped'],
     status), name
@@ -701,9 +729,23 @@ def web_attributes_finished_after(conn: ConnectionLike, *, build_id: int, after:
     return QueryResults(conn, WEB_ATTRIBUTES_FINISHED_AFTER, _decode_hook, build_id, after, after_id)
 
 
-def web_effects(conn: ConnectionLike, *, build_id: int) -> QueryResults[models.BuildEffect]:
-    def _decode_hook(row: asyncpg.Record) -> models.BuildEffect:
-        return models.BuildEffect(id_=row[0], build_id=row[1], name=row[2], status=row[3], error=row[4], log_size=row[5], log_truncated=row[6], started_at=row[7], finished_at=row[8], deps=row[9])
+async def effect_run_detail(conn: ConnectionLike, *, id_: int, project_id: int) -> EffectRunDetailRow | None:
+    row = await conn.fetchrow(EFFECT_RUN_DETAIL, id_, project_id)
+    if row is None:
+        return None
+    return EffectRunDetailRow(id_=row[0], kind=row[1], build_id=row[2], schedule_name=row[3], effect=row[4], status=row[5], error=row[6], started_at=row[7], finished_at=row[8], build_number=row[9])
+
+
+async def effect_run_id(conn: ConnectionLike, *, build_id: int | None, name: str) -> int | None:
+    row = await conn.fetchrow(EFFECT_RUN_ID, build_id, name)
+    if row is None:
+        return None
+    return row[0]
+
+
+def web_effects(conn: ConnectionLike, *, build_id: int | None) -> QueryResults[models.EffectRun]:
+    def _decode_hook(row: asyncpg.Record) -> models.EffectRun:
+        return models.EffectRun(id_=row[0], project_id=row[1], kind=row[2], build_id=row[3], schedule_name=row[4], name=row[5], status=row[6], error=row[7], deps=row[8], log_size=row[9], log_truncated=row[10], started_at=row[11], finished_at=row[12])
 
     return QueryResults(conn, WEB_EFFECTS, _decode_hook, build_id)
 

--- a/nixbot/nixbot/db_gen/work_queue.py
+++ b/nixbot/nixbot/db_gen/work_queue.py
@@ -68,8 +68,8 @@ WHERE id = (
                    AND (r.created_at, r.id) < (w.created_at, w.id)))
       )
       AND NOT (w.kind = 'effect' AND EXISTS (
-        SELECT 1 FROM build_effects e
-        JOIN build_effects d ON d.build_id = e.build_id
+        SELECT 1 FROM effect_runs e
+        JOIN effect_runs d ON d.build_id = e.build_id
             AND d.name IN (SELECT jsonb_array_elements_text(e.deps))
         WHERE e.build_id = (w.payload->>'build_id')::bigint
           AND e.name = w.payload->>'name'

--- a/nixbot/nixbot/effects.py
+++ b/nixbot/nixbot/effects.py
@@ -25,7 +25,7 @@ import os
 from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 from urllib.parse import urlsplit
 
 import nixbot_effects
@@ -224,3 +224,27 @@ async def run_scheduled_effect(
         log_write,
         lambda: nixbot_effects.run_scheduled_effect(ctx, schedule_name, effect),
     )
+
+
+class EffectsBackend(Protocol):
+    """How the orchestrator evaluates and runs effects. Tests fake it."""
+
+    async def list_effects(self, ctx: EffectsContext) -> dict[str, EffectMeta]: ...
+    async def list_scheduled_effects(self, ctx: EffectsContext) -> dict: ...
+    async def run_effect(
+        self, ctx: EffectsContext, effect: str, log_write: LogWrite | None = None
+    ) -> bool: ...
+    async def run_scheduled_effect(
+        self,
+        ctx: EffectsContext,
+        schedule_name: str,
+        effect: str,
+        log_write: LogWrite | None = None,
+    ) -> bool: ...
+
+
+class NixEffects:
+    list_effects = staticmethod(list_effects)
+    list_scheduled_effects = staticmethod(list_scheduled_effects)
+    run_effect = staticmethod(run_effect)
+    run_scheduled_effect = staticmethod(run_scheduled_effect)

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -346,11 +346,15 @@ async def _run_one_effect(
 ) -> None:
     """One effect with its own row and log."""
     # A rerun resets the existing effect row.
-    await builds_q.start_effect(o.pool, build_id=build.id_, name=name, status="running")
+    run_id = await builds_q.start_effect(
+        o.pool, build_id=build.id_, name=name, status="running"
+    )
+    if run_id is None:  # build row gone
+        return
     # A green commit status on a failed deploy hides the failure. Report
     # per-effect status so the forge reflects the real outcome.
     await o.reporter.effect_started(event, build, name)
-    async with o.open_log(build.id_, f"effect:{name}") as writer:
+    async with o.open_effect_log(run_id) as writer:
         try:
             success = await run_effect(ctx, name, writer.write)
         except Exception as e:

--- a/nixbot/nixbot/effects_run.py
+++ b/nixbot/nixbot/effects_run.py
@@ -26,8 +26,6 @@ from .effects import (
     EffectsContext,
     effect_push_url,
     effects_context,
-    list_effects,
-    run_effect,
     should_run_effects,
 )
 from .events import effects_event_for_build
@@ -141,7 +139,7 @@ async def discover_effects(
     try:
         # A bad effect DAG (cycle, unknown dependency) fails discovery
         # here and its reason ends up in the log.
-        return await list_effects(ctx)
+        return await o.effects.list_effects(ctx)
     except (EffectError, OSError):
         # OSError: nix/git missing from PATH. Effects are best-effort
         # and must not fail the (already reported) build.
@@ -356,7 +354,7 @@ async def _run_one_effect(
     await o.reporter.effect_started(event, build, name)
     async with o.open_effect_log(run_id) as writer:
         try:
-            success = await run_effect(ctx, name, writer.write)
+            success = await o.effects.run_effect(ctx, name, writer.write)
         except Exception as e:
             # Any escape would leave the row running forever
             # (nothing re-runs effects) and kill the loop for the

--- a/nixbot/nixbot/executor.py
+++ b/nixbot/nixbot/executor.py
@@ -65,10 +65,9 @@ RECENT_BUFFER_SIZE = 4096
 FRAME_FLUSH_THRESHOLD = 64 * 1024
 
 
-# Log path is derived from (build_id, name), not stored. Names come from
-# untrusted flakes: percent-encode so a log cannot escape its build
-# directory, and keep effects in a subdirectory so an attribute named
-# "effect-X" cannot collide with an effect log.
+# Log path is derived, not stored. Attribute names come from untrusted
+# flakes: percent-encode so a log cannot escape its build directory.
+# Effect runs of every kind are keyed by their row id.
 
 
 def build_log_dir(state_dir: Path, build_id: int) -> Path:
@@ -79,18 +78,8 @@ def attribute_log_path(state_dir: Path, build_id: int, attr: str) -> Path:
     return build_log_dir(state_dir, build_id) / f"{quote(attr, safe='')}.zst"
 
 
-def effect_log_path(state_dir: Path, build_id: int, name: str) -> Path:
-    return (
-        build_log_dir(state_dir, build_id) / "effects" / f"{quote(name, safe='')}.zst"
-    )
-
-
-def log_path_for_key(state_dir: Path, build_id: int, key: str) -> Path:
-    """Path for a log-registry key: "effect:<name>" for effects, the
-    attribute name otherwise."""
-    if key.startswith("effect:"):
-        return effect_log_path(state_dir, build_id, key.removeprefix("effect:"))
-    return attribute_log_path(state_dir, build_id, key)
+def effect_run_log_path(state_dir: Path, run_id: int) -> Path:
+    return state_dir / "logs" / "effects" / f"{run_id}.zst"
 
 
 async def iter_lines(

--- a/nixbot/nixbot/migrations/0028_effect_runs.sql
+++ b/nixbot/nixbot/migrations/0028_effect_runs.sql
@@ -1,0 +1,68 @@
+-- One table for every effect run. build_effects (onPush, owned by a
+-- build) and scheduled_effect_runs (onSchedule, owned by a project) had
+-- grown parallel log/web/recovery stacks. Upcoming onEvent effects would
+-- have needed a third. `kind` says what triggered the run. build-owned
+-- rows stay one per (build, name) and are reset in place on restart.
+-- Rows without a build (schedules) are history.
+CREATE TABLE effect_runs (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    project_id BIGINT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    -- 'push' | 'schedule'
+    kind TEXT NOT NULL,
+    build_id BIGINT REFERENCES builds (id) ON DELETE CASCADE,
+    schedule_name TEXT,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'running',
+    error TEXT,
+    deps JSONB,
+    log_size BIGINT NOT NULL DEFAULT 0,
+    log_truncated BOOLEAN NOT NULL DEFAULT FALSE,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at TIMESTAMPTZ,
+    -- NULL build_id never conflicts, so schedule rows accumulate.
+    UNIQUE (build_id, kind, name),
+    CHECK ((kind = 'schedule') = (schedule_name IS NOT NULL)),
+    CHECK (kind = 'schedule' OR build_id IS NOT NULL)
+);
+CREATE INDEX effect_runs_project_idx ON effect_runs (project_id, started_at DESC);
+
+INSERT INTO effect_runs (project_id, kind, build_id, name, status, error, deps,
+                         log_size, log_truncated, started_at, finished_at)
+SELECT b.project_id, 'push', e.build_id, e.name, e.status, e.error, e.deps,
+       e.log_size, e.log_truncated, e.started_at, e.finished_at
+FROM build_effects e JOIN builds b ON b.id = e.build_id
+ORDER BY e.id;
+
+INSERT INTO effect_runs (project_id, kind, schedule_name, name, status, error,
+                         started_at, finished_at)
+SELECT project_id, 'schedule', schedule_name, effect, status, error,
+       started_at, finished_at
+FROM scheduled_effect_runs
+ORDER BY id;
+
+DROP TABLE build_effects;
+DROP TABLE scheduled_effect_runs;
+DROP FUNCTION notify_effect_status();
+DROP FUNCTION notify_scheduled_run_status();
+
+-- One notify shape for all kinds. build_id is null for schedule runs,
+-- which is how listeners told the two apart before. Names are
+-- repo-controlled, so truncate them (cf. migration 0012).
+CREATE FUNCTION notify_effect_run_status() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'UPDATE' AND OLD.status IS NOT DISTINCT FROM NEW.status THEN
+        RETURN NEW;
+    END IF;
+    PERFORM pg_notify('build_events', json_strip_nulls(json_build_object(
+        'project_id', NEW.project_id,
+        'run_id', NEW.id,
+        'build_id', NEW.build_id,
+        'schedule_name', left(NEW.schedule_name, 256),
+        'effect', left(NEW.name, 256),
+        'status', NEW.status))::text);
+    RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER effect_runs_status_notify
+AFTER INSERT OR UPDATE ON effect_runs
+FOR EACH ROW EXECUTE FUNCTION notify_effect_run_status();

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -34,6 +34,7 @@ from .canceller import (
     has_skip_ci_marker,
 )
 from .db import BuildStatus
+from .db_gen import maintenance as q
 from .effects_state import TaskTokens
 from .events import (
     BuildResult,
@@ -47,8 +48,7 @@ from .executor import (
     LogWriter,
     attribute_log_path,
     build_log_dir,
-    effect_log_path,
-    log_path_for_key,
+    effect_run_log_path,
 )
 from .gitrepo import MergeConflictError, pr_refspec
 from .repo_config import CONFIG_FILENAMES
@@ -165,28 +165,28 @@ class Orchestrator:
     def _log_dir(self, build_id: int) -> Path:
         return build_log_dir(self.config.state_dir, build_id)
 
-    def reset_build_logs(self, build_id: int, attr: str | None) -> None:
+    async def reset_build_logs(self, build_id: int, attr: str | None) -> None:
         """Drop the previous run's log files when a build is reset to
         pending. A full restart (attr None) also re-runs effects, so it
-        clears the whole build log directory. A single-attribute restart
-        removes only that attribute's log."""
+        clears the whole build log directory and the effect logs. A
+        single-attribute restart removes only that attribute's log."""
         if attr is None:
             shutil.rmtree(self._log_dir(build_id), ignore_errors=True)
+            await self.reset_effect_logs(build_id)
         else:
             attribute_log_path(self.config.state_dir, build_id, attr).unlink(
                 missing_ok=True
             )
 
-    def reset_effect_logs(self, build_id: int, names: list[str] | None = None) -> None:
+    async def reset_effect_logs(
+        self, build_id: int, names: list[str] | None = None
+    ) -> None:
         """Drop effect log files when a build's effects are reset.
         `names` limits the cleanup to those effects."""
-        if names is None:
-            shutil.rmtree(self._log_dir(build_id) / "effects", ignore_errors=True)
-            return
-        for name in names:
-            effect_log_path(self.config.state_dir, build_id, name).unlink(
-                missing_ok=True
-            )
+        for run_id in await q.build_effect_run_ids(
+            self.pool, build_id=build_id, names=names
+        ):
+            effect_run_log_path(self.config.state_dir, run_id).unlink(missing_ok=True)
 
     def gcroots_dir(self, build: BuildRecord) -> Path:
         return self.config.state_dir / "eval-gcroots" / str(build.id_)
@@ -460,17 +460,29 @@ class Orchestrator:
         await effects_run.post_effects_summary(self, event, build)
 
     @asynccontextmanager
-    async def open_log(self, build_id: int, key: str) -> AsyncIterator[LogWriter]:
+    async def open_log(self, build_id: int, attr: str) -> AsyncIterator[LogWriter]:
         """LogWriter registered for live streaming. Closed and
-        unregistered on exit. Shared by attribute and effect runs."""
-        path = log_path_for_key(self.config.state_dir, build_id, key)
+        unregistered on exit."""
+        path = attribute_log_path(self.config.state_dir, build_id, attr)
         writer = LogWriter(path=path, size_limit=self.config.log_size_limit)
-        self.log_registry.register(build_id, key, writer)
+        self.log_registry.register(build_id, attr, writer)
         try:
             yield writer
         finally:
             await writer.close()
-            self.log_registry.unregister(build_id, key)
+            self.log_registry.unregister(build_id, attr)
+
+    @asynccontextmanager
+    async def open_effect_log(self, run_id: int) -> AsyncIterator[LogWriter]:
+        """Same for an effect run of any kind, keyed by its row id."""
+        path = effect_run_log_path(self.config.state_dir, run_id)
+        writer = LogWriter(path=path, size_limit=self.config.log_size_limit)
+        self.log_registry.register_effect(run_id, writer)
+        try:
+            yield writer
+        finally:
+            await writer.close()
+            self.log_registry.unregister_effect(run_id)
 
     async def finish_linked(
         self,

--- a/nixbot/nixbot/orchestrator.py
+++ b/nixbot/nixbot/orchestrator.py
@@ -35,6 +35,7 @@ from .canceller import (
 )
 from .db import BuildStatus
 from .db_gen import maintenance as q
+from .effects import EffectsBackend, NixEffects
 from .effects_state import TaskTokens
 from .events import (
     BuildResult,
@@ -80,6 +81,10 @@ if TYPE_CHECKING:
     OutputWriter = Callable[[Path, str, str, str, str, str, str], Path]
 
 logger = logging.getLogger(__name__)
+
+
+def default_effects() -> EffectsBackend:
+    return NixEffects()
 
 
 class EvalRunnerLike(Protocol):
@@ -130,7 +135,8 @@ class Orchestrator:
     running_effects: dict[tuple[int, str], effects_run.RunningEffect] = field(
         default_factory=dict
     )
-    # Injectable for tests. Defaults to the real implementations.
+    # Injectable, default_effects is late-bound so tests can replace it.
+    effects: EffectsBackend = field(default_factory=lambda: default_effects())  # noqa: PLW0108
     register_gcroot: GcrootRegistrar = gcroots.register_gcroot
     write_output_path: OutputWriter = outputs.write_output_path
     # Store-path validity probe for eval reuse. Injectable for tests.

--- a/nixbot/nixbot/queries/builds.sql
+++ b/nixbot/nixbot/queries/builds.sql
@@ -86,10 +86,10 @@ UPDATE builds SET eval_warnings = sqlc.arg(warnings)::jsonb WHERE id = $1;
 -- the same statement: they only get queue items when the build
 -- succeeds; after a failed rebuild nothing else owns them.
 WITH failed_effects AS (
-    UPDATE build_effects SET status = 'failed',
+    UPDATE effect_runs SET status = 'failed',
         error = 'build did not succeed', finished_at = now()
-    WHERE build_effects.build_id = sqlc.arg(id)::bigint
-      AND build_effects.status = 'pending'
+    WHERE effect_runs.build_id = sqlc.arg(id)::bigint
+      AND effect_runs.status = 'pending'
       AND sqlc.arg(status)::text IN ('failed', 'cancelled')
 )
 UPDATE builds
@@ -198,40 +198,46 @@ ON CONFLICT (build_id, attr) DO UPDATE SET
 WHERE NOT sqlc.arg(if_unfinished)::boolean
     OR build_attributes.status IN ('pending', 'building');
 
--- name: StartEffect :exec
-INSERT INTO build_effects (build_id, name, status) VALUES ($1, $2, $3)
-ON CONFLICT (build_id, name) DO UPDATE SET
-    status = $3, error = NULL, log_size = 0,
-    log_truncated = FALSE, started_at = now(), finished_at = NULL;
+-- name: StartEffect :one
+INSERT INTO effect_runs (project_id, kind, build_id, name, status)
+SELECT b.project_id, 'push', b.id, sqlc.arg(name)::text, sqlc.arg(status)::text
+FROM builds b WHERE b.id = sqlc.arg(build_id)::bigint
+ON CONFLICT (build_id, kind, name) DO UPDATE SET
+    status = EXCLUDED.status, error = NULL, log_size = 0,
+    log_truncated = FALSE, started_at = now(), finished_at = NULL
+RETURNING id;
 
 -- name: StartPendingEffects :exec
 -- Batch variant for enqueueing one build's discovered effects.
 -- deps carries each effect's `after` list as a JSON array.
-INSERT INTO build_effects (build_id, name, status, deps)
-SELECT sqlc.arg(build_id)::bigint, u.name, 'pending', u.deps::jsonb
-FROM (SELECT unnest(sqlc.arg(names)::text[]) AS name,
+INSERT INTO effect_runs (project_id, kind, build_id, name, status, deps)
+SELECT b.project_id, 'push', b.id, u.name, 'pending', u.deps::jsonb
+FROM builds b,
+     (SELECT unnest(sqlc.arg(names)::text[]) AS name,
              unnest(sqlc.arg(deps)::text[]) AS deps) AS u
-ON CONFLICT (build_id, name) DO UPDATE SET
+WHERE b.id = sqlc.arg(build_id)::bigint
+ON CONFLICT (build_id, kind, name) DO UPDATE SET
     status = 'pending', error = NULL, log_size = 0,
     log_truncated = FALSE, started_at = now(), finished_at = NULL,
     deps = EXCLUDED.deps;
 
 -- name: RecordSkippedEffects :exec
 -- DO NOTHING: rows from a real run (build reused by a gated ref) stay.
-INSERT INTO build_effects (build_id, name, status, finished_at)
-SELECT sqlc.arg(build_id)::bigint, u.name, 'skipped', now()
-FROM unnest(sqlc.arg(names)::text[]) AS u(name)
-ON CONFLICT (build_id, name) DO NOTHING;
+INSERT INTO effect_runs (project_id, kind, build_id, name, status, finished_at)
+SELECT b.project_id, 'push', b.id, u.name, 'skipped', now()
+FROM builds b, unnest(sqlc.arg(names)::text[]) AS u(name)
+WHERE b.id = sqlc.arg(build_id)::bigint
+ON CONFLICT (build_id, kind, name) DO NOTHING;
 
 -- name: EffectDepStatuses :many
 -- Statuses of the effects this effect declared in `after`.
-SELECT d.name, d.status FROM build_effects e
-JOIN build_effects d ON d.build_id = e.build_id
+SELECT d.name, d.status FROM effect_runs e
+JOIN effect_runs d ON d.build_id = e.build_id
     AND d.name IN (SELECT jsonb_array_elements_text(e.deps))
 WHERE e.build_id = $1 AND e.name = $2;
 
 -- name: FinishEffect :exec
-UPDATE build_effects SET
+UPDATE effect_runs SET
     status = $3, error = sqlc.narg(error),
     log_size = $4, log_truncated = $5, finished_at = now()
 WHERE build_id = $1 AND name = $2;
@@ -251,11 +257,11 @@ SELECT
         WHEN bool_or(status = 'succeeded') THEN 'succeeded'
         ELSE 'skipped'
     END::text AS status
-FROM build_effects WHERE build_id = $1
+FROM effect_runs WHERE build_id = $1
 HAVING count(*) > 0;
 
 -- name: EffectsForBuild :many
-SELECT * FROM build_effects WHERE build_id = $1 ORDER BY name;
+SELECT * FROM effect_runs WHERE build_id = $1 ORDER BY name;
 
 -- name: AttributeStatuses :many
 SELECT attr, status FROM build_attributes WHERE build_id = $1;

--- a/nixbot/nixbot/queries/maintenance.sql
+++ b/nixbot/nixbot/queries/maintenance.sql
@@ -31,7 +31,7 @@ WITH cleared_failures AS (
     WHERE build_id = sqlc.arg(build_id)::bigint
       AND (sqlc.narg(attr)::text IS NULL OR attr = sqlc.narg(attr))
 ), reset_effect_rows AS (
-    UPDATE build_effects SET status = 'pending', error = NULL,
+    UPDATE effect_runs SET status = 'pending', error = NULL,
         finished_at = NULL, log_size = 0, log_truncated = FALSE
     WHERE build_id = sqlc.arg(build_id)::bigint
       AND sqlc.narg(attr)::text IS NULL
@@ -50,7 +50,7 @@ WHERE builds.id = sqlc.arg(build_id)::bigint;
 WITH flag AS (
     UPDATE builds SET effects_started = FALSE WHERE id = sqlc.arg(build_id)
 )
-UPDATE build_effects SET status = 'pending', error = NULL,
+UPDATE effect_runs SET status = 'pending', error = NULL,
     finished_at = NULL, log_size = 0,
     log_truncated = FALSE
 WHERE build_id = sqlc.arg(build_id)
@@ -107,15 +107,11 @@ SELECT build_id, attr, system, drv_path, outputs, status
 FROM build_attributes WHERE build_id = ANY(sqlc.arg(build_ids)::bigint[]);
 
 -- name: FailInterruptedEffects :many
-UPDATE build_effects SET status = 'failed',
+-- build_id is null for schedule runs.
+UPDATE effect_runs SET status = 'failed',
     error = 'interrupted by a service restart', finished_at = now()
 WHERE status = 'running' AND started_at < sqlc.arg(started_before)
 RETURNING build_id, name;
-
--- name: FailInterruptedScheduledRuns :exec
-UPDATE scheduled_effect_runs SET status = 'failed',
-    error = 'interrupted by a service restart', finished_at = now()
-WHERE status = 'running' AND started_at < sqlc.arg(started_before);
 
 -- name: CleanupOldRows :many
 -- One retention sweep: builds (cascading to attributes/log rows),
@@ -132,10 +128,10 @@ WITH del_builds AS (
       AND status IN ('succeeded', 'failed', 'cancelled')
     RETURNING builds.id
 ), del_runs AS (
-    DELETE FROM scheduled_effect_runs
-    WHERE finished_at IS NOT NULL
+    DELETE FROM effect_runs
+    WHERE build_id IS NULL AND finished_at IS NOT NULL
       AND finished_at < now() - make_interval(days => sqlc.arg(retention_days)::int)
-    RETURNING scheduled_effect_runs.id
+    RETURNING effect_runs.id
 ), pruned_statuses AS (
     DELETE FROM failed_statuses
     WHERE to_timestamp(timestamp)
@@ -151,7 +147,11 @@ WITH del_builds AS (
 )
 SELECT 'build' AS kind, del_builds.id FROM del_builds
 UNION ALL
-SELECT 'scheduled_run' AS kind, del_runs.id FROM del_runs;
+SELECT 'effect_run' AS kind, del_runs.id FROM del_runs
+UNION ALL
+-- Cascade-deleted with their build, still visible in this snapshot.
+SELECT 'effect_run' AS kind, r.id FROM effect_runs r
+WHERE r.build_id IN (SELECT del_builds.id FROM del_builds);
 
 -- name: AllBuildIds :many
 SELECT id FROM builds;
@@ -183,11 +183,16 @@ WITH cancelled AS (
 SELECT cancelled.status_generation FROM cancelled;
 
 -- name: DropRemovedEffects :exec
-DELETE FROM build_effects WHERE build_id = $1
+DELETE FROM effect_runs WHERE build_id = $1
 AND NOT (name = ANY(sqlc.arg(names)::text[]));
 
 -- name: EffectStatus :one
-SELECT status FROM build_effects WHERE build_id = $1 AND name = $2;
+SELECT status FROM effect_runs WHERE build_id = $1 AND kind = 'push' AND name = $2;
+
+-- name: BuildEffectRunIds :many
+-- For unlinking logs on reset. NULL names = all of the build's runs.
+SELECT id FROM effect_runs WHERE build_id = sqlc.arg(build_id)
+  AND (sqlc.narg(names)::text[] IS NULL OR name = ANY(sqlc.narg(names)::text[]));
 
 -- name: SucceededAttributeOutputs :many
 SELECT attr, outputs FROM build_attributes

--- a/nixbot/nixbot/queries/scheduled.sql
+++ b/nixbot/nixbot/queries/scheduled.sql
@@ -26,19 +26,21 @@ WHERE last_run IS NULL
    OR last_run < date_trunc('minute', sqlc.arg(now)::timestamptz);
 
 -- name: StartScheduledRun :one
-INSERT INTO scheduled_effect_runs (project_id, schedule_name, effect)
-VALUES ($1, $2, $3) RETURNING id;
+INSERT INTO effect_runs (project_id, kind, schedule_name, name)
+VALUES ($1, 'schedule', $2, $3) RETURNING id;
 
 -- name: FinishScheduledRun :exec
-UPDATE scheduled_effect_runs
-SET status = $2, error = sqlc.narg(error), finished_at = now() WHERE id = $1;
+UPDATE effect_runs
+SET status = $2, error = sqlc.narg(error), log_size = $3, log_truncated = $4,
+    finished_at = now()
+WHERE id = $1;
 
 -- name: LatestScheduledRuns :many
-SELECT DISTINCT ON (schedule_name, effect)
-       id, schedule_name, effect, status, error,
+SELECT DISTINCT ON (schedule_name, name)
+       id, schedule_name, name AS effect, status, error,
        started_at, finished_at
-FROM scheduled_effect_runs WHERE project_id = $1
-ORDER BY schedule_name, effect, started_at DESC;
+FROM effect_runs WHERE project_id = $1 AND kind = 'schedule'
+ORDER BY schedule_name, name, started_at DESC;
 
 -- name: ProjectSchedules :many
 SELECT schedule_name, effect, when_spec, last_run
@@ -49,20 +51,14 @@ ORDER BY schedule_name, effect;
 UPDATE scheduled_effects SET last_run = $4
 WHERE project_id = $1 AND schedule_name = $2 AND effect = $3;
 
--- name: ScheduledRunExists :one
-SELECT id FROM scheduled_effect_runs WHERE id = $1 AND project_id = $2;
-
--- name: ScheduledRunDetail :one
-SELECT id, schedule_name, effect, status, error, started_at, finished_at
-FROM scheduled_effect_runs WHERE id = $1 AND project_id = $2;
-
 -- name: ScheduledRunsForEffect :many
 -- Run history for one (schedule, effect); cursor on id for infinite
 -- scroll (id order matches started_at order for a single effect).
-SELECT id, schedule_name, effect, status, error, started_at, finished_at
-FROM scheduled_effect_runs
+SELECT id, schedule_name, name AS effect, status, error, started_at, finished_at
+FROM effect_runs
 WHERE project_id = sqlc.arg(project_id)
+  AND kind = 'schedule'
   AND schedule_name = sqlc.arg(schedule_name)
-  AND effect = sqlc.arg(effect)
+  AND name = sqlc.arg(effect)
   AND (sqlc.narg(before)::bigint IS NULL OR id < sqlc.narg(before))
 ORDER BY id DESC LIMIT sqlc.arg(limit_)::bigint;

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -116,9 +116,19 @@ WHERE a.build_id = $1 AND a.finished_at IS NOT NULL
                                    sqlc.arg(after_id)::bigint))
 ORDER BY a.finished_at, a.id;
 
+-- name: EffectRunDetail :one
+-- Any kind. The build number is joined for the log page header.
+SELECT r.id, r.kind, r.build_id, r.schedule_name, r.name AS effect, r.status,
+       r.error, r.started_at, r.finished_at, b.number AS build_number
+FROM effect_runs r LEFT JOIN builds b ON b.id = r.build_id
+WHERE r.id = $1 AND r.project_id = $2;
+
+-- name: EffectRunId :one
+SELECT id FROM effect_runs WHERE build_id = $1 AND kind = 'push' AND name = $2;
+
 -- name: WebEffects :many
 -- Worst first.
-SELECT * FROM build_effects WHERE build_id = $1
+SELECT * FROM effect_runs WHERE build_id = $1
 ORDER BY array_position(
     ARRAY['failed', 'dependency_failed', 'running', 'pending', 'succeeded', 'skipped'],
     status), name;

--- a/nixbot/nixbot/queries/work_queue.sql
+++ b/nixbot/nixbot/queries/work_queue.sql
@@ -41,8 +41,8 @@ WHERE id = (
                    AND (r.created_at, r.id) < (w.created_at, w.id)))
       )
       AND NOT (w.kind = 'effect' AND EXISTS (
-        SELECT 1 FROM build_effects e
-        JOIN build_effects d ON d.build_id = e.build_id
+        SELECT 1 FROM effect_runs e
+        JOIN effect_runs d ON d.build_id = e.build_id
             AND d.name IN (SELECT jsonb_array_elements_text(e.deps))
         WHERE e.build_id = (w.payload->>'build_id')::bigint
           AND e.name = w.payload->>'name'

--- a/nixbot/nixbot/recovery.py
+++ b/nixbot/nixbot/recovery.py
@@ -37,6 +37,7 @@ import asyncpg
 from . import db
 from .build_scheduler import AttributeResult, AttributeStatus
 from .db_gen import maintenance as q
+from .executor import effect_run_log_path
 from .models import CacheStatus, NixEvalJobSuccess
 
 if TYPE_CHECKING:
@@ -162,9 +163,7 @@ async def fail_interrupted_effects(
     (process start) are swept: the sweep runs concurrently with the
     work loop, and newer rows are live effects. Returns the settled
     rows for the caller to report."""
-    settled = await q.fail_interrupted_effects(pool, started_before=started_before)
-    await q.fail_interrupted_scheduled_runs(pool, started_before=started_before)
-    return settled
+    return await q.fail_interrupted_effects(pool, started_before=started_before)
 
 
 async def check_store_paths(paths: list[str], nix_db: Path = NIX_DB) -> set[str]:
@@ -224,14 +223,14 @@ async def cleanup_old_builds(
     directories past the retention horizon. Returns deleted count."""
     rows = await q.cleanup_old_rows(pool, retention_days=retention_days)
     deleted_ids = [r.id_ for r in rows if r.kind == "build"]
-    old_run_ids = [r.id_ for r in rows if r.kind == "scheduled_run"]
+    old_run_ids = [r.id_ for r in rows if r.kind == "effect_run"]
     for build_id in deleted_ids:
         log_dir = state_dir / "logs" / str(build_id)
         with contextlib.suppress(OSError):
             shutil.rmtree(log_dir)
     for run_id in old_run_ids:
         with contextlib.suppress(OSError):
-            (state_dir / "logs" / "scheduled" / f"{run_id}.zst").unlink()
+            effect_run_log_path(state_dir, run_id).unlink()
     if deleted_ids:
         logger.info("retention cleanup", extra={"deleted_builds": len(deleted_ids)})
     return len(deleted_ids)
@@ -253,6 +252,10 @@ async def cleanup_orphan_log_dirs(
     logs_root = state_dir / "logs"
     if not logs_root.is_dir():
         return
+    # Pre-effect_runs layouts: logs/scheduled/<id>.zst and
+    # logs/<build>/effects/. Their rows now point at logs/effects/<id>.
+    with contextlib.suppress(OSError):
+        shutil.rmtree(logs_root / "scheduled")
     cutoff = time.time() - grace_seconds
     candidates: list[tuple[int, str]] = []
     for entry in os.scandir(logs_root):
@@ -267,6 +270,8 @@ async def cleanup_orphan_log_dirs(
         return
     build_ids = set(await q.all_build_ids(pool))
     for build_id, path in candidates:
-        if build_id not in build_ids:
-            with contextlib.suppress(OSError):
+        with contextlib.suppress(OSError):
+            if build_id not in build_ids:
                 shutil.rmtree(path)
+            else:
+                shutil.rmtree(Path(path) / "effects")

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -197,7 +197,7 @@ async def rerun_effects(
         # previous run's logs here too, so pending rows show no stale
         # output.
         await q.reset_effects_state(o.pool, build_id=build.id_, names=names)
-        o.reset_effect_logs(build.id_, names)
+        await o.reset_effect_logs(build.id_, names)
         async with rerun_worktree(o, info, build, "effects", credentials) as (
             event,
             worktree_path,

--- a/nixbot/nixbot/restart_dispatch.py
+++ b/nixbot/nixbot/restart_dispatch.py
@@ -61,7 +61,7 @@ async def rerun(
     info = repo_info(project)
     if restart:
         await q.reset_build_for_restart(o.pool, build_id=build_id, attr=attr)
-        o.reset_build_logs(build_id, attr)
+        await o.reset_build_logs(build_id, attr)
         build = await builds_q.get_build(o.pool, id_=build_id)
         if build is None:
             return

--- a/nixbot/nixbot/schedule_runner.py
+++ b/nixbot/nixbot/schedule_runner.py
@@ -12,14 +12,14 @@ import time
 from functools import partial
 from typing import TYPE_CHECKING
 
-from .effects import EffectsContext, effects_context, run_scheduled_effect
+from .effects import EffectsContext, effects_context
 from .effects_run import effect_checkout
 from .executor import failure_excerpt
 from .repos import repo_info
 from .schedules import (
     DueEffect,
     ScheduledEffectsStore,
-    discover_schedules,
+    parse_schedules_from_json,
 )
 from .workload_identity import EffectIdentity
 
@@ -96,7 +96,9 @@ async def refresh_schedules(s: CIService, project_id: int, rev: str) -> None:
             repo=info.name,
             extra_sandbox_paths=s.config.effects_extra_sandbox_paths,
         )
-        schedules = await discover_schedules(ctx)
+        schedules = parse_schedules_from_json(
+            await s.orchestrator.effects.list_scheduled_effects(ctx)
+        )
         await ScheduledEffectsStore(s.pool).replace_schedules(project_id, schedules)
     finally:
         await s.orchestrator.repos.remove_worktree(worktree)
@@ -177,7 +179,7 @@ async def _run_scheduled_inner(
             ctx.bind_id_token_audiences = partial(
                 s.orchestrator.task_tokens.bind_audiences, task_token
             )
-            return await run_scheduled_effect(
+            return await s.orchestrator.effects.run_scheduled_effect(
                 ctx, due.schedule_name, due.effect, log.write
             )
     finally:

--- a/nixbot/nixbot/schedule_runner.py
+++ b/nixbot/nixbot/schedule_runner.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from .effects import EffectsContext, effects_context, run_scheduled_effect
 from .effects_run import effect_checkout
-from .executor import LogWriter
+from .executor import failure_excerpt
 from .repos import repo_info
 from .schedules import (
     DueEffect,
@@ -25,6 +25,7 @@ from .workload_identity import EffectIdentity
 
 if TYPE_CHECKING:
     from .events import RepoInfo
+    from .executor import LogWriter
     from .service import CIService
 
 logger = logging.getLogger(__name__)
@@ -116,18 +117,26 @@ async def run_scheduled(
     # Manual runs pre-create the row. The sweep loop does not.
     if run_id is None:
         run_id = await store.start_run(due)
-    try:
-        success = await _run_scheduled_inner(s, due, info, run_id)
-        await store.finish_run(run_id, success=success)
-    except Exception as e:
-        # Spawned task: an exception would only surface as "Task
-        # exception was never retrieved" and leave the row running.
-        logger.exception("scheduled effect crashed", extra={"run_id": run_id})
-        await store.finish_run(run_id, success=False, error=str(e))
+    async with s.orchestrator.open_effect_log(run_id) as log:
+        try:
+            success = await _run_scheduled_inner(s, due, info, log)
+            error = None if success else (failure_excerpt(log.tail_lines()) or None)
+        except Exception as e:
+            # Spawned task: an exception would only surface as "Task
+            # exception was never retrieved" and leave the row running.
+            logger.exception("scheduled effect crashed", extra={"run_id": run_id})
+            success, error = False, str(e)
+    await store.finish_run(
+        run_id,
+        success=success,
+        error=error,
+        log_size=log.bytes_seen,
+        log_truncated=log.truncated,
+    )
 
 
 async def _run_scheduled_inner(
-    s: CIService, due: DueEffect, info: RepoInfo, run_id: int
+    s: CIService, due: DueEffect, info: RepoInfo, log: LogWriter
 ) -> bool:
     credentials = await s.credentials_provider(info.forge).get(info.clone_url)
     await s.orchestrator.repos.fetch(
@@ -150,14 +159,6 @@ async def _run_scheduled_inner(
             schedule=due.schedule_name,
         ),
     )
-    log_dir = s.config.state_dir / "logs" / "scheduled"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log = LogWriter(
-        path=log_dir / f"{run_id}.zst",
-        size_limit=s.config.log_size_limit,
-    )
-    # Shared registry so the web SSE route can stream this run live.
-    s.orchestrator.log_registry.register_scheduled(run_id, log)
     try:
         rev = await worktree.rev_parse("HEAD")
         async with effect_checkout(
@@ -181,6 +182,4 @@ async def _run_scheduled_inner(
             )
     finally:
         s.orchestrator.task_tokens.revoke(task_token)
-        await log.close()
-        s.orchestrator.log_registry.unregister_scheduled(run_id)
         await s.orchestrator.repos.remove_worktree(worktree)

--- a/nixbot/nixbot/schedules.py
+++ b/nixbot/nixbot/schedules.py
@@ -17,13 +17,11 @@ from typing import TYPE_CHECKING, Any, cast
 
 from .config import ScheduledEffectConfig, ScheduleWhen
 from .db_gen import scheduled as q
-from .effects import list_scheduled_effects
 from .sql_util import expect, row_dicts
 
 if TYPE_CHECKING:
     import asyncpg
 
-    from .effects import EffectsContext
 
 logger = logging.getLogger(__name__)
 
@@ -46,13 +44,6 @@ def parse_schedules_from_json(
             effects=schedule_data.get("effects", []),
         )
     return result
-
-
-async def discover_schedules(
-    ctx: EffectsContext,
-) -> dict[str, ScheduledEffectConfig]:
-    """The onSchedule definitions on a default-branch checkout."""
-    return parse_schedules_from_json(await list_scheduled_effects(ctx))
 
 
 def is_due(when: ScheduleWhen, schedule_name: str, now: datetime) -> bool:

--- a/nixbot/nixbot/schedules.py
+++ b/nixbot/nixbot/schedules.py
@@ -247,18 +247,26 @@ class ScheduledEffectsStore:
                 self.pool,
                 project_id=due.project_id,
                 schedule_name=due.schedule_name,
-                effect=due.effect,
+                name=due.effect,
             )
         )
 
     async def finish_run(
-        self, run_id: int, *, success: bool, error: str | None = None
+        self,
+        run_id: int,
+        *,
+        success: bool,
+        error: str | None = None,
+        log_size: int = 0,
+        log_truncated: bool = False,
     ) -> None:
         await q.finish_scheduled_run(
             self.pool,
             id_=run_id,
             status="succeeded" if success else "failed",
             error=error,
+            log_size=log_size,
+            log_truncated=log_truncated,
         )
 
     async def latest_runs_for_project(self, project_id: int) -> list[dict]:

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -592,7 +592,8 @@ class CIService:
         re-runs a settled effect to clear it."""
         by_build: dict[int, list[str]] = {}
         for row in settled:
-            by_build.setdefault(row.build_id, []).append(row.name)
+            if row.build_id is not None:
+                by_build.setdefault(row.build_id, []).append(row.name)
         for build_id, names in by_build.items():
             build = await builds_q.get_build(self.pool, id_=build_id)
             if build is None:

--- a/nixbot/nixbot/tests/conftest.py
+++ b/nixbot/nixbot/tests/conftest.py
@@ -8,7 +8,13 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from .support import db_pool, ephemeral_postgres, init_upstream, truncate_work_queue
+from .support import (
+    FakeEffects,
+    db_pool,
+    ephemeral_postgres,
+    init_upstream,
+    truncate_work_queue,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
@@ -47,15 +53,6 @@ def fresh_work_queue(postgres_dsn: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _no_effects_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stub effects/schedule discovery, which would evaluate the flake
-    with real nix. Tests that want effects patch these again."""
-
-    async def no_effects(_ctx: object) -> dict:
-        return {}
-
-    async def no_schedules(_ctx: object) -> dict:
-        return {}
-
-    monkeypatch.setattr("nixbot.effects_run.list_effects", no_effects)
-    monkeypatch.setattr("nixbot.schedule_runner.discover_schedules", no_schedules)
+def _fake_effects(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Real discovery would evaluate the flake with nix."""
+    monkeypatch.setattr("nixbot.orchestrator.default_effects", FakeEffects)

--- a/nixbot/nixbot/tests/support.py
+++ b/nixbot/nixbot/tests/support.py
@@ -402,9 +402,15 @@ class WebHarness:
         url: str,
         user: User | None = None,
         headers: dict[str, str] | None = None,
+        *,
+        follow_redirects: bool = False,
     ) -> httpx.Response:
         request_headers = cookie_header(self._cookies(user)) | (headers or {})
-        return self.run(self.http.get(url, headers=request_headers))
+        return self.run(
+            self.http.get(
+                url, headers=request_headers, follow_redirects=follow_redirects
+            )
+        )
 
     def post(
         self,

--- a/nixbot/nixbot/tests/support.py
+++ b/nixbot/nixbot/tests/support.py
@@ -10,7 +10,7 @@ import os
 import re
 import subprocess
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import asyncpg
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
     from nixbot.auth import User
     from nixbot.build_scheduler import CachedFailure
+    from nixbot.effects import EffectMeta
 
 from nixbot.models import CacheStatus, NixEvalJobSuccess
 
@@ -69,6 +70,35 @@ def mk_job(
         outputs={"out": out or f"/nix/store/{attr}-out"},
         system=system,
     )
+
+
+@dataclass
+class FakeEffects:
+    """EffectsBackend without nix. Configure the listings, read what ran.
+    Assigning e.g. `fake.run_effect = fn` replaces one operation."""
+
+    push: dict[str, EffectMeta] = field(default_factory=dict)
+    schedules: dict[str, Any] = field(default_factory=dict)
+    push_error: Exception | None = None
+    ran: list[str] = field(default_factory=list)
+
+    async def list_effects(self, _ctx: Any) -> dict[str, EffectMeta]:
+        if self.push_error is not None:
+            raise self.push_error
+        return self.push
+
+    async def list_scheduled_effects(self, _ctx: Any) -> dict[str, Any]:
+        return self.schedules
+
+    async def run_effect(self, _ctx: Any, effect: str, _log: Any = None) -> bool:
+        self.ran.append(effect)
+        return True
+
+    async def run_scheduled_effect(
+        self, _ctx: Any, schedule_name: str, effect: str, _log: Any = None
+    ) -> bool:
+        self.ran.append(f"{schedule_name}/{effect}")
+        return True
 
 
 class FakeCache:

--- a/nixbot/nixbot/tests/test_cli.py
+++ b/nixbot/nixbot/tests/test_cli.py
@@ -69,8 +69,8 @@ async def postgres_dsn(postgres_dsn: str) -> str:
             failed,
         )
         await pool.execute(
-            "INSERT INTO build_effects (build_id, name, status) "
-            "VALUES ($1, 'deploy', 'failed'), ($1, 'notify', 'dependency_failed')",
+            "INSERT INTO effect_runs (project_id, kind, build_id, name, status) "
+            "VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'deploy', 'failed'), ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'notify', 'dependency_failed')",
             failed,
         )
     return postgres_dsn

--- a/nixbot/nixbot/tests/test_cli_api.py
+++ b/nixbot/nixbot/tests/test_cli_api.py
@@ -50,8 +50,8 @@ async def postgres_dsn(postgres_dsn: str) -> str:
             failed,
         )
         await pool.execute(
-            "INSERT INTO build_effects (build_id, name, status) "
-            "VALUES ($1, 'deploy', 'failed')",
+            "INSERT INTO effect_runs (project_id, kind, build_id, name, status) "
+            "VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'deploy', 'failed')",
             failed,
         )
     return postgres_dsn

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -131,8 +131,8 @@ async def seed(dsn: str) -> None:
             build_id,
         )
         await pool.execute(
-            "INSERT INTO build_effects (build_id, name, status) "
-            "VALUES ($1, 'deploy', 'failed')",
+            "INSERT INTO effect_runs (project_id, kind, build_id, name, status) "
+            "VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'deploy', 'failed')",
             build_id,
         )
         # Queue for the mass-cancel tests: two pending, one running.
@@ -882,8 +882,8 @@ async def test_effect_item_setup_failure_settles_row(
             pool, project_id, commit_sha="c5", tree_hash="t5", status="succeeded"
         )
         await pool.execute(
-            "INSERT INTO build_effects (build_id, name, status) "
-            "VALUES ($1, 'deploy', 'pending')",
+            "INSERT INTO effect_runs (project_id, kind, build_id, name, status) "
+            "VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'deploy', 'pending')",
             build_id,
         )
         await service.enqueue_work(
@@ -891,7 +891,7 @@ async def test_effect_item_setup_failure_settles_row(
         )
         await service.drain_work()
         row = await pool.fetchrow(
-            "SELECT status, error FROM build_effects WHERE build_id = $1",
+            "SELECT status, error FROM effect_runs WHERE build_id = $1",
             build_id,
         )
         assert row["status"] == "failed"
@@ -959,8 +959,8 @@ async def test_recovery_reports_interrupted_effects(
         )
         # started_at before the service start so the sweep claims it.
         await pool.execute(
-            "INSERT INTO build_effects (build_id, name, status, started_at) "
-            "VALUES ($1, 'deploy', 'running', now() - interval '1 hour')",
+            "INSERT INTO effect_runs (project_id, kind, build_id, name, status, started_at) "
+            "VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'deploy', 'running', now() - interval '1 hour')",
             build_id,
         )
 
@@ -1058,8 +1058,9 @@ async def test_restart_resets_effects(postgres_dsn: str, tmp_path: Path) -> None
             effects_started=True,
         )
         await pool.execute(
-            "INSERT INTO build_effects (build_id, name, status, finished_at, "
-            "log_size) VALUES ($1, 'deploy', 'failed', now(), 42)",
+            "INSERT INTO effect_runs (project_id, kind, build_id, name, status,"
+            " finished_at, log_size) SELECT project_id, 'push', id, 'deploy',"
+            " 'failed', now(), 42 FROM builds WHERE id = $1",
             build_id,
         )
 
@@ -1071,7 +1072,7 @@ async def test_restart_resets_effects(postgres_dsn: str, tmp_path: Path) -> None
         # Stale log cleared by the reset. The failed rerun
         # (unfetchable URL) settled the row.
         row = await pool.fetchrow(
-            "SELECT status, error, log_size FROM build_effects WHERE build_id = $1",
+            "SELECT status, error, log_size FROM effect_runs WHERE build_id = $1",
             build_id,
         )
         assert dict(row) == {

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -28,6 +28,7 @@ from nixbot.db_gen import builds as builds_q
 from nixbot.effects import EffectMeta, EffectsContext
 from nixbot.events import BuildResult, ChangeEvent, EvalReport, RepoInfo
 from nixbot.executor import attribute_log_path, effect_log_path
+from nixbot.gcroots import GcrootRegistrationError
 from nixbot.gitrepo import FetchCredentials, RepoManager
 from nixbot.memory import EvalWorkerConfig
 from nixbot.models import CacheStatus
@@ -2291,3 +2292,38 @@ async def test_reuse_post_process_error_still_reports_status(
     finished = [e for e in reporter.events if e[0] == "finished"]
     assert finished
     assert finished[-1][2] == BuildStatus.SUCCEEDED
+
+
+async def test_reuse_with_missing_output_still_post_processes(
+    make_env: EnvFactory, upstream: Path, pool: asyncpg.Pool
+) -> None:
+    """An output that is gone from the local store (remote-built,
+    GC'd) must not abort the reuse: the rest of post-processing
+    (schedules, events) still happens."""
+    add_commit(upstream, "reuse-gone")
+    sha = git(upstream, "rev-parse", "HEAD")
+    orchestrator, _reporter, project = await make_env(
+        FakeEvalRunner([mk_job("a"), mk_job("b")]),
+        FakeExecutor(),
+        name="reuse-gone",
+    )
+    assert await orchestrator.handle_change_event(
+        ChangeEvent(repo=project, branch="main", commit_sha=sha)
+    )
+    registered: list[str] = []
+
+    async def gone(gcroots_dir: Path, proj: str, attr: str, out: str) -> None:
+        if attr == "a":
+            msg = "don't know how to build these paths"
+            raise GcrootRegistrationError(msg)
+        registered.append(attr)
+
+    orchestrator.register_gcroot = gone
+    await pool.execute("DELETE FROM work_queue WHERE kind = 'refresh-schedules'")
+    assert await orchestrator.handle_change_event(
+        ChangeEvent(repo=project, branch="main", commit_sha=sha)
+    )
+    assert registered == ["b"]
+    assert await pool.fetchval(
+        "SELECT count(*) FROM work_queue WHERE kind = 'refresh-schedules'"
+    )

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -16,7 +16,6 @@ from nixbot_effects import EffectError
 
 from nixbot import build_run as build_run_mod
 from nixbot import db
-from nixbot import effects_run as effects_run_mod
 from nixbot.build_scheduler import (
     AttributeResult,
     AttributeStatus,
@@ -37,7 +36,14 @@ from nixbot.orchestrator import AttributeExecutor, EvalRunnerLike, Orchestrator
 from nixbot.recovery import fail_interrupted_effects
 from nixbot.work_queue import WorkItem, WorkQueue
 
-from .support import FakeCache, attribute_statuses, git, insert_project, mk_job
+from .support import (
+    FakeCache,
+    FakeEffects,
+    attribute_statuses,
+    git,
+    insert_project,
+    mk_job,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -291,23 +297,14 @@ def patch_effects(
     monkeypatch: pytest.MonkeyPatch,
     run_effect: object | None = None,
     effects: dict[str, EffectMeta] | None = None,
-) -> list[str]:
-    """Replace effect discovery/run with a fake "deploy" effect.
-
-    Returns the list that records executed effect names. A custom
-    run_effect replaces the recording default."""
-    ran: list[str] = []
-
-    async def fake_list(ctx: object) -> dict[str, EffectMeta]:
-        return effects or {"deploy": EffectMeta()}
-
-    async def fake_run(ctx: object, name: str, log_write: object = None) -> bool:
-        ran.append(name)
-        return True
-
-    monkeypatch.setattr(effects_run_mod, "list_effects", fake_list)
-    monkeypatch.setattr(effects_run_mod, "run_effect", run_effect or fake_run)
-    return ran
+) -> FakeEffects:
+    """FakeEffects with a "deploy" effect for orchestrators made after
+    this. A custom run_effect replaces the recording default."""
+    fake = FakeEffects(push=effects or {"deploy": EffectMeta()})
+    if run_effect is not None:
+        fake.run_effect = run_effect  # type: ignore[method-assign,assignment]
+    monkeypatch.setattr("nixbot.orchestrator.default_effects", lambda: fake)
+    return fake
 
 
 @pytest.fixture
@@ -321,7 +318,7 @@ def run_effect_build(
     the recorded effect runs for further assertions."""
 
     async def run() -> tuple[BuildRecord | None, Orchestrator, RepoInfo, list[str]]:
-        ran = patch_effects(monkeypatch)
+        ran = patch_effects(monkeypatch).ran
         orchestrator, _, project = await make_env(
             FakeEvalRunner([mk_job("a")]), FakeExecutor()
         )
@@ -1184,7 +1181,7 @@ async def test_pr_worktree_config_cannot_grant_effects(
     git(upstream, "checkout", "main")
     base = git(upstream, "rev-parse", "HEAD")
 
-    ran = patch_effects(monkeypatch)
+    ran = patch_effects(monkeypatch).ran
     orchestrator, reporter, project = await make_env(
         FakeEvalRunner([mk_job("a")]),
         FakeExecutor(),
@@ -1265,7 +1262,7 @@ async def test_rerun_effects_cancels_hung_effect(
         await asyncio.Event().wait()
         return True
 
-    monkeypatch.setattr(effects_run_mod, "run_effect", hung_run)
+    orchestrator.effects.run_effect = hung_run  # type: ignore[method-assign,assignment]
     await orchestrator.rerun_effects(project, build)
     queue = WorkQueue(pool)
     item = await queue.claim_next()
@@ -1277,7 +1274,9 @@ async def test_rerun_effects_cancels_hung_effect(
     await asyncio.sleep(0)
     assert (build.id_, "deploy") in orchestrator.running_effects
 
-    ran2 = patch_effects(monkeypatch)
+    fresh = FakeEffects(push={"deploy": EffectMeta()})
+    orchestrator.effects = fresh
+    ran2 = fresh.ran
     await asyncio.wait_for(orchestrator.rerun_effects(project, build), timeout=5)
     await hung_item
     await queue.finish(item.id)
@@ -1803,12 +1802,9 @@ async def test_effect_dep_cycle_fails_discovery(
     """A dependency cycle is a repo mistake: discovery fails, no effect
     rows are created, and the (already reported) build stays green."""
 
-    async def cyclic_list(ctx: object) -> dict[str, EffectMeta]:
-        msg = "dependency cycle between effects"
-        raise EffectError(msg)
-
-    patch_effects(monkeypatch)
-    monkeypatch.setattr(effects_run_mod, "list_effects", cyclic_list)
+    patch_effects(monkeypatch).push_error = EffectError(
+        "dependency cycle between effects"
+    )
     _, _, build = await _effects_build(make_env, upstream, "eff-cycle")
     assert await build_status(pool, build.id_) == BuildStatus.SUCCEEDED
     assert (
@@ -2003,7 +1999,7 @@ async def test_reuse_for_default_branch_push_runs_effects(
     PR run never started effects) and report the effects on the main
     commit, not the build's stored PR-head commit."""
 
-    ran = patch_effects(monkeypatch)
+    ran = patch_effects(monkeypatch).ran
     add_commit(upstream, "reuse-deploy")
     pr_sha = git(upstream, "rev-parse", "HEAD")
     orchestrator, reporter, project = await make_env(
@@ -2239,11 +2235,7 @@ async def test_effects_phase_error_keeps_succeeded_build(
     """An exception after the final fan-out (effects discovery here)
     must not flip an already-succeeded build to failed."""
 
-    async def boom_list(ctx: object) -> list[str]:
-        msg = "state api down"
-        raise RuntimeError(msg)
-
-    monkeypatch.setattr(effects_run_mod, "list_effects", boom_list)
+    patch_effects(monkeypatch).push_error = RuntimeError("state api down")
     add_commit(upstream, "late-boom")
     orchestrator, reporter, project = await make_env(
         FakeEvalRunner([mk_job("a")]),

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -27,7 +27,7 @@ from nixbot.db import BuildStatus
 from nixbot.db_gen import builds as builds_q
 from nixbot.effects import EffectMeta, EffectsContext
 from nixbot.events import BuildResult, ChangeEvent, EvalReport, RepoInfo
-from nixbot.executor import attribute_log_path, effect_log_path
+from nixbot.executor import attribute_log_path, effect_run_log_path
 from nixbot.gcroots import GcrootRegistrationError
 from nixbot.gitrepo import FetchCredentials, RepoManager
 from nixbot.memory import EvalWorkerConfig
@@ -340,7 +340,7 @@ def run_effect_build(
 
 async def effect_statuses(pool: asyncpg.Pool, build_id: int) -> dict[str, str]:
     rows = await pool.fetch(
-        "SELECT name, status FROM build_effects WHERE build_id = $1", build_id
+        "SELECT name, status FROM effect_runs WHERE build_id = $1", build_id
     )
     return {r["name"]: r["status"] for r in rows}
 
@@ -1226,8 +1226,8 @@ async def test_rerun_effects_runs_effects_again(
     )
     # A stale row from an effect no longer in the flake.
     await pool.execute(
-        "INSERT INTO build_effects (build_id, name, status) "
-        "VALUES ($1, 'removed', 'failed')",
+        "INSERT INTO effect_runs (project_id, kind, build_id, name, status) "
+        "VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'removed', 'failed')",
         build.id_,
     )
     await orchestrator.rerun_effects(project, build)
@@ -1238,7 +1238,7 @@ async def test_rerun_effects_runs_effects_again(
         "SELECT count(*) FROM work_queue WHERE kind = 'refresh-schedules'"
     )
     rows = await pool.fetch(
-        "SELECT name, status FROM build_effects WHERE build_id = $1",
+        "SELECT name, status FROM effect_runs WHERE build_id = $1",
         build.id_,
     )
     assert [(r["name"], r["status"]) for r in rows] == [("deploy", "succeeded")]
@@ -1284,7 +1284,7 @@ async def test_rerun_effects_cancels_hung_effect(
     await drain_effect_items(orchestrator, project, pool)
     assert ran2 == ["deploy"]
     status = await pool.fetchval(
-        "SELECT status FROM build_effects WHERE build_id = $1 AND name = 'deploy'",
+        "SELECT status FROM effect_runs WHERE build_id = $1 AND name = 'deploy'",
         build.id_,
     )
     assert status == "succeeded"
@@ -1329,7 +1329,7 @@ async def test_rerun_single_effect(
     statuses = {
         r["name"]: r["status"]
         for r in await pool.fetch(
-            "SELECT name, status FROM build_effects WHERE build_id = $1", build.id_
+            "SELECT name, status FROM effect_runs WHERE build_id = $1", build.id_
         )
     }
     assert statuses == {
@@ -1338,7 +1338,7 @@ async def test_rerun_single_effect(
         "other": "succeeded",
     }
     other_finished = await pool.fetchval(
-        "SELECT finished_at FROM build_effects WHERE build_id = $1 AND name = 'other'",
+        "SELECT finished_at FROM effect_runs WHERE build_id = $1 AND name = 'other'",
         build.id_,
     )
 
@@ -1350,7 +1350,7 @@ async def test_rerun_single_effect(
     statuses = {
         r["name"]: r["status"]
         for r in await pool.fetch(
-            "SELECT name, status FROM build_effects WHERE build_id = $1", build.id_
+            "SELECT name, status FROM effect_runs WHERE build_id = $1", build.id_
         )
     }
     assert statuses == {
@@ -1360,7 +1360,7 @@ async def test_rerun_single_effect(
     }
     assert (
         await pool.fetchval(
-            "SELECT finished_at FROM build_effects "
+            "SELECT finished_at FROM effect_runs "
             "WHERE build_id = $1 AND name = 'other'",
             build.id_,
         )
@@ -1512,7 +1512,7 @@ async def test_effect_items_resume_only_pending(
     # Crash mid-run: the sweep settles the row. The requeued
     # item must skip it.
     await pool.execute(
-        "UPDATE build_effects SET status = 'running' WHERE build_id = $1",
+        "UPDATE effect_runs SET status = 'running' WHERE build_id = $1",
         build.id_,
     )
     await fail_interrupted_effects(pool, datetime.now(UTC) + timedelta(minutes=1))
@@ -1520,7 +1520,7 @@ async def test_effect_items_resume_only_pending(
     assert ran == ["deploy"]
     # Crash before the run: the pending row resumes.
     await pool.execute(
-        "UPDATE build_effects SET status = 'pending' WHERE build_id = $1",
+        "UPDATE effect_runs SET status = 'pending' WHERE build_id = $1",
         build.id_,
     )
     await orchestrator.run_effect_item(project, build, "deploy")
@@ -1557,7 +1557,7 @@ async def test_effect_crash_settles_the_row(
     await drain_effect_items(orchestrator, project, pool)
     assert build is not None
     row = await pool.fetchrow(
-        "SELECT status, finished_at FROM build_effects WHERE build_id = $1",
+        "SELECT status, finished_at FROM effect_runs WHERE build_id = $1",
         build.id_,
     )
     assert row is not None
@@ -1616,7 +1616,7 @@ async def test_concurrent_effects_use_independent_worktrees(
     rows = {
         r["name"]: r["status"]
         for r in await pool.fetch(
-            "SELECT name, status FROM build_effects WHERE build_id = $1", build.id_
+            "SELECT name, status FROM effect_runs WHERE build_id = $1", build.id_
         )
     }
     assert rows == {"deploy-alaska": "succeeded", "deploy-kk": "succeeded"}
@@ -1694,7 +1694,7 @@ async def test_effect_item_not_claimable_until_dep_settles(
     assert second.payload["name"] == "deploy"
     await orchestrator.run_effect_item(project, build, "deploy")
     row = await pool.fetchrow(
-        "SELECT status FROM build_effects WHERE build_id = $1 AND name = 'deploy'",
+        "SELECT status FROM effect_runs WHERE build_id = $1 AND name = 'deploy'",
         build.id_,
     )
     assert row["status"] == "dependency_failed"
@@ -1726,7 +1726,7 @@ async def test_effect_dep_failure_skips_dependent(
     rows = {
         r["name"]: (r["status"], r["error"])
         for r in await pool.fetch(
-            "SELECT name, status, error FROM build_effects WHERE build_id = $1",
+            "SELECT name, status, error FROM effect_runs WHERE build_id = $1",
             build.id_,
         )
     }
@@ -1813,7 +1813,7 @@ async def test_effect_dep_cycle_fails_discovery(
     assert await build_status(pool, build.id_) == BuildStatus.SUCCEEDED
     assert (
         await pool.fetchval(
-            "SELECT count(*) FROM build_effects WHERE build_id = $1", build.id_
+            "SELECT count(*) FROM effect_runs WHERE build_id = $1", build.id_
         )
         == 0
     )
@@ -2181,7 +2181,10 @@ async def test_effect_log_does_not_collide_with_attribute_log(
     await drain_effect_items(orchestrator, project, pool)
     state_dir = orchestrator.config.state_dir
     attr_log = attribute_log_path(state_dir, build.id_, "effect-deploy")
-    effect_log = effect_log_path(state_dir, build.id_, "deploy")
+    run_id = await pool.fetchval(
+        "SELECT id FROM effect_runs WHERE build_id = $1 AND name = 'deploy'", build.id_
+    )
+    effect_log = effect_run_log_path(state_dir, run_id)
     assert attr_log != effect_log
     assert attr_log.exists()
     assert effect_log.exists()

--- a/nixbot/nixbot/tests/test_recovery.py
+++ b/nixbot/nixbot/tests/test_recovery.py
@@ -254,13 +254,13 @@ async def test_failed_rebuild_settles_pending_effects(pool: asyncpg.Pool) -> Non
 
     build_id = await make_build(pool, "fx-failed-rebuild")
     await pool.execute(
-        "INSERT INTO build_effects (build_id, name, status) "
-        "VALUES ($1, 'deploy', 'pending')",
+        "INSERT INTO effect_runs (project_id, kind, build_id, name, status) "
+        "VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'deploy', 'pending')",
         build_id,
     )
     await db.set_build_status(pool, build_id, "failed")
     row = await pool.fetchrow(
-        "SELECT status, error FROM build_effects WHERE build_id = $1",
+        "SELECT status, error FROM effect_runs WHERE build_id = $1",
         build_id,
     )
     assert row["status"] == "failed"
@@ -293,27 +293,24 @@ async def test_interrupted_effects_fail_on_recovery(pool: asyncpg.Pool) -> None:
 
     build_id = await make_build(pool, "fx-sweep")
     await pool.execute(
-        "INSERT INTO build_effects (build_id, name) VALUES ($1, 'deploy')",
+        "INSERT INTO effect_runs (project_id, kind, build_id, name) VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'deploy')",
         build_id,
     )
     project_id = await pool.fetchval(
         "SELECT project_id FROM builds WHERE id = $1", build_id
     )
     await pool.execute(
-        "INSERT INTO scheduled_effect_runs (project_id, schedule_name, "
-        "effect) VALUES ($1, 's', 'beat')",
+        "INSERT INTO effect_runs (project_id, kind, schedule_name, name) "
+        "VALUES ($1, 'schedule', 's', 'beat')",
         project_id,
     )
     await fail_interrupted_effects(pool, datetime.now(UTC) + timedelta(minutes=1))
-    for table, column in [
-        ("build_effects", "build_id"),
-        ("scheduled_effect_runs", "project_id"),
-    ]:
-        row = await pool.fetchrow(
-            f"SELECT status, error, finished_at FROM {table} "  # noqa: S608
-            f"WHERE {column} = $1",
-            build_id if column == "build_id" else project_id,
-        )
+    rows = await pool.fetch(
+        "SELECT status, error, finished_at FROM effect_runs WHERE project_id = $1",
+        project_id,
+    )
+    assert len(rows) == 2  # noqa: PLR2004
+    for row in rows:
         assert row["status"] == "failed"
         assert "interrupted" in row["error"]
         assert row["finished_at"] is not None
@@ -329,11 +326,11 @@ async def test_interrupted_effects_sweep_spares_live_effects(
     build_id = await make_build(pool, "fx-live")
     process_start = datetime.now(UTC)
     await pool.execute(
-        "INSERT INTO build_effects (build_id, name) VALUES ($1, 'deploy')",
+        "INSERT INTO effect_runs (project_id, kind, build_id, name) VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'deploy')",
         build_id,
     )
     await fail_interrupted_effects(pool, process_start)
     status = await pool.fetchval(
-        "SELECT status FROM build_effects WHERE build_id = $1", build_id
+        "SELECT status FROM effect_runs WHERE build_id = $1", build_id
     )
     assert status == "running"

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -29,7 +29,7 @@ from nixbot.executor import (
     StructuredCapture,
     attribute_log_path,
     container_path,
-    effect_log_path,
+    effect_run_log_path,
 )
 from nixbot.logstore import LogContainerWriter
 from nixbot.web import events as events_module
@@ -1347,17 +1347,17 @@ def test_log_sse_stream_caps_history_backlog(
         run_id = await _insert_scheduled_run(
             ctx.pool, project_id, effect="big", status="running"
         )
-        writer = LogWriter(path=tmp_path / "logs" / "scheduled" / f"{run_id}.zst")
+        writer = LogWriter(path=effect_run_log_path(tmp_path, run_id))
         await writer.write("".join(f"line{i:05d}\n" for i in range(3000)).encode())
-        registry.register_scheduled(run_id, writer)
+        registry.register_effect(run_id, writer)
         try:
-            url = f"/repos/github/acme/widget/schedules/runs/{run_id}/stream"
+            url = f"/repos/github/acme/widget/effects/runs/{run_id}/stream"
             stream_task = asyncio.ensure_future(client.http.get(url))
             await asyncio.sleep(0.1)
             await writer.close()
             return (await stream_task).text
         finally:
-            registry.unregister_scheduled(run_id)
+            registry.unregister_effect(run_id)
 
     stream = client.loop.run_until_complete(run())
     assert "line02999" in stream
@@ -1382,17 +1382,17 @@ def test_log_sse_stream_neutralizes_carriage_returns(
         run_id = await _insert_scheduled_run(
             ctx.pool, project_id, effect="cr", status="running"
         )
-        writer = LogWriter(path=tmp_path / "logs" / "scheduled" / f"{run_id}.zst")
+        writer = LogWriter(path=effect_run_log_path(tmp_path, run_id))
         await writer.write(b"progress 1%\rprogress 2%\r\nevent: done\rtail\n")
-        registry.register_scheduled(run_id, writer)
+        registry.register_effect(run_id, writer)
         try:
-            url = f"/repos/github/acme/widget/schedules/runs/{run_id}/stream"
+            url = f"/repos/github/acme/widget/effects/runs/{run_id}/stream"
             stream_task = asyncio.ensure_future(client.http.get(url))
             await asyncio.sleep(0.1)
             await writer.close()
             return (await stream_task).text
         finally:
-            registry.unregister_scheduled(run_id)
+            registry.unregister_effect(run_id)
 
     stream = client.loop.run_until_complete(run())
     body_lines = stream.split("\n")
@@ -1633,20 +1633,20 @@ def test_build_page_shows_effects(client: WebHarness) -> None:
     async def seed_effects() -> None:
         ctx = client.ctx
         build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
-        await ctx.pool.execute(
-            """
-            INSERT INTO build_effects (build_id, name, status, error, log_size,
-                                       finished_at)
-            VALUES ($1, 'deploy', 'failed', 'ssh: connection refused',
-                    42, now()),
-                   ($1, 'notify', 'running', NULL, 0, NULL)
-            """,
+        await _insert_effect_run(
+            ctx.pool,
             build_id,
+            "deploy",
+            "failed",
+            error="ssh: connection refused",
+            log_size=42,
+            finished_at=datetime.now(UTC),
         )
+        await _insert_effect_run(ctx.pool, build_id, "notify", "running")
         pr_build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 3")
         await ctx.pool.execute(
-            "INSERT INTO build_effects (build_id, name, status, finished_at) "
-            "VALUES ($1, 'deploy', 'skipped', now())",
+            "INSERT INTO effect_runs (project_id, kind, build_id, name, status, finished_at) "
+            "VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'deploy', 'skipped', now())",
             pr_build_id,
         )
 
@@ -1657,8 +1657,7 @@ def test_build_page_shows_effects(client: WebHarness) -> None:
     assert "deploy" in text
     assert "ssh: connection refused" in text
     # Both finished-with-log and running effects link to the viewer.
-    assert "logs/effect:deploy" in text
-    assert "logs/effect:notify" in text
+    assert text.count("/effects/runs/") == 2
     # Builds without effects don't render the section.
     assert "Effects" not in client.get("/repos/github/acme/widget/builds/1").text
     pr_text = client.get("/repos/github/acme/widget/builds/3").text
@@ -1672,20 +1671,24 @@ def test_effect_log_raw_text(client: WebHarness, tmp_path: Path) -> None:
         ctx = client.ctx
         ctx.state_dir = tmp_path
         build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
-        log_file = effect_log_path(tmp_path, build_id, "deploy2")
-        log_file.parent.mkdir(parents=True, exist_ok=True)
-        log_file.write_bytes(
-            zstandard.ZstdCompressor().compress(b"activating system...\n")
-        )
-        await ctx.pool.execute(
-            "INSERT INTO build_effects (build_id, name, status, log_size, "
-            "finished_at) VALUES ($1, 'deploy2', 'succeeded', 42, now())",
+        run_id = await _insert_effect_run(
+            ctx.pool,
             build_id,
+            "deploy2",
+            "succeeded",
+            log_size=42,
+            finished_at=datetime.now(UTC),
         )
+        _write_effect_log(tmp_path, run_id, b"activating system...\n")
 
     client.loop.run_until_complete(seed_effect_log())
-    response = client.get("/repos/github/acme/widget/builds/2/logs/effect:deploy2.txt")
+    # Old per-build URL redirects to the run.
+    response = client.get(
+        "/repos/github/acme/widget/builds/2/logs/effect:deploy2.txt",
+        follow_redirects=True,
+    )
     assert response.status_code == 200
+    assert "/effects/runs/" in str(response.url)
     assert "activating system" in response.text
 
 
@@ -1696,27 +1699,29 @@ def test_effect_log_viewer_status_icon(client: WebHarness, tmp_path: Path) -> No
         ctx = client.ctx
         ctx.state_dir = tmp_path
         build_id = await ctx.pool.fetchval("SELECT id FROM builds WHERE number = 2")
-        log_file = effect_log_path(tmp_path, build_id, "deploy3")
-        log_file.parent.mkdir(parents=True, exist_ok=True)
-        log_file.write_bytes(
-            zstandard.ZstdCompressor().compress(b"activating system...\n")
-        )
-        await ctx.pool.execute(
-            "INSERT INTO build_effects (build_id, name, status, log_size, "
-            "finished_at) VALUES ($1, 'deploy3', 'succeeded', 42, now())",
+        run_id = await _insert_effect_run(
+            ctx.pool,
             build_id,
+            "deploy3",
+            "succeeded",
+            log_size=42,
+            finished_at=datetime.now(UTC),
         )
+        _write_effect_log(tmp_path, run_id, b"activating system...\n")
 
     client.loop.run_until_complete(seed_effect_log())
-    text = client.get("/repos/github/acme/widget/builds/2/logs/effect:deploy3").text
+    text = client.get(
+        "/repos/github/acme/widget/builds/2/logs/effect:deploy3", follow_redirects=True
+    ).text
     assert "status-icon succeeded" in text
+    assert "effect of <a" in text
     # Controls must target the effect endpoints, not /attrs/effect:...
     assert "attrs/effect" not in text
 
 
 def test_effect_changes_notify_build_events(client: WebHarness) -> None:
     """The page's SSE refresh rides on build_events. Without a trigger
-    on build_effects the Effects section never updates live."""
+    on effect_runs the Effects section never updates live."""
 
     async def run() -> list[str]:
         ctx = client.ctx
@@ -1727,11 +1732,11 @@ def test_effect_changes_notify_build_events(client: WebHarness) -> None:
         try:
             await conn.add_listener("build_events", listener)
             await ctx.pool.execute(
-                "INSERT INTO build_effects (build_id, name) VALUES ($1, 'fxlive')",
+                "INSERT INTO effect_runs (project_id, kind, build_id, name) VALUES ((SELECT project_id FROM builds WHERE id = $1), 'push', $1, 'fxlive')",
                 build_id,
             )
             await ctx.pool.execute(
-                "UPDATE build_effects SET status = 'succeeded', "
+                "UPDATE effect_runs SET status = 'succeeded', "
                 "finished_at = now() WHERE build_id = $1 AND name = 'fxlive'",
                 build_id,
             )
@@ -1906,9 +1911,9 @@ async def _insert_scheduled_run(  # noqa: PLR0913
     error: str | None = None,
 ) -> int:
     return await pool.fetchval(
-        "INSERT INTO scheduled_effect_runs "
-        "(project_id, schedule_name, effect, status, error, finished_at) "
-        "VALUES ($1, $2, $3, $4, $5, now()) RETURNING id",
+        "INSERT INTO effect_runs "
+        "(project_id, kind, schedule_name, name, status, error, finished_at) "
+        "VALUES ($1, 'schedule', $2, $3, $4, $5, now()) RETURNING id",
         project_id,
         schedule_name,
         effect,
@@ -1917,10 +1922,34 @@ async def _insert_scheduled_run(  # noqa: PLR0913
     )
 
 
-def _write_scheduled_log(state_dir: Path, run_id: int, data: bytes) -> None:
-    log_dir = state_dir / "logs" / "scheduled"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    (log_dir / f"{run_id}.zst").write_bytes(zstandard.ZstdCompressor().compress(data))
+def _write_effect_log(state_dir: Path, run_id: int, data: bytes) -> None:
+    path = effect_run_log_path(state_dir, run_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(zstandard.ZstdCompressor().compress(data))
+
+
+async def _insert_effect_run(  # noqa: PLR0913
+    pool: asyncpg.Pool,
+    build_id: int,
+    name: str,
+    status: str,
+    *,
+    error: str | None = None,
+    log_size: int = 0,
+    finished_at: datetime | None = None,
+) -> int:
+    return await pool.fetchval(
+        "INSERT INTO effect_runs"
+        " (project_id, kind, build_id, name, status, error, log_size, finished_at)"
+        " SELECT project_id, 'push', id, $2, $3, $4, $5, $6"
+        " FROM builds WHERE id = $1 RETURNING id",
+        build_id,
+        name,
+        status,
+        error,
+        log_size,
+        finished_at,
+    )
 
 
 def test_scheduled_run_viewer_renders_ansi(client: WebHarness, tmp_path: Path) -> None:
@@ -1934,16 +1963,16 @@ def test_scheduled_run_viewer_renders_ansi(client: WebHarness, tmp_path: Path) -
             "SELECT id FROM projects WHERE forge_repo_id = 'web-1'"
         )
         run_id = await _insert_scheduled_run(ctx.pool, project_id)
-        _write_scheduled_log(tmp_path, run_id, b"\x1b[31;1merror:\x1b[0m boom\n")
+        _write_effect_log(tmp_path, run_id, b"\x1b[31;1merror:\x1b[0m boom\n")
         return run_id
 
     run_id = client.run(setup())
-    resp = client.get(f"/repos/github/acme/widget/schedules/runs/{run_id}")
+    resp = client.get(f"/repos/github/acme/widget/effects/runs/{run_id}")
     assert resp.status_code == 200
     assert "ansi-red" in resp.text
     assert f"runs/{run_id}.txt" in resp.text  # raw link present
     # Raw route still works and is not shadowed by the HTML viewer.
-    raw = client.get(f"/repos/github/acme/widget/schedules/runs/{run_id}.txt")
+    raw = client.get(f"/repos/github/acme/widget/effects/runs/{run_id}.txt")
     assert raw.status_code == 200
     assert "error: boom" in raw.text
     assert "\x1b[" not in raw.text
@@ -1962,7 +1991,7 @@ def test_scheduled_run_viewer_cross_project_404(client: WebHarness) -> None:
 
     run_id = client.run(setup())
     assert (
-        client.get(f"/repos/github/acme/widget/schedules/runs/{run_id}").status_code
+        client.get(f"/repos/github/acme/widget/effects/runs/{run_id}").status_code
         == 404
     )
 
@@ -1982,7 +2011,7 @@ def test_scheduled_run_log_unavailable_placeholder(
         return await _insert_scheduled_run(ctx.pool, project_id, effect="pruned")
 
     run_id = client.run(setup())
-    resp = client.get(f"/repos/github/acme/widget/schedules/runs/{run_id}")
+    resp = client.get(f"/repos/github/acme/widget/effects/runs/{run_id}")
     assert resp.status_code == 200
     assert "log unavailable" in resp.text
 
@@ -2001,7 +2030,7 @@ def test_scheduled_run_viewer_waiting_before_log(client: WebHarness) -> None:
         )
 
     run_id = client.run(setup())
-    resp = client.get(f"/repos/github/acme/widget/schedules/runs/{run_id}")
+    resp = client.get(f"/repos/github/acme/widget/effects/runs/{run_id}")
     assert resp.status_code == 200
     assert "waiting for the run to start" in resp.text
     assert "log unavailable" not in resp.text
@@ -2074,18 +2103,18 @@ def test_scheduled_run_stream_replays_history(
         run_id = await _insert_scheduled_run(
             ctx.pool, project_id, effect="streamed", status="running"
         )
-        writer = LogWriter(path=tmp_path / "logs" / "scheduled" / f"{run_id}.zst")
+        writer = LogWriter(path=effect_run_log_path(tmp_path, run_id))
         await writer.write(b"scheduled early\n")
-        registry.register_scheduled(run_id, writer)
+        registry.register_effect(run_id, writer)
         try:
-            url = f"/repos/github/acme/widget/schedules/runs/{run_id}/stream"
+            url = f"/repos/github/acme/widget/effects/runs/{run_id}/stream"
             task = asyncio.ensure_future(client.http.get(url))
             await asyncio.sleep(0.1)
             await writer.write(b"scheduled late\n")
             await writer.close()
             return (await task).text
         finally:
-            registry.unregister_scheduled(run_id)
+            registry.unregister_effect(run_id)
 
     stream = client.loop.run_until_complete(run())
     assert "scheduled early" in stream
@@ -2108,13 +2137,12 @@ def test_scheduled_run_notify_build_events(client: WebHarness) -> None:
         try:
             await conn.add_listener("build_events", listener)
             run_id = await ctx.pool.fetchval(
-                "INSERT INTO scheduled_effect_runs "
-                "(project_id, schedule_name, effect) VALUES ($1, 'n', 'd') "
-                "RETURNING id",
+                "INSERT INTO effect_runs (project_id, kind, schedule_name, name)"
+                " VALUES ($1, 'schedule', 'n', 'd') RETURNING id",
                 project_id,
             )
             await ctx.pool.execute(
-                "UPDATE scheduled_effect_runs SET status = 'succeeded', "
+                "UPDATE effect_runs SET status = 'succeeded', "
                 "finished_at = now() WHERE id = $1",
                 run_id,
             )

--- a/nixbot/nixbot/web/api_routes.py
+++ b/nixbot/nixbot/web/api_routes.py
@@ -116,6 +116,8 @@ class Attribute(BaseModel):
 
 
 class Effect(BaseModel):
+    id: int
+    kind: str
     name: str
     status: str
     error: str | None

--- a/nixbot/nixbot/web/logs.py
+++ b/nixbot/nixbot/web/logs.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import (
     HTMLResponse,
     PlainTextResponse,
+    RedirectResponse,
     Response,
     StreamingResponse,
 )
@@ -32,7 +33,12 @@ from ..build_scheduler import TERMINAL_FAILURES  # noqa: TID252
 from ..db_gen import maintenance as maint_gen  # noqa: TID252
 from ..db_gen import scheduled as sched_gen  # noqa: TID252
 from ..db_gen import web as gen  # noqa: TID252
-from ..executor import container_path, log_path_for_key, read_log  # noqa: TID252
+from ..executor import (  # noqa: TID252
+    attribute_log_path,
+    container_path,
+    effect_run_log_path,
+    read_log,
+)
 from ..logstore import LogContainerReader, is_container  # noqa: TID252
 from ..sql_util import row_dict, row_dicts  # noqa: TID252
 from ..status import NO_LOG_STATUSES  # noqa: TID252
@@ -51,9 +57,8 @@ class LogRegistry:
 
     def __init__(self) -> None:
         self._writers: dict[tuple[int, str], LogWriter] = {}
-        # Scheduled-effect runs have no build_id. Key them by run id in
-        # a separate map so the namespaces cannot collide.
-        self._scheduled: dict[int, LogWriter] = {}
+        # Effect runs (any kind) are keyed by their effect_runs id.
+        self._effects: dict[int, LogWriter] = {}
 
     def register(self, build_id: int, attr: str, writer: LogWriter) -> None:
         self._writers[(build_id, attr)] = writer
@@ -64,14 +69,14 @@ class LogRegistry:
     def get(self, build_id: int, attr: str) -> LogWriter | None:
         return self._writers.get((build_id, attr))
 
-    def register_scheduled(self, run_id: int, writer: LogWriter) -> None:
-        self._scheduled[run_id] = writer
+    def register_effect(self, run_id: int, writer: LogWriter) -> None:
+        self._effects[run_id] = writer
 
-    def unregister_scheduled(self, run_id: int) -> None:
-        self._scheduled.pop(run_id, None)
+    def unregister_effect(self, run_id: int) -> None:
+        self._effects.pop(run_id, None)
 
-    def get_scheduled(self, run_id: int) -> LogWriter | None:
-        return self._scheduled.get(run_id)
+    def get_effect(self, run_id: int) -> LogWriter | None:
+        return self._effects.get(run_id)
 
 
 _COLOR_CLASSES = {}
@@ -453,7 +458,7 @@ async def _failure_summary(
             continue
         # The file may not exist yet (never ran, or pending after a
         # reset); _log_text handles that.
-        path = log_path_for_key(ctx.state_dir, build["id"], a["attr"])
+        path = attribute_log_path(ctx.state_dir, build["id"], a["attr"])
         text = await _log_text(registry, build, a["attr"], path)
         failures.append(
             {
@@ -508,7 +513,7 @@ class _LogRoutes:
         attr: str,
     ) -> tuple[dict, dict, Path | None]:
         project, build = await self._build_or_404(request, forge, owner, name, number)
-        path = log_path_for_key(self.ctx.state_dir, build["id"], attr)
+        path = attribute_log_path(self.ctx.state_dir, build["id"], attr)
         return project, build, path
 
     async def log_raw_text(  # noqa: PLR0913
@@ -554,43 +559,73 @@ class _LogRoutes:
             return await self.log_viewer(request, forge, owner, name, number, shadowed)
         return await self.log_raw_text(request, forge, owner, name, number, attr, tail)
 
-    def _scheduled_log_path(self, run_id: int) -> Path:
-        return self.ctx.state_dir / "logs" / "scheduled" / f"{run_id}.zst"
+    def _effect_log_path(self, run_id: int) -> Path:
+        return effect_run_log_path(self.ctx.state_dir, run_id)
 
-    async def _scheduled_run_text(self, run_id: int) -> str | None:
-        """Decoded log of a scheduled run: live writer snapshot while it
+    async def _effect_run_text(self, run_id: int) -> str | None:
+        """Decoded log of an effect run: live writer snapshot while it
         runs, otherwise the on-disk file. None when no log exists."""
-        writer = self.registry.get_scheduled(run_id)
+        writer = self.registry.get_effect(run_id)
         if writer is not None:
             data = await writer.snapshot()
         else:
-            path = self._scheduled_log_path(run_id)
+            path = self._effect_log_path(run_id)
             if not await asyncio.to_thread(path.exists):
                 return None
             data = await asyncio.to_thread(read_log, path)
         return data.decode(errors="replace")
 
-    async def scheduled_run_log(
+    async def _run_or_404(
+        self, request: Request, forge: str, owner: str, name: str, run_id: int
+    ) -> tuple[dict, dict]:
+        project = await self.ctx.repo_or_404(forge, owner, name, request)
+        run = await gen.effect_run_detail(
+            self.ctx.pool, id_=run_id, project_id=project["id"]
+        )
+        if run is None:
+            raise HTTPException(status_code=404)
+        return project, row_dict(run)
+
+    async def effect_run_log(  # noqa: PLR0913
         self,
         request: Request,
         forge: str,
         owner: str,
         name: str,
         run_id: int,
+        tail: int | None = Query(None, ge=1),
     ) -> PlainTextResponse:
-        """Log of one scheduled-effect run as plain text."""
-        project = await self.ctx.repo_or_404(forge, owner, name, request)
-        row = await sched_gen.scheduled_run_exists(
-            self.ctx.pool, id_=run_id, project_id=project["id"]
-        )
-        if row is None:
-            raise HTTPException(status_code=404)
-        text = await self._scheduled_run_text(run_id)
+        """Log of one effect run as plain text."""
+        await self._run_or_404(request, forge, owner, name, run_id)
+        text = await self._effect_run_text(run_id)
         if text is None:
             raise HTTPException(status_code=404)
-        return PlainTextResponse(await asyncio.to_thread(strip_ansi, text))
+        return PlainTextResponse(
+            await asyncio.to_thread(_plain, text, tail, ansi=False)
+        )
 
-    async def scheduled_run_viewer(
+    async def build_effect_log_redirect(  # noqa: PLR0913
+        self,
+        request: Request,
+        forge: str,
+        owner: str,
+        name: str,
+        number: int,
+        effect: str,
+        suffix: str = "",
+    ) -> RedirectResponse:
+        """Old per-build effect log URL, still emitted in forge statuses."""
+        _, build = await self._build_or_404(request, forge, owner, name, number)
+        run_id = await gen.effect_run_id(
+            self.ctx.pool, build_id=build["id"], name=effect
+        )
+        if run_id is None:
+            raise HTTPException(status_code=404)
+        return RedirectResponse(
+            f"/repos/{forge}/{owner}/{name}/effects/runs/{run_id}{suffix}"
+        )
+
+    async def effect_run_viewer(
         self,
         request: Request,
         forge: str,
@@ -598,24 +633,19 @@ class _LogRoutes:
         name: str,
         run_id: int,
     ) -> HTMLResponse:
-        """ANSI-rendered HTML log of one scheduled-effect run."""
-        project = await self.ctx.repo_or_404(forge, owner, name, request)
-        run = await sched_gen.scheduled_run_detail(
-            self.ctx.pool, id_=run_id, project_id=project["id"]
-        )
-        if run is None:
-            raise HTTPException(status_code=404)
+        """ANSI-rendered HTML log of one effect run."""
+        project, run = await self._run_or_404(request, forge, owner, name, run_id)
         # Live page renders no snapshot: the stream replays full history
         # on connect (mirrors log_viewer).
-        live = self.registry.get_scheduled(run_id) is not None
+        live = self.registry.get_effect(run_id) is not None
         content = ""
         waiting = False
         unavailable = False
         if not live:
-            text = await self._scheduled_run_text(run_id)
+            text = await self._effect_run_text(run_id)
             if text is not None:
                 content = await asyncio.to_thread(render_log_lines, text)
-            elif run.status == "running":
+            elif run["status"] in ("pending", "running"):
                 # Started but the writer is not registered yet (fetch /
                 # checkout runs before the first log byte). Poll until it
                 # appears instead of claiming the log is gone.
@@ -624,18 +654,26 @@ class _LogRoutes:
                 # Terminal run whose log was pruned: placeholder, not a
                 # 404, so the history link still resolves.
                 unavailable = True
+        build = None
+        if run["build_id"] is not None:
+            build = await self.ctx.queries.build_by_number(
+                project["id"], run["build_number"]
+            )
         return await self.ctx.render(
-            "scheduled_log.html",
+            "effect_log.html",
             request=request,
             project=project,
-            run=row_dict(run),
+            run=run,
+            build=build,
             content=content,
             live=live,
             waiting=waiting,
             unavailable=unavailable,
+            can_control=build is not None
+            and await self.ctx.can_control(request, build),
         )
 
-    async def scheduled_run_stream(
+    async def effect_run_stream(
         self,
         request: Request,
         forge: str,
@@ -644,14 +682,9 @@ class _LogRoutes:
         run_id: int,
     ) -> StreamingResponse:
         """SSE: history from disk, then live chunks until completion."""
-        project = await self.ctx.repo_or_404(forge, owner, name, request)
-        row = await sched_gen.scheduled_run_exists(
-            self.ctx.pool, id_=run_id, project_id=project["id"]
-        )
-        if row is None:
-            raise HTTPException(status_code=404)
-        writer = self.registry.get_scheduled(run_id)
-        path = self._scheduled_log_path(run_id)
+        await self._run_or_404(request, forge, owner, name, run_id)
+        writer = self.registry.get_effect(run_id)
+        path = self._effect_log_path(run_id)
         return StreamingResponse(
             _stream_events(writer, path), media_type="text/event-stream"
         )
@@ -944,7 +977,7 @@ class _LogRoutes:
         groups: list[dict] = []
         if len(q.strip()) >= 2:  # noqa: PLR2004
             for a in await self.ctx.queries.attributes(build["id"]):
-                path = log_path_for_key(self.ctx.state_dir, build["id"], a["attr"])
+                path = attribute_log_path(self.ctx.state_dir, build["id"], a["attr"])
                 reader = await _load_container(path)
                 if reader is None:
                     continue
@@ -988,21 +1021,9 @@ class _LogRoutes:
         project, build, path = await self._resolve(
             request, forge, owner, name, number, attr
         )
-        # Effect statuses live in build_effects, not attributes.
-        is_effect = attr.startswith("effect:")
-        attr_row: dict[str, Any] = {}
-        if is_effect:
-            attr_status = await maint_gen.effect_status(
-                self.ctx.pool,
-                build_id=build["id"],
-                name=attr.removeprefix("effect:"),
-            )
-        else:
-            row = await gen.attribute_status(
-                self.ctx.pool, build_id=build["id"], attr=attr
-            )
-            attr_row = row_dict(row) if row else {}
-            attr_status = row.status if row else None
+        row = await gen.attribute_status(self.ctx.pool, build_id=build["id"], attr=attr)
+        attr_row: dict[str, Any] = row_dict(row) if row else {}
+        attr_status = row.status if row else None
         # Live pages render no snapshot: the stream replays full
         # history on connect, the client would throw it away.
         writer = self.registry.get(build["id"], attr)
@@ -1051,7 +1072,6 @@ class _LogRoutes:
             build=build,
             attr_status=attr_status,
             attr_row=attr_row,
-            is_effect=is_effect,
             attr=attr,
             content=content,
             toc=toc,
@@ -1077,6 +1097,12 @@ def create_log_router(ctx: WebContext, registry: LogRegistry) -> APIRouter:
     # viewer catch-all. /logs/raw/{attr} is the unambiguous raw route;
     # the .txt suffix stays as a fallback for existing consumers.
     router.get(f"{_BASE}/search")(routes.build_search)
+    # Effect logs moved to /effects/runs/{id}. Keep the per-build URLs
+    # that forge statuses and old links point at.
+    for suffix in (".txt", "/stream", ""):
+        router.get(f"{_BASE}/logs/effect:{{effect:path}}{suffix}")(
+            functools.partial(routes.build_effect_log_redirect, suffix=suffix)
+        )
     router.get(f"{_BASE}/logs/raw/{{attr:path}}")(routes.log_raw_text)
     router.get(f"{_BASE}/logs/{{attr}}.txt")(routes.log_raw_text_legacy)
     router.get(f"{_BASE}/logs/{{attr:path}}/stream")(routes.log_stream)
@@ -1090,18 +1116,16 @@ def create_log_router(ctx: WebContext, registry: LogRegistry) -> APIRouter:
     router.get(f"{_BASE}/logs/{{attr:path}}", response_class=HTMLResponse)(
         routes.log_viewer
     )
-    # Same ordering discipline as the attribute routes above: the .txt
-    # and /stream suffixes and the runs list precede the int {run_id}
-    # viewer so it cannot swallow them.
-    sched_base = "/repos/{forge}/{owner:owner}/{name:segment}/schedules"
-    router.get(f"{sched_base}/runs", response_class=HTMLResponse)(
+    repo_base = "/repos/{forge}/{owner:owner}/{name:segment}"
+    router.get(f"{repo_base}/schedules/runs", response_class=HTMLResponse)(
         routes.scheduled_runs_history
     )
-    router.get(f"{sched_base}/runs/{{run_id:int}}.txt")(routes.scheduled_run_log)
-    router.get(f"{sched_base}/runs/{{run_id:int}}/stream")(routes.scheduled_run_stream)
-    router.get(f"{sched_base}/runs/{{run_id:int}}", response_class=HTMLResponse)(
-        routes.scheduled_run_viewer
-    )
+    # .txt and /stream precede the int {run_id} viewer so it cannot
+    # swallow them.
+    runs = f"{repo_base}/effects/runs/{{run_id:int}}"
+    router.get(f"{runs}.txt")(routes.effect_run_log)
+    router.get(f"{runs}/stream")(routes.effect_run_stream)
+    router.get(runs, response_class=HTMLResponse)(routes.effect_run_viewer)
     return router
 
 

--- a/nixbot/nixbot/web/routing.py
+++ b/nixbot/nixbot/web/routing.py
@@ -3,7 +3,7 @@
 GitLab nested groups put "/" into the owner (e.g. "group/sub"), which
 plain `{owner}` parameters cannot match. The `owner` convertor accepts
 one or more path segments, but never segments that start a fixed route
-suffix (builds/rows/attrs/schedules). Otherwise a multi-segment owner
+suffix (builds/rows/attrs/schedules/effects). Otherwise a multi-segment owner
 would swallow `/builds/{number}` and misroute deeper URLs to the repo
 page. The `segment` convertor is the single-segment variant for the
 project name: without it, `/repos/f/a/b/rows` would parse as
@@ -17,7 +17,7 @@ from __future__ import annotations
 from starlette.convertors import Convertor, register_url_convertor
 
 # Literal segments that follow {name} in project routes.
-_RESERVED = ("builds", "rows", "attrs", "schedules", r"badge\.svg")
+_RESERVED = ("builds", "rows", "attrs", "schedules", "effects", r"badge\.svg")
 _SEGMENT = r"(?:(?!(?:" + "|".join(_RESERVED) + r")(?:/|$))[^/]+)"
 
 

--- a/nixbot/nixbot/web/templates/_schedule_run_rows.html
+++ b/nixbot/nixbot/web/templates/_schedule_run_rows.html
@@ -2,7 +2,7 @@
 {% for r in runs %}
   <tr data-id="{{ r.id }}">
     <td>
-      {{ status_icon(r.status) }}<a href="{{ repo_path(project) }}/schedules/runs/{{ r.id }}">#{{ r.id }}</a>
+      {{ status_icon(r.status) }}<a href="{{ repo_path(project) }}/effects/runs/{{ r.id }}">#{{ r.id }}</a>
     </td>
     <td class="muted">
       <time datetime="{{ r.started_at.isoformat() }}" title="{{ r.started_at }}">{{ r.started_at | timeago }}</time>

--- a/nixbot/nixbot/web/templates/build.html
+++ b/nixbot/nixbot/web/templates/build.html
@@ -168,7 +168,7 @@
               <td class="attr-status">{{ status_icon(e.status) }}</td>
               <td class="attr-name">
                 {% if e.log_size or e.status == "running" %}
-                  <a href="{{ build_path(project, build.number) }}/logs/effect:{{ e.name | urlencode }}"><code>{{ e.name }}</code></a>
+                  <a href="{{ repo_path(project) }}/effects/runs/{{ e.id }}"><code>{{ e.name }}</code></a>
                 {% else %}
                   <code>{{ e.name }}</code>
                 {% endif %}

--- a/nixbot/nixbot/web/templates/effect_log.html
+++ b/nixbot/nixbot/web/templates/effect_log.html
@@ -1,7 +1,11 @@
 {% extends "base.html" %}
 {% from "_macros.html" import status_icon %}
-{% set label = run.schedule_name if run.schedule_name == run.effect else run.schedule_name ~ " · " ~ run.effect %}
-{% set history_url = repo_path(project) ~ "/schedules/runs?schedule=" ~ (run.schedule_name | urlencode) ~ "&effect=" ~ (run.effect | urlencode) %}
+{% if run.kind == "schedule" %}
+  {% set label = run.schedule_name if run.schedule_name == run.effect else run.schedule_name ~ " · " ~ run.effect %}
+{% else %}
+  {% set label = run.effect %}
+{% endif %}
+{% set run_url = repo_path(project) ~ "/effects/runs/" ~ run.id %}
 {% block title %}
   {{ label }} run
 {% endblock title %}
@@ -13,13 +17,29 @@
           {{ status_icon(run.status) }}
           <code>{{ label }}</code>
           <small>
-            run #{{ run.id }}
-            · <a href="{{ repo_path(project) }}/schedules/runs/{{ run.id }}.txt">raw</a>
-            · <a href="{{ history_url }}">history</a>
+            {% if build %}
+              effect of <a href="{{ build_path(project, build.number) }}">build #{{ build.number }}</a>
+            {% else %}
+              run #{{ run.id }}
+            {% endif %}
+            · <a href="{{ run_url }}.txt">raw</a>
+            {% if run.kind == "schedule" %}
+              {% set history_url = repo_path(project) ~ "/schedules/runs?schedule=" ~ (run.schedule_name | urlencode) ~ "&effect=" ~ (run.effect | urlencode) %}
+              · <a href="{{ history_url }}">history</a>
+            {% endif %}
             · <a href="{{ repo_path(project) }}">{{ project.owner }}/{{ project.name }}</a>
           </small>
         </h2>
+        <div class="controls">
+          {% if build and can_control and build.status == "succeeded" and run.status not in ("pending", "running") %}
+            <form method="post"
+                  action="{{ build_path(project, build.number) }}/effects/restart?name={{ run.effect | urlencode }}">
+              <button>restart</button>
+            </form>
+          {% endif %}
+        </div>
       </div>
+      {% if run.error %}<pre class="error">{{ run.error }}</pre>{% endif %}
       {% if live %}
         <label>
           <input type="checkbox" id="follow" checked>
@@ -46,23 +66,22 @@
     /* Started but no writer/log yet: reload until it appears, since the
        running->running INSERT raised no further event to react to. */
     if (WAITING) setTimeout(() => location.reload(), 2000);
-    /* Status changes for this run (INSERT running / terminal UPDATE)
-       arrive on the shared events channel. Reload to re-render the
-       header dot and, once finished, the server-side static log. */
+    /* Status changes for this run arrive on the shared events channel.
+       Reload to re-render the header dot and, once finished, the
+       server-side static log. */
     const events = new EventSource("/events?project={{ project.id }}");
     events.addEventListener("status", (ev) => {
       let e;
       try { e = JSON.parse(ev.data); } catch { return; }
       if (e.run_id !== RUN_ID) return;
-      if (!LIVE || !["running"].includes(e.status)) location.reload();
+      if (!LIVE || e.status !== "running") location.reload();
     });
     if (LIVE) {
       const follow = document.getElementById("follow");
       const atBottom = () =>
         log.scrollHeight - log.scrollTop - log.clientHeight < 4;
       log.addEventListener("scroll", () => { follow.checked = atBottom(); });
-      const source = new EventSource(
-        "{{ repo_path(project) }}/schedules/runs/{{ run.id }}/stream");
+      const source = new EventSource("{{ run_url }}/stream");
       let errors = 0;
       source.onopen = () => { errors = 0; log.textContent = ""; };
       source.onerror = () => {

--- a/nixbot/nixbot/web/templates/log.html
+++ b/nixbot/nixbot/web/templates/log.html
@@ -25,14 +25,7 @@
           </small>
         </h2>
         <div class="controls">
-          {% if is_effect %}
-            {% if can_control and build.status == "succeeded" and attr_status not in ("pending", "running") %}
-              <form method="post"
-                    action="{{ build_path(project, build.number) }}/effects/restart?name={{ attr | replace('effect:', '', 1) | urlencode }}">
-                <button>restart</button>
-              </form>
-            {% endif %}
-          {% elif can_control and attr_status in ('pending', 'building') %}
+          {% if can_control and attr_status in ('pending', 'building') %}
             <form method="post"
                   action="{{ build_path(project, build.number) }}/attrs/{{ attr | urlencode }}/cancel">
               <button>cancel</button>

--- a/nixbot/nixbot/web/templates/repo.html
+++ b/nixbot/nixbot/web/templates/repo.html
@@ -119,7 +119,7 @@
               </td>
               <td class="muted attr-status">
                 {% if s.run %}
-                  <a href="{{ repo_path(project) }}/schedules/runs/{{ s.run.id }}">
+                  <a href="{{ repo_path(project) }}/effects/runs/{{ s.run.id }}">
                     <time datetime="{{ s.run.started_at.isoformat() }}"
                           title="{{ s.run.started_at }}">{{ s.run.started_at | timeago }}</time>
                   </a>


### PR DESCRIPTION
Groundwork split out of the onEvent work (#165): one effect_runs table instead of build_effects and scheduled_effect_runs, and an EffectsBackend on the orchestrator that tests fake instead of monkeypatching. Includes the gcroot fix as first commit.