### PR TITLE
eval: size cgroup from MemAvailable, not MemFree

### DIFF
--- a/nixbot/nixbot/memory.py
+++ b/nixbot/nixbot/memory.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging
 import multiprocessing
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -37,19 +36,34 @@ class MemoryInfo:
     zfs_arc_used: int = 0
 
 
+def _read_meminfo(path: Path) -> dict[str, int]:
+    """Parse /proc/meminfo into MiB values."""
+    fields: dict[str, int] = {}
+    with path.open() as f:
+        for line in f:
+            key, _, rest = line.partition(":")
+            parts = rest.split()
+            if parts:
+                fields[key] = int(parts[0]) // 1024
+    return fields
+
+
 def get_memory_info(
+    meminfo_path: Path = Path("/proc/meminfo"),
     arcstats_path: Path = Path("/proc/spl/kstat/zfs/arcstats"),
 ) -> MemoryInfo:
-    """Get memory information on Linux, including reclaimable ZFS ARC."""
+    """Get memory information on Linux, including reclaimable ZFS ARC.
+
+    MemAvailable, not MemFree: page cache is reclaimable and MemFree is
+    near zero on any host that has been up for a while.
+    """
     try:
-        total_pages = os.sysconf("SC_PHYS_PAGES")
-        page_size = os.sysconf("SC_PAGE_SIZE")
-        available_pages = os.sysconf("SC_AVPHYS_PAGES")
-        total_memory_mib = (total_pages * page_size) // (1024 * 1024)
-        available_memory_mib = (available_pages * page_size) // (1024 * 1024)
-    except (ValueError, OSError):
+        meminfo = _read_meminfo(meminfo_path)
+        total_memory_mib = meminfo["MemTotal"]
+        available_memory_mib = meminfo["MemAvailable"]
+    except (OSError, KeyError, ValueError):
         logger.warning(
-            "could not get memory info via sysconf, using conservative estimates"
+            "could not read %s, using conservative memory estimates", meminfo_path
         )
         total_memory_mib = 8192
         available_memory_mib = 4096

--- a/nixbot/nixbot/memory.py
+++ b/nixbot/nixbot/memory.py
@@ -1,12 +1,13 @@
-"""Eval worker count and memory-limit sizing.
-
-Only the Linux path is needed, the service is Linux-only.
-"""
+"""Eval worker count and memory-limit sizing."""
 
 from __future__ import annotations
 
 import logging
 import multiprocessing
+import os
+import re
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -48,23 +49,55 @@ def _read_meminfo(path: Path) -> dict[str, int]:
     return fields
 
 
+# Pages Darwin hands out without swapping, the closest analogue to
+# Linux MemAvailable.
+_VM_STAT_AVAILABLE = (
+    "Pages free",
+    "Pages inactive",
+    "Pages speculative",
+    "Pages purgeable",
+)
+
+
+def parse_vm_stat(output: str) -> int:
+    """Available MiB from Darwin `vm_stat` output."""
+    m = re.search(r"page size of (\d+) bytes", output)
+    if m is None:
+        msg = "vm_stat: no page size"
+        raise ValueError(msg)
+    page_size = int(m.group(1))
+    pages = 0
+    for line in output.splitlines():
+        key, _, value = line.partition(":")
+        if key.strip() in _VM_STAT_AVAILABLE:
+            pages += int(value.strip().rstrip("."))
+    return pages * page_size // (1024 * 1024)
+
+
+def _darwin_memory_info() -> tuple[int, int]:
+    total = os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE") // (1024 * 1024)
+    out = subprocess.run(["vm_stat"], capture_output=True, text=True, check=True).stdout
+    return total, parse_vm_stat(out)
+
+
 def get_memory_info(
     meminfo_path: Path = Path("/proc/meminfo"),
     arcstats_path: Path = Path("/proc/spl/kstat/zfs/arcstats"),
 ) -> MemoryInfo:
