### PR TITLE
nixbot_effects: add onEvent listing, matching and running

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -129,7 +129,13 @@ nbo effects graph                       # dependency DAG as an ASCII tree
 nbo effects run default.deploy          # run one effect in the local sandbox
 nbo effects run github:org/repo/branch#default.deploy
 nbo effects run-scheduled github:org/repo#nightly flake-update
+nbo effects list --event pull_request --pr 7 --permission write
+nbo effects run --event comment --command apply --permission admin apply
 ```
+
+For `onEvent` effects, `--event KIND` plus flags describing the event (`--pr`,
+`--actor`, `--permission`, `--label`, `--command`, ...) stand in for a real
+delivery, and `list` then shows why each effect would be skipped.
 
 ## Exit codes
 

--- a/docs/EFFECTS.md
+++ b/docs/EFFECTS.md
@@ -218,6 +218,70 @@ derivation attribute; effects built without `mkEffect` can set the attribute
 directly. Effects that do not set it get no checkout. If the repository has no
 forge token to push with, the effect fails with an error.
 
+## Event effects (`onEvent`)
+
+`herculesCI.onEvent.<kind>.<name>` defines effects that react to pull requests,
+PR comments, PR close and build results. See
+[examples/on-event/flake.nix](../examples/on-event/flake.nix). Hercules CI
+ignores `onEvent`.
+
+The effect code is **always evaluated from the default branch**. A pull request
+cannot change what runs by editing `onEvent`. This is independent of
+`effects_on_pull_requests`, which controls whether a PR's own `onPush` effects
+run. The event only contributes data, available at runtime as JSON in
+`$NIXBOT_EVENT_JSON` (`/run/event.json`) and as `NIXBOT_EVENT_KIND`,
+`NIXBOT_ACTOR`, `NIXBOT_PR_NUMBER`, `NIXBOT_PR_HEAD`, `NIXBOT_COMMAND`,
+`NIXBOT_COMMAND_ARGS`, `NIXBOT_BUILD_STATUS`, `NIXBOT_BUILD_URL`.
+
+| kind                  | delivered when                                     | payload                                                                  |
+| --------------------- | -------------------------------------------------- | ------------------------------------------------------------------------ |
+| `pull_request`        | a PR build finished `succeeded`                    | `actor?`, `build`, `pullRequest`                                         |
+| `pull_request_closed` | PR closed or merged                                | `actor?`, `pullRequest` (with `merged`)                                  |
+| `comment`             | new PR comment whose first line is `/command args` | `actor`, `command`, `args`, `pullRequest`, `build?`                      |
+| `build_finished`      | any build reached a terminal status                | `actor?`, `build` (with `previousStatus`, `failedAttrs`), `pullRequest?` |
+
+`actor` is who caused the delivery (pusher, commenter, the user who pressed
+restart) as `{ name = "github:alice"; permission = "write"; }`. It is absent
+when nobody did (poller). `pullRequest.author` carries the PR opener the same
+way. Permissions are looked up on the forge at delivery time.
+
+`mkEffect { when = { ... }; }` restricts when an effect runs. All given keys
+must match. An effect that does not match is recorded as `skipped` with the
+reason shown in the web UI.
+
+| `when` key                              | matches if                                                        |
+| --------------------------------------- | ----------------------------------------------------------------- |
+| `permission = "read"\|"write"\|"admin"` | actor **or** PR author has at least this level                    |
+| `labels = [ ... ]`                      | PR has all of these labels                                        |
+| `branches = [ "main" "release-*" ]`     | glob on PR base branch, or build branch                           |
+| `commands = [ "plan" ]`                 | `comment` kind: the `/command` used                               |
+| `status = [ "succeeded" ]`              | status of the build in the payload                                |
+| `transition = "broke"\|"fixed"`         | build status vs the previous finished build of the same branch/PR |
+
+`lock` works as for `onPush` and may contain `{pr}`, so `lock = "preview-{pr}"`
+serialises per pull request, also against `onPush` effects using the same
+expanded name. A newer delivery for the same PR cancels still-queued effects of
+the previous one. `after` is not supported for event effects.
+
+`checkout = true` mounts the **PR head** at `/build/checkout`. Unlike for
+`onPush` the clone has no push credentials, and its content is untrusted: tools
+like `tofu plan` execute code from it, so guard such effects with
+`when.permission`.
+
+Try an effect locally by describing the event with flags instead of pushing:
+
+```console
+$ nbo effects list --event pull_request --pr 7 --permission write --label preview
+$ nbo effects run --event comment --command plan --actor github:alice \
+    --permission write plan
+```
+
+`list` prints every effect of that kind together with the reason it would be
+skipped. The flags cover what `when` looks at: `--pr`, `--actor`,
+`--permission`, `--author-permission`, `--label`, `--command`, `--args`,
+`--build-status` and `--previous-build-status`. `--payload FILE` takes a
+complete payload instead.
+
 ## Buildbot secrets configuration
 
 When running effects through nixbot (not locally), secrets are configured at

--- a/examples/on-event/flake.nix
+++ b/examples/on-event/flake.nix
@@ -1,0 +1,132 @@
+# `onEvent` effects: react to pull requests, PR comments, PR close and
+# build results. Effect code is always taken from the default branch,
+# the event only contributes data ($NIXBOT_EVENT_JSON and NIXBOT_*
+# variables). See docs/EFFECTS.md "Event effects".
+#
+# Try locally:
+#   nbo effects list --event pull_request --payload pr.json
+#   nbo effects run  --event comment --payload comment.json plan
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixbot.url = "github:Mic92/nixbot";
+  inputs.nixbot.inputs.nixpkgs.follows = "nixpkgs";
+
+  outputs =
+    { nixpkgs, nixbot, ... }:
+    let
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      fx = nixbot.lib.effects { inherit pkgs; };
+      inherit (fx) mkEffect;
+      nbo = nixbot.packages.x86_64-linux.nixbot-cli;
+
+      # checkout = true mounts the PR head at $NIXBOT_EFFECT_CHECKOUT (cwd).
+      # That tree is untrusted: `tofu plan` executes provider code from it,
+      # hence `permission = "write"` on everything below.
+      tofu =
+        args:
+        mkEffect (
+          {
+            inputs = [
+              pkgs.opentofu
+              nbo
+            ];
+            checkout = true;
+            userSetupScript = "cd infra && tofu init -input=false";
+          }
+          // args
+        );
+      planScript = ''
+        tofu plan -input=false -no-color -lock=false | tee "$TMPDIR/plan.txt"
+        nbo pr comment --replace-marker tofu-plan --file "$TMPDIR/plan.txt"
+      '';
+    in
+    {
+      herculesCI =
+        { ... }:
+        {
+          # hercules-compatible part: main applies for real.
+          onPush.default.outputs.effects.apply = tofu {
+            lock = "infra";
+            effectScript = "tofu apply -input=false -auto-approve";
+          };
+
+          onEvent = {
+            # A PR build turned green.
+            pull_request = {
+              plan = tofu {
+                # actor (pusher) or PR author needs write access
+                when.permission = "write";
+                # queues behind a running apply
+                lock = "infra";
+                effectScript = planScript;
+              };
+              preview = mkEffect {
+                when = {
+                  permission = "write";
+                  labels = [ "preview" ];
+                };
+                lock = "preview-{pr}";
+                inputs = [ nbo ];
+                effectScript = ''
+                  echo deploy "pr-$NIXBOT_PR_NUMBER" at "$NIXBOT_PR_HEAD"
+                  nbo pr comment --replace-marker preview "https://pr-$NIXBOT_PR_NUMBER.preview.example.org"
+                '';
+              };
+            };
+
+            # PR closed or merged. Same lock as `preview`, so a deploy for
+            # the last push finishes before teardown starts.
+            pull_request_closed.teardown = mkEffect {
+              lock = "preview-{pr}";
+              effectScript = ''echo destroy "pr-$NIXBOT_PR_NUMBER"'';
+            };
+
+            # "/plan" and "/apply" comments on open PRs.
+            comment = {
+              plan = tofu {
+                when = {
+                  commands = [ "plan" ];
+                  permission = "write";
+                };
+                lock = "infra";
+                effectScript = planScript;
+              };
+              apply = tofu {
+                when = {
+                  commands = [ "apply" ];
+                  permission = "write";
+                  # refuse a red or unbuilt head
+                  status = [ "succeeded" ];
+                };
+                lock = "infra";
+                effectScript = ''
+                  tofu apply -input=false -auto-approve
+                  nbo pr comment "Applied $NIXBOT_PR_HEAD (requested by $NIXBOT_ACTOR)."
+                '';
+              };
+            };
+
+            # Edge-triggered notifications for main.
+            build_finished = {
+              broke = mkEffect {
+                when = {
+                  branches = [ "main" ];
+                  transition = "broke";
+                };
+                effectScript = ''
+                  echo "main broke: $NIXBOT_BUILD_URL"
+                  jq -r '.build.failedAttrs[]' "$NIXBOT_EVENT_JSON"
+                '';
+              };
+              fixed = mkEffect {
+                when = {
+                  branches = [ "main" ];
+                  transition = "fixed";
+                };
+                effectScript = ''echo "main is green again: $NIXBOT_BUILD_URL"'';
+              };
+            };
+          };
+        };
+    };
+}

--- a/herculesCI/effects-lib.nix
+++ b/herculesCI/effects-lib.nix
@@ -33,6 +33,9 @@ in
       # serializing runs across builds.
       after ? [ ],
       lock ? null,
+      # onEvent only: conditions nixbot checks against the event before
+      # running, see docs/EFFECTS.md. `lock` may contain `{pr}` there.
+      when ? { },
     }:
     pkgs.stdenvNoCC.mkDerivation {
       inherit
@@ -42,7 +45,7 @@ in
         ;
       # Attr paths are nested lists, which cannot be coerced into
       # derivation env vars; expose them via passthru instead.
-      passthru = { inherit after lock; };
+      passthru = { inherit after lock when; };
       isEffect = true;
       __nixbot_effect_checkout = checkout;
       # like upstream hercules-ci-effects

--- a/nixbot_cli/nixbot_cli/effects.py
+++ b/nixbot_cli/nixbot_cli/effects.py
@@ -12,15 +12,19 @@ import json
 import sys
 from dataclasses import asdict
 from pathlib import Path
+from typing import Any
 
 from nixbot_effects.eval import options_from_flake_ref
 from nixbot_effects.graph import render_tree
+from nixbot_effects.match import KINDS, event_payload, skip_reason
 
 from nixbot_effects import (
     EffectsOptions,
     list_effects,
+    list_event_effects,
     list_scheduled_effects,
     run_effect,
+    run_event_effect,
     run_scheduled_effect,
 )
 
@@ -77,16 +81,42 @@ async def _split_flake_ref(
     return name, options
 
 
+def _payload_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    """The event to match against: a file, or one described by flags."""
+    if args.payload is not None:
+        try:
+            return json.loads(args.payload.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            sys.exit(f"nbo: cannot read payload {args.payload}: {e}")
+    return event_payload(
+        pr=args.pr,
+        branch=args.branch,
+        actor=args.actor,
+        permission=args.permission,
+        author_permission=args.author_permission,
+        labels=args.labels,
+        command=args.command,
+        args=args.args,
+        status=args.build_status,
+        previous_status=args.previous_build_status,
+    )
+
+
 async def list_command(args: argparse.Namespace) -> None:
     options = _options_from_args(args)
     if args.flake_ref:
         options = await options_from_flake_ref(args.flake_ref, options)
-    effects = await list_effects(options)
-    json.dump(
-        {name: asdict(meta) for name, meta in effects.items()},
-        fp=sys.stdout,
-        indent=2,
-    )
+    if args.event:
+        payload = _payload_from_args(args)
+        out = {}
+        for name, meta in (await list_event_effects(options, args.event)).items():
+            out[name] = asdict(meta)
+            out[name]["skipReason"] = skip_reason(meta.when, payload)
+    else:
+        out = {
+            name: asdict(meta) for name, meta in (await list_effects(options)).items()
+        }
+    json.dump(out, fp=sys.stdout, indent=2)
     print()
 
 
@@ -112,6 +142,9 @@ async def run_command(args: argparse.Namespace) -> None:
     effect, options = await _split_flake_ref(
         args.effect, options, f"nbo effects run {args.effect}#<effect-name>"
     )
+    if args.event:
+        await run_event_effect(options, args.event, effect, _payload_from_args(args))
+        return
     await run_effect(options, effect)
 
 
@@ -136,6 +169,60 @@ def _key_value(option: str) -> tuple[str, str]:
         msg = f"expected KEY=VALUE, got {option!r}"
         raise argparse.ArgumentTypeError(msg)
     return (key, value)
+
+
+def _add_event_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--event",
+        choices=KINDS,
+        metavar="KIND",
+        help=f"use onEvent.KIND instead of onPush ({', '.join(KINDS)})",
+    )
+    parser.add_argument(
+        "--payload",
+        type=Path,
+        metavar="FILE",
+        help="event payload JSON, as delivered by nixbot; otherwise the "
+        "flags below describe the event",
+    )
+    parser.add_argument("--pr", type=int, metavar="N", help="pull request number")
+    parser.add_argument(
+        "--actor", metavar="USER", help="who triggered the event, e.g. github:alice"
+    )
+    parser.add_argument(
+        "--permission",
+        choices=("read", "write", "admin"),
+        help="the actor's permission on the repository",
+    )
+    parser.add_argument(
+        "--author-permission",
+        choices=("read", "write", "admin"),
+        help="the PR author's permission (defaults to --permission)",
+    )
+    parser.add_argument(
+        "--label",
+        action="append",
+        default=[],
+        dest="labels",
+        metavar="LABEL",
+        help="a label on the pull request (repeatable)",
+    )
+    parser.add_argument("--command", metavar="NAME", help="the /command commented")
+    parser.add_argument(
+        "--args", default="", metavar="ARGS", help="arguments after the /command"
+    )
+    parser.add_argument(
+        "--build-status",
+        default="succeeded",
+        choices=("succeeded", "failed"),
+        help="status of the build the event is about",
+    )
+    parser.add_argument(
+        "--previous-build-status",
+        choices=("succeeded", "failed"),
+        metavar="STATUS",
+        help="status of the previous build, for when.transition",
+    )
 
 
 def _add_common_flags(parser: argparse.ArgumentParser) -> None:
@@ -251,7 +338,9 @@ def register(sub: argparse._SubParsersAction) -> None:
   nbo effects graph                 the dependency DAG as an ASCII tree
   nbo effects run default.deploy    run one effect in the local sandbox
   nbo effects run github:org/repo/branch#default.deploy   without a checkout
-  nbo effects run-scheduled github:org/repo#nightly flake-update""",
+  nbo effects run-scheduled github:org/repo#nightly flake-update
+  nbo effects list --event pull_request --pr 7 --label preview   onEvent effects with skip reasons
+  nbo effects run --event comment --command apply --permission admin apply""",
     )
     effects.set_defaults(func=cmd_effects, needs_client=False)
     esub = effects.add_subparsers(dest="effects_command", required=True)
@@ -261,6 +350,7 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="List available effects (optionally from a flake reference)",
     )
     _add_common_flags(list_parser)
+    _add_event_flags(list_parser)
     list_parser.set_defaults(effects_func=list_command)
     list_parser.add_argument(
         "flake_ref",
@@ -285,6 +375,7 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Run an effect (supports flakeref#effect syntax)",
     )
     _add_common_flags(run_parser)
+    _add_event_flags(run_parser)
     run_parser.set_defaults(effects_func=run_command)
     run_parser.add_argument(
         "effect",

--- a/nixbot_effects/nixbot_effects/__init__.py
+++ b/nixbot_effects/nixbot_effects/__init__.py
@@ -5,17 +5,20 @@ CLI in `cli.py` is a thin standalone wrapper.
 """
 
 from .errors import EffectError
-from .eval import list_effects, list_scheduled_effects
-from .graph import EffectMeta
+from .eval import list_effects, list_event_effects, list_scheduled_effects
+from .graph import EffectMeta, EventEffectMeta
 from .options import EffectsOptions
-from .run import run_effect, run_scheduled_effect
+from .run import run_effect, run_event_effect, run_scheduled_effect
 
 __all__ = [
     "EffectError",
     "EffectMeta",
     "EffectsOptions",
+    "EventEffectMeta",
     "list_effects",
+    "list_event_effects",
     "list_scheduled_effects",
     "run_effect",
+    "run_event_effect",
     "run_scheduled_effect",
 ]

--- a/nixbot_effects/nixbot_effects/eval.py
+++ b/nixbot_effects/nixbot_effects/eval.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .errors import EffectError
-from .graph import EffectMeta, validate_deps
+from .graph import EffectMeta, EventEffectMeta, validate_deps
+from .match import KINDS, validate_when
 from .proc import stream_command
 
 if TYPE_CHECKING:
@@ -144,6 +145,17 @@ async def scheduled_effect_function(opts: EffectsOptions) -> str:
     return await _effects_expr(opts, "hci.onSchedule or {}")
 
 
+def _check_kind(kind: str) -> None:
+    if kind not in KINDS:
+        msg = f"unknown event kind {kind!r}, expected one of {', '.join(KINDS)}"
+        raise EffectError(msg)
+
+
+async def event_effect_function(opts: EffectsOptions, kind: str) -> str:
+    _check_kind(kind)
+    return await _effects_expr(opts, f"hci.onEvent.{kind} or {{}}")
+
+
 async def _nix_eval_json(expr: str, opts: EffectsOptions) -> Any:  # noqa: ANN401
     out = await stream_command(
         nix_command("eval", "--json", "--expr", expr),
@@ -152,6 +164,36 @@ async def _nix_eval_json(expr: str, opts: EffectsOptions) -> Any:  # noqa: ANN40
         debug=opts.debug,
     )
     return json.loads(out)
+
+
+def _walk_expr(root: str) -> str:
+    """Nix expression listing every effect under attrset `root` as
+    `{ "<dotted.path>" = { after, lock, when, checkout }; }`."""
+    return f"""
+        let
+          root = {root};
+          isEffect = v: v ? isEffect || v ? effectScript || v ? run
+            || v ? dependencies || (v.type or null) == "derivation";
+          dep = name: a:
+            if builtins.isList a then builtins.concatStringsSep "." a
+            else throw "effect '${{name}}': 'after' entries must be attribute paths (lists of strings), job first";
+          meta = name: e:
+            let d = e.run or e; in {{
+              after = map (dep name) (d.after or []);
+              lock = d.lock or null;
+              when = d.when or {{}};
+              checkout = (d.__nixbot_effect_checkout or false) == true;
+            }};
+          walk = prefix: v:
+            let name = builtins.concatStringsSep "." prefix; in
+            if !builtins.isAttrs v || v ? _type then []
+            else if isEffect v then [ {{ inherit name; value = meta name v; }} ]
+            else if v.recurseForDerivations or true then builtins.concatLists
+              (map (n: walk (prefix ++ [ n ]) v.${{n}}) (builtins.attrNames v))
+            else [];
+        in builtins.listToAttrs (builtins.concatLists
+          (map (n: walk [ n ] root.${{n}}) (builtins.attrNames root)))
+        """
 
 
 async def list_effects(opts: EffectsOptions) -> dict[str, EffectMeta]:
@@ -164,35 +206,28 @@ async def list_effects(opts: EffectsOptions) -> dict[str, EffectMeta]:
     returned as dotted names. Metadata comes from the effect or its `run`
     wrapper (hercules-ci's runIf).
     """
-    expr = f"""
-        let
-          jobs = {await effect_function(opts)};
-          isEffect = v: v ? isEffect || v ? effectScript || v ? run
-            || v ? dependencies || (v.type or null) == "derivation";
-          dep = name: a:
-            if builtins.isList a then builtins.concatStringsSep "." a
-            else throw "effect '${{name}}': 'after' entries must be attribute paths (lists of strings), job first";
-          meta = name: e:
-            let d = e.run or e; in {{
-              after = map (dep name) (d.after or []);
-              lock = d.lock or null;
-            }};
-          walk = prefix: v:
-            let name = builtins.concatStringsSep "." prefix; in
-            if !builtins.isAttrs v || v ? _type then []
-            else if isEffect v then [ {{ inherit name; value = meta name v; }} ]
-            else if v.recurseForDerivations or true then builtins.concatLists
-              (map (n: walk (prefix ++ [ n ]) v.${{n}}) (builtins.attrNames v))
-            else [];
-        in builtins.listToAttrs (builtins.concatLists
-          (map (job: walk [ job ] jobs.${{job}}) (builtins.attrNames jobs)))
-        """
+    expr = _walk_expr(f"({await effect_function(opts)})")
     effects = {
         name: EffectMeta(after=tuple(info["after"]), lock=info["lock"])
         for name, info in (await _nix_eval_json(expr, opts)).items()
     }
     # A bad DAG (cycle, unknown dependency) fails discovery right here.
     validate_deps(effects)
+    return effects
+
+
+async def list_event_effects(
+    opts: EffectsOptions, kind: str
+) -> dict[str, EventEffectMeta]:
+    """onEvent.<kind> effects with their `when`, lock and checkout flag.
+    Names are dotted attribute paths below the kind."""
+    expr = _walk_expr(f"({await event_effect_function(opts, kind)})")
+    effects = {}
+    for name, info in (await _nix_eval_json(expr, opts)).items():
+        validate_when(name, info["when"])
+        effects[name] = EventEffectMeta(
+            when=info["when"], lock=info["lock"], checkout=info["checkout"]
+        )
     return effects
 
 
@@ -263,6 +298,16 @@ async def instantiate_effects(
 ) -> tuple[str, bool]:
     return await _select_effect(
         f"let e = ({await effect_function(opts)}).{effect}; in", opts, gcroot
+    )
+
+
+async def instantiate_event_effect(
+    kind: str, effect: str, opts: EffectsOptions, gcroot: Path
+) -> tuple[str, bool]:
+    return await _select_effect(
+        f"let e = ({await event_effect_function(opts, kind)}).{effect}; in",
+        opts,
+        gcroot,
     )
 
 

--- a/nixbot_effects/nixbot_effects/graph.py
+++ b/nixbot_effects/nixbot_effects/graph.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 from .errors import EffectError
 
@@ -18,6 +19,17 @@ class EffectMeta:
 
     after: tuple[str, ...] = ()
     lock: str | None = None
+
+
+@dataclass(frozen=True)
+class EventEffectMeta:
+    """What nixbot needs to match and schedule one onEvent effect
+    without evaluating Nix again."""
+
+    when: dict[str, Any] = field(default_factory=dict)
+    # May contain `{pr}`, expanded per delivery.
+    lock: str | None = None
+    checkout: bool = False
 
 
 def validate_deps(meta: dict[str, EffectMeta]) -> None:

--- a/nixbot_effects/nixbot_effects/match.py
+++ b/nixbot_effects/nixbot_effects/match.py
@@ -1,0 +1,195 @@
+"""Matching onEvent effects against a delivery payload.
+
+Pure functions shared by the daemon and `nbo effects`, so `when`
+semantics can be checked locally without a running nixbot.
+"""
+
+from __future__ import annotations
+
+from fnmatch import fnmatchcase
+from typing import Any
+
+from .errors import EffectError
+
+KINDS = ("pull_request", "pull_request_closed", "comment", "build_finished")
+WHEN_KEYS = frozenset(
+    {"permission", "labels", "branches", "commands", "status", "transition"}
+)
+_LEVELS = {None: 0, "none": 0, "read": 1, "write": 2, "admin": 3}
+_TRANSITIONS = {"broke", "fixed"}
+
+Payload = dict[str, Any]
+
+
+def validate_when(name: str, when: dict[str, Any]) -> None:
+    unknown = set(when) - WHEN_KEYS
+    if unknown:
+        msg = f"effect '{name}': unknown `when` keys: {', '.join(sorted(unknown))}"
+        raise EffectError(msg)
+    if (p := when.get("permission")) is not None and p not in (
+        "read",
+        "write",
+        "admin",
+    ):
+        msg = f"effect '{name}': when.permission must be read|write|admin, got {p!r}"
+        raise EffectError(msg)
+    if (t := when.get("transition")) is not None and t not in _TRANSITIONS:
+        msg = f"effect '{name}': when.transition must be broke|fixed, got {t!r}"
+        raise EffectError(msg)
+
+
+def _permission(when: dict[str, Any], payload: Payload) -> str | None:
+    want = when.get("permission")
+    if want is None:
+        return None
+    actor = payload.get("actor") or {}
+    author = (payload.get("pullRequest") or {}).get("author") or {}
+    have = max(
+        _LEVELS.get(actor.get("permission"), 0),
+        _LEVELS.get(author.get("permission"), 0),
+    )
+    if have >= _LEVELS[want]:
+        return None
+    who = ", ".join(
+        f"{role} {s['name']}: {s.get('permission') or 'none'}"
+        for role, s in (("actor", actor), ("author", author))
+        if s.get("name")
+    )
+    return f"needs {want} access ({who or 'no actor'})"
+
+
+def _labels(when: dict[str, Any], payload: Payload) -> str | None:
+    want = when.get("labels")
+    if not want:
+        return None
+    have = set((payload.get("pullRequest") or {}).get("labels") or [])
+    missing = [label for label in want if label not in have]
+    return f"missing labels: {', '.join(missing)}" if missing else None
+
+
+def _branches(when: dict[str, Any], payload: Payload) -> str | None:
+    globs = when.get("branches")
+    if not globs:
+        return None
+    pr = payload.get("pullRequest")
+    branch = pr.get("baseRef") if pr else (payload.get("build") or {}).get("branch")
+    if branch and any(fnmatchcase(branch, g) for g in globs):
+        return None
+    return f"branch {branch!r} matches none of {', '.join(globs)}"
+
+
+def _commands(when: dict[str, Any], payload: Payload) -> str | None:
+    want = when.get("commands")
+    if not want:
+        return None
+    cmd = payload.get("command")
+    return None if cmd in want else f"command /{cmd} not in {', '.join(want)}"
+
+
+def _status(when: dict[str, Any], payload: Payload) -> str | None:
+    want = when.get("status")
+    if not want:
+        return None
+    build = payload.get("build")
+    if not build:
+        return "no build for this commit"
+    status = build.get("status")
+    return None if status in want else f"build is {status}, needs {'|'.join(want)}"
+
+
+def _transition(when: dict[str, Any], payload: Payload) -> str | None:
+    want = when.get("transition")
+    if want is None:
+        return None
+    build = payload.get("build") or {}
+    now, prev = build.get("status"), build.get("previousStatus")
+    ok = (
+        now == "failed" and prev in (None, "succeeded")
+        if want == "broke"
+        else now == "succeeded" and prev == "failed"
+    )
+    return None if ok else f"not a {want} transition ({prev or 'none'} -> {now})"
+
+
+_CHECKS = (_commands, _permission, _labels, _branches, _status, _transition)
+
+
+def skip_reason(when: dict[str, Any], payload: Payload) -> str | None:
+    """Why `when` does not match `payload`, or None if it matches."""
+    for check in _CHECKS:
+        if (reason := check(when, payload)) is not None:
+            return reason
+    return None
+
+
+def event_payload(  # noqa: PLR0913
+    *,
+    pr: int | None = None,
+    branch: str | None = None,
+    actor: str | None = None,
+    permission: str | None = None,
+    author: str | None = None,
+    author_permission: str | None = None,
+    labels: list[str] | None = None,
+    command: str | None = None,
+    args: str = "",
+    status: str = "succeeded",
+    previous_status: str | None = None,
+    head_rev: str | None = None,
+) -> Payload:
+    """A payload like nixbot delivers, from the few fields `when` looks
+    at. For trying effects out locally; the daemon builds its payloads
+    from the forge."""
+    payload: Payload = {"build": {"status": status, "branch": branch or "main"}}
+    if previous_status is not None:
+        payload["build"]["previousStatus"] = previous_status
+    if actor is not None:
+        payload["actor"] = {"name": actor, "permission": permission}
+    if pr is not None:
+        payload["pullRequest"] = {
+            "number": pr,
+            "baseRef": branch or "main",
+            "headRev": head_rev or "0" * 40,
+            "labels": labels or [],
+            "author": {
+                "name": author or actor,
+                "permission": author_permission
+                if author_permission is not None
+                else permission,
+            },
+        }
+    if command is not None:
+        payload["command"] = command
+        payload["args"] = args
+    return payload
+
+
+def expand_lock(lock: str | None, payload: Payload) -> str | None:
+    if lock is None or "{pr}" not in lock:
+        return lock
+    pr = payload.get("pullRequest")
+    if not pr:
+        msg = f"lock {lock!r} uses {{pr}} but the event has no pull request"
+        raise EffectError(msg)
+    return lock.replace("{pr}", str(pr["number"]))
+
+
+def payload_env(kind: str, payload: Payload) -> dict[str, str]:
+    """Flat NIXBOT_* variables for the common fields. Scripts read the
+    rest from $NIXBOT_EVENT_JSON."""
+    # .get throughout: hand-written payloads for local runs may be partial.
+    actor = payload.get("actor") or {}
+    pr = payload.get("pullRequest") or {}
+    build = payload.get("build") or {}
+    env = {
+        "NIXBOT_EVENT_KIND": kind,
+        "NIXBOT_EVENT_JSON": "/run/event.json",
+        "NIXBOT_ACTOR": actor.get("name"),
+        "NIXBOT_PR_NUMBER": pr.get("number"),
+        "NIXBOT_PR_HEAD": pr.get("headRev"),
+        "NIXBOT_COMMAND": payload.get("command"),
+        "NIXBOT_COMMAND_ARGS": payload.get("args"),
+        "NIXBOT_BUILD_STATUS": build.get("status"),
+        "NIXBOT_BUILD_URL": build.get("url"),
+    }
+    return {k: str(v) for k, v in env.items() if v is not None}

--- a/nixbot_effects/nixbot_effects/options.py
+++ b/nixbot_effects/nixbot_effects/options.py
@@ -45,6 +45,9 @@ class EffectsOptions:
     # Runner-prepared pushable clone, mounted at the effect's
     # __nixbot_effect_checkout path.
     effect_checkout: Path | None = None
+    # onEvent delivery: (kind, payload). Exposed as /run/event.json
+    # and NIXBOT_* variables inside the sandbox.
+    event: tuple[str, dict[str, Any]] | None = None
     # Line-wise sink for all child output (nix eval, bwrap, the effect).
     log: LogWrite | None = None
     debug: bool = False

--- a/nixbot_effects/nixbot_effects/run.py
+++ b/nixbot_effects/nixbot_effects/run.py
@@ -16,10 +16,12 @@ from .errors import EffectError
 from .eval import (
     build_derivation,
     instantiate_effects,
+    instantiate_event_effect,
     instantiate_scheduled_effect,
     nix_command,
     parse_derivation,
 )
+from .match import payload_env
 from .proc import stream_command
 from .sandbox import (
     effect_checkout_mount,
@@ -180,6 +182,13 @@ async def _run_in_sandbox(
             secrets_file = work_dir / "secrets.json"
             secrets_file.touch(mode=0o600)
             secrets_file.write_text(json.dumps(secrets))
+            event_args: list[str] = []
+            if opts.event is not None:
+                kind, payload = opts.event
+                event_file = work_dir / "event.json"
+                event_file.write_text(json.dumps(payload))
+                event_args = ["--ro-bind", str(event_file), "/run/event.json"]
+                env.update(payload_env(kind, payload))
             cmd = [
                 *_bubblewrap_command(
                     drv_path,
@@ -197,6 +206,7 @@ async def _run_in_sandbox(
                 "--ro-bind",
                 str(secrets_file),
                 "/run/secrets.json",
+                *event_args,
                 *env_args(env, clear_env),
                 "--",
                 drv["builder"],
@@ -239,6 +249,19 @@ async def run_effect(opts: EffectsOptions, effect: str) -> None:
         gcroot = Path(tmpdir) / "result"
         drv_path, should_run = await instantiate_effects(effect, opts, gcroot)
         await _run_selected(opts, effect, drv_path, should_run=should_run)
+
+
+async def run_event_effect(
+    opts: EffectsOptions, kind: str, effect: str, payload: dict[str, Any]
+) -> None:
+    """Run one onEvent.<kind> effect with `payload` as its event."""
+    opts.event = (kind, payload)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gcroot = Path(tmpdir) / "result"
+        drv_path, should_run = await instantiate_event_effect(
+            kind, effect, opts, gcroot
+        )
+        await _run_selected(opts, f"{kind}/{effect}", drv_path, should_run=should_run)
 
 
 async def run_scheduled_effect(

--- a/nixbot_effects/nixbot_effects/tests/test_on_event.py
+++ b/nixbot_effects/nixbot_effects/tests/test_on_event.py
@@ -1,0 +1,178 @@
+"""onEvent effects: listing from the flake and matching `when` against
+delivery payloads without Nix."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nixbot_effects import EffectError, EventEffectMeta
+from nixbot_effects.eval import instantiate_event_effect, list_event_effects
+from nixbot_effects.match import event_payload, expand_lock, payload_env, skip_reason
+from nixbot_effects.options import EffectsOptions
+from nixbot_effects.tests.support import init_repo
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+FLAKE_NIX = """\
+{
+  outputs = { self, ... }:
+    let
+      # mkDerivation merges passthru into the result set. Emulate that.
+      effect = attrs: derivation {
+        name = "effect";
+        system = builtins.currentSystem;
+        builder = "/bin/sh";
+        args = [ "-c" "echo > $out" ];
+        isEffect = true;
+      } // attrs;
+    in {
+      herculesCI = { primaryRepo, ... }: {
+        onEvent.pull_request = {
+          plan = effect {
+            when = { permission = "write"; };
+            lock = "infra-{pr}";
+            __nixbot_effect_checkout = true;
+          };
+          env.notify = effect { };
+        };
+        onEvent.comment.bad = effect { when.typo = 1; };
+      };
+    };
+}
+"""
+
+
+async def test_list_event_effects(tmp_path: Path) -> None:
+    repo, _ = init_repo(tmp_path, {"flake.nix": FLAKE_NIX})
+    opts = EffectsOptions(path=repo)
+    assert await list_event_effects(opts, "pull_request") == {
+        "plan": EventEffectMeta(
+            when={"permission": "write"}, lock="infra-{pr}", checkout=True
+        ),
+        "env.notify": EventEffectMeta(),
+    }
+    assert await list_event_effects(opts, "build_finished") == {}
+    with pytest.raises(EffectError, match="unknown `when` keys: typo"):
+        await list_event_effects(opts, "comment")
+    with pytest.raises(EffectError, match="unknown event kind"):
+        await list_event_effects(opts, "push")
+    drv, should_run = await instantiate_event_effect(
+        "pull_request", "env.notify", opts, tmp_path / "gcroot"
+    )
+    assert drv.endswith("-effect.drv")
+    assert should_run
+
+
+PR = {
+    "number": 7,
+    "headRev": "abc",
+    "baseRef": "main",
+    "labels": ["preview"],
+    "author": {"name": "github:dave", "permission": "read"},
+}
+BUILD = {"status": "succeeded", "url": "https://ci/b/1", "branch": "main"}
+
+
+def test_permission_actor_or_author() -> None:
+    when = {"permission": "write"}
+    assert skip_reason(when, {"pullRequest": PR}) == (
+        "needs write access (author github:dave: read)"
+    )
+    assert skip_reason(when, {}) == "needs write access (no actor)"
+    actor = {"name": "github:alice", "permission": "admin"}
+    assert skip_reason(when, {"pullRequest": PR, "actor": actor}) is None
+    author_ok = {**PR, "author": {"name": "github:dave", "permission": "write"}}
+    assert skip_reason(when, {"pullRequest": author_ok, "actor": None}) is None
+
+
+def test_labels_branches_commands_status() -> None:
+    payload = {"pullRequest": PR, "build": BUILD, "command": "plan"}
+    assert skip_reason({"labels": ["preview"]}, payload) is None
+    assert skip_reason({"labels": ["preview", "x"]}, payload) == "missing labels: x"
+    assert skip_reason({"branches": ["release-*"]}, payload) == (
+        "branch 'main' matches none of release-*"
+    )
+    assert skip_reason({"branches": ["ma*"]}, payload) is None
+    # Without a PR the build branch counts.
+    assert skip_reason({"branches": ["main"]}, {"build": BUILD}) is None
+    assert skip_reason({"commands": ["apply"]}, payload) == (
+        "command /plan not in apply"
+    )
+    assert skip_reason({"status": ["succeeded"]}, payload) is None
+    assert skip_reason({"status": ["succeeded"]}, {"pullRequest": PR}) == (
+        "no build for this commit"
+    )
+
+
+def test_transition() -> None:
+    def build(now: str, prev: str | None) -> dict:
+        return {"build": {**BUILD, "status": now, "previousStatus": prev}}
+
+    assert skip_reason({"transition": "broke"}, build("failed", "succeeded")) is None
+    assert skip_reason({"transition": "broke"}, build("failed", None)) is None
+    assert skip_reason({"transition": "broke"}, build("failed", "failed")) == (
+        "not a broke transition (failed -> failed)"
+    )
+    assert skip_reason({"transition": "fixed"}, build("succeeded", "failed")) is None
+    assert skip_reason({"transition": "fixed"}, build("succeeded", None)) == (
+        "not a fixed transition (none -> succeeded)"
+    )
+
+
+def test_event_payload_from_fields() -> None:
+    """The CLI describes an event with flags instead of a JSON file."""
+    payload = event_payload(
+        pr=7,
+        actor="github:alice",
+        permission="write",
+        labels=["preview"],
+    )
+    assert skip_reason({"permission": "write", "labels": ["preview"]}, payload) is None
+    assert skip_reason({"permission": "admin"}, payload) == (
+        "needs admin access (actor github:alice: write, author github:alice: write)"
+    )
+    # A comment is vouched for by the commenter alone.
+    comment = event_payload(actor="github:bob", command="apply", args="now")
+    assert skip_reason({"commands": ["apply"]}, comment) is None
+    assert skip_reason({"permission": "write"}, comment) == (
+        "needs write access (actor github:bob: none)"
+    )
+    assert payload_env("comment", comment)["NIXBOT_COMMAND_ARGS"] == "now"
+
+
+def test_expand_lock_and_env() -> None:
+    assert expand_lock("infra-{pr}", {"pullRequest": PR}) == "infra-7"
+    assert expand_lock("infra", {}) == "infra"
+    assert expand_lock(None, {}) is None
+    with pytest.raises(EffectError, match="no pull request"):
+        expand_lock("x-{pr}", {"build": BUILD})
+    env = payload_env(
+        "comment",
+        {
+            "actor": {"name": "github:alice", "permission": "write"},
+            "pullRequest": PR,
+            "build": BUILD,
+            "command": "plan",
+            "args": "-target=foo",
+        },
+    )
+    assert env == {
+        "NIXBOT_EVENT_KIND": "comment",
+        "NIXBOT_EVENT_JSON": "/run/event.json",
+        "NIXBOT_ACTOR": "github:alice",
+        "NIXBOT_PR_NUMBER": "7",
+        "NIXBOT_PR_HEAD": "abc",
+        "NIXBOT_COMMAND": "plan",
+        "NIXBOT_COMMAND_ARGS": "-target=foo",
+        "NIXBOT_BUILD_STATUS": "succeeded",
+        "NIXBOT_BUILD_URL": "https://ci/b/1",
+    }
+    # Partial hand-written payloads (local runs) must not crash.
+    assert payload_env("comment", {"pullRequest": {"number": 1}}) == {
+        "NIXBOT_EVENT_KIND": "comment",
+        "NIXBOT_EVENT_JSON": "/run/event.json",
+        "NIXBOT_PR_NUMBER": "1",
+    }


### PR DESCRIPTION
Adds the library side of onEvent effects: listing `herculesCI.onEvent.<kind>`,
matching an effect's `when` attrset against an event payload, and running one
effect with that payload. Matching happens in Python, so per-event data never
enters Nix evaluation.

`nbo effects list --event` and `nbo effects run --event` exercise the same code
locally against a hand-written payload. Nothing in the daemon uses this yet.

Part of #165.
