### PR TITLE
herculesCI: deploy through flakelet-relay instead of ssh certs

### DIFF
--- a/herculesCI/default.nix
+++ b/herculesCI/default.nix
@@ -12,31 +12,17 @@ in
 { primaryRepo, ... }:
 {
   onPush.default.outputs = {
-    # Fire-and-forget: the target enqueues a detached flakelet update,
-    # which restarts nixbot and with it this effect runner.
+    # The update restarts nixbot and with it this effect runner, so do
+    # not wait for the result. Authorized by rule "nixbot" in
+    # Mic92/dotfiles nixosModules/flakelet-relay.
     effects.deploy = hci-effects.runIf (primaryRepo.branch or null == "main") (
       hci-effects.mkEffect {
         name = "deploy";
-        idTokenAudiences = [ "step-ca-ssh" ];
-        inputs = [
-          pkgs.step-cli
-          pkgs.openssh
-        ];
+        idTokenAudiences = [ "flakelet-relay" ];
+        inputs = [ (pkgs.callPackage ./flakelet-push.nix { }) ];
         effectScript = ''
-          export STEPPATH=$PWD/.step
-          step ca bootstrap --ca-url https://ca.r \
-            --fingerprint 759759ea7dc7d635d761ce19a07bc0b3ab02212318e05b49d2b194c60414b84a
-
-          ssh-keygen -t ed25519 -N "" -q -f ./id_deploy
-          step ssh certificate --sign --provisioner nixbot \
-            --token "$(nixbot-id-token step-ca-ssh)" \
-            deploy ./id_deploy.pub
-
-          ssh -i ./id_deploy \
-            -o CertificateFile=./id_deploy-cert.pub \
-            -o UserKnownHostsFile=$PWD/known_hosts \
-            -o StrictHostKeyChecking=accept-new \
-            flakelet-deploy@eve.r
+          export FLAKELET_RELAY_TOKEN_COMMAND="nixbot-id-token flakelet-relay"
+          flakelet-push --relay-srv thalheim.io deploy --detach eve/nixbot
         '';
       }
     );

--- a/herculesCI/flakelet-push.nix
+++ b/herculesCI/flakelet-push.nix
@@ -1,0 +1,23 @@
+# flakelet-push from Mic92/flakelet-relay for the deploy effect, as a
+# plain package so this flake needs no extra input.
+{
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage {
+  pname = "flakelet-push";
+  version = "0-unstable-2026-09-03";
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "flakelet-relay";
+    rev = "521f8072bcdcfca712d5598a9979d5b7557eab72";
+    hash = "sha256-3fLTA1nRvw7zZilI9mEeuqOvGEW8+VeE+82K7jdhaJw=";
+  };
+  cargoHash = "sha256-gjNXc8rQZM5QKcVu/TV5RJzLdhC8XVhtRICrq1ZtK+A=";
+  cargoBuildFlags = [
+    "--bin"
+    "flakelet-push"
+  ];
+  doCheck = false;
+  meta.mainProgram = "flakelet-push";
+}


### PR DESCRIPTION
Uses the relays on eve/eva with this repo's id token; --detach because the update restarts nixbot.