-    """Get memory information on Linux, including reclaimable ZFS ARC.
+    """Get total and available memory, including reclaimable ZFS ARC.
 
     MemAvailable, not MemFree: page cache is reclaimable and MemFree is
     near zero on any host that has been up for a while.
     """
     try:
-        meminfo = _read_meminfo(meminfo_path)
-        total_memory_mib = meminfo["MemTotal"]
-        available_memory_mib = meminfo["MemAvailable"]
-    except (OSError, KeyError, ValueError):
-        logger.warning(
-            "could not read %s, using conservative memory estimates", meminfo_path
-        )
+        if sys.platform == "darwin":
+            total_memory_mib, available_memory_mib = _darwin_memory_info()
+        else:
+            meminfo = _read_meminfo(meminfo_path)
+            total_memory_mib = meminfo["MemTotal"]
+            available_memory_mib = meminfo["MemAvailable"]
+    except (OSError, KeyError, ValueError, subprocess.SubprocessError):
+        logger.warning("could not read memory info, using conservative estimates")
         total_memory_mib = 8192
         available_memory_mib = 4096
 

--- a/nixbot/nixbot/nix_eval.py
+++ b/nixbot/nixbot/nix_eval.py
@@ -78,8 +78,9 @@ class EvalSettings:
 
     worker_count: int = 1
     max_memory_size_mib: int = 4096
-    # See EvalWorkerConfig.cgroup_limit_mib. None derives it from the
-    # worker budget.
+    # See EvalWorkerConfig.cgroup_limit_mib. The worker budget is the
+    # floor: a smaller cgroup would OOM-kill an eval that stays within
+    # its configured limits.
     cgroup_limit_mib: int | None = None
     show_trace: bool = False
     # bwrap sandbox. Disable only in tests.
@@ -100,9 +101,10 @@ class EvalSettings:
 
     @property
     def memory_limit_mib(self) -> int:
+        budget = self.max_memory_size_mib * (self.worker_count + 1)
         if self.cgroup_limit_mib is not None:
-            return self.cgroup_limit_mib
-        return self.max_memory_size_mib * (self.worker_count + 1)
+            return max(budget, self.cgroup_limit_mib)
+        return budget
 
 
 @dataclass

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -144,6 +144,34 @@ def test_full_command_composition(tmp_path: Path) -> None:
     assert cmd[0] == "nix-eval-jobs"
 
 
+def test_memory_limit_never_below_worker_budget(tmp_path: Path) -> None:
+    # Regression (#182): a host-derived cgroup limit smaller than the
+    # configured worker budget OOM-killed evals at that limit.
+    settings = EvalSettings(
+        gc_roots_dir=tmp_path,
+        worker_count=2,
+        max_memory_size_mib=4096,
+        cgroup_limit_mib=2048,
+    )
+    assert settings.memory_limit_mib == 3 * 4096
+    settings.cgroup_limit_mib = 50000
+    assert settings.memory_limit_mib == 50000
+
+
+def test_memory_info_uses_memavailable(tmp_path: Path) -> None:
+    # Regression (#182): MemFree excludes page cache and is near zero on
+    # any long-running host, which collapsed the eval cgroup to 2 GiB.
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemTotal:       16384000 kB\n"
+        "MemFree:          102400 kB\n"
+        "MemAvailable:   10240000 kB\n"
+    )
+    info = get_memory_info(meminfo_path=meminfo, arcstats_path=tmp_path / "absent")
+    assert info.total_memory_mib == 16000
+    assert info.available_memory_mib == 10000
+
+
 def test_memory_info_zfs_arc(tmp_path: Path) -> None:
     arcstats = tmp_path / "arcstats"
     arcstats.write_text("name type data\nsize 4 2147483648\n")

--- a/nixbot/nixbot/tests/test_nix_eval.py
+++ b/nixbot/nixbot/tests/test_nix_eval.py
@@ -21,6 +21,7 @@ from nixbot.memory import (
     MemoryInfo,
     calculate_eval_workers,
     get_memory_info,
+    parse_vm_stat,
 )
 from nixbot.nix_eval import (
     EvalError,
@@ -170,6 +171,21 @@ def test_memory_info_uses_memavailable(tmp_path: Path) -> None:
     info = get_memory_info(meminfo_path=meminfo, arcstats_path=tmp_path / "absent")
     assert info.total_memory_mib == 16000
     assert info.available_memory_mib == 10000
+
+
+def test_parse_vm_stat() -> None:
+    out = (
+        "Mach Virtual Memory Statistics: (page size of 16384 bytes)\n"
+        "Pages free:                               10000.\n"
+        "Pages active:                            500000.\n"
+        "Pages inactive:                           20000.\n"
+        "Pages speculative:                         2000.\n"
+        "Pages throttled:                              0.\n"
+        "Pages wired down:                        100000.\n"
+        "Pages purgeable:                            768.\n"
+        '"Translation faults":                 123456789.\n'
+    )
+    assert parse_vm_stat(out) == (10000 + 20000 + 2000 + 768) * 16384 // 2**20
 
 
 def test_memory_info_zfs_arc(tmp_path: Path) -> None:


### PR DESCRIPTION
SC_AVPHYS_PAGES is MemFree, which is near zero on warm hosts, so the eval cgroup collapsed to its 2048 MiB floor and the kernel OOM-killed nix-eval-jobs regardless of evalMaxMemorySize. Read MemAvailable and floor the cgroup limit at the configured worker budget.

Fixes #182