### PR TITLE
Run post-build steps from one place

### DIFF
--- a/nixbot/nixbot/after_build.py
+++ b/nixbot/nixbot/after_build.py
@@ -1,0 +1,79 @@
+"""Everything that follows a settled build: effects and their checks,
+schedule refresh, onEvent deliveries. Fresh builds, reruns and reused
+builds all go through here. A failing step is logged and the others
+still run."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from .db import BuildStatus
+from .db_gen import builds as q
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+    from pathlib import Path
+
+    from .db import BuildRecord
+    from .events import ChangeEvent
+    from .gitrepo import FetchCredentials
+    from .orchestrator import Orchestrator
+
+logger = logging.getLogger(__name__)
+
+
+async def after_build(  # noqa: PLR0913
+    o: Orchestrator,
+    event: ChangeEvent,
+    build: BuildRecord,
+    status: str,
+    *,
+    worktree_path: Path,
+    credentials: FetchCredentials | None,
+    reused: bool = False,
+) -> None:
+    if status == BuildStatus.SUCCEEDED:
+        await _step(
+            "effects",
+            build,
+            _effects(o, event, build, worktree_path, credentials, reused),
+        )
+        await _step("schedules", build, o.refresh_schedules(event))
+    await _step("deliveries", build, _deliveries(o, event, build, reused))
+
+
+async def _step(name: str, build: BuildRecord, step: Awaitable[None]) -> None:
+    try:
+        await step
+    except Exception:
+        logger.exception(
+            "post-build step failed", extra={"build_id": build.id_, "step": name}
+        )
+
+
+async def _effects(  # noqa: PLR0913
+    o: Orchestrator,
+    event: ChangeEvent,
+    build: BuildRecord,
+    worktree_path: Path,
+    credentials: FetchCredentials | None,
+    reused: bool,
+) -> None:
+    if reused and build.effects_started:
+        # Effects already ran for this tree; only copy their statuses
+        # onto the commit that reused the build.
+        from .build_reuse import replay_effect_statuses  # noqa: PLC0415
+
+        await replay_effect_statuses(o, event, build)
+        return
+    await o.maybe_run_effects(event, build, worktree_path, credentials)
+
+
+async def _deliveries(
+    o: Orchestrator, event: ChangeEvent, build: BuildRecord, reused: bool
+) -> None:
+    refreshed = await q.get_build(o.pool, id_=build.id_)
+    if refreshed is not None:
+        # A reused build had its build_finished delivered when it finished.
+        await o.deliver_events(event, refreshed, finished=not reused)

--- a/nixbot/nixbot/build_reuse.py
+++ b/nixbot/nixbot/build_reuse.py
@@ -14,6 +14,7 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
+from .after_build import after_build
 from .canceller import RegisterOutcome
 from .db import BuildStatus
 from .db_gen import builds as builds_q
@@ -157,25 +158,21 @@ async def reuse_terminal_build(  # noqa: PLR0913
         return
     o.canceller.complete(build.id_)
     if build.status == BuildStatus.SUCCEEDED:
-        # Guarded like in-build post-processing: a gcroots/outputs
-        # failure must not strand this context without a status.
         try:
             await _post_process_existing(o, event, build)
-            if build.effects_started:
-                # Effects already ran and will not re-run. Replay their
-                # statuses so the reusing commit is not left blank.
-                await replay_effect_statuses(o, event, build)
-            else:
-                # A build that never started effects (e.g. a PR build)
-                # must still deploy when a default-branch push reuses it.
-                await o.maybe_run_effects(event, build, worktree_path, credentials)
-            await o.refresh_schedules(event)
-            await o.deliver_events(event, build, finished=False)
         except Exception:
             logger.exception(
-                "post-processing reused build failed",
-                extra={"build_id": build.id_},
+                "gcroots/outputs for reused build failed", extra={"build_id": build.id_}
             )
+    await after_build(
+        o,
+        event,
+        build,
+        build.status,
+        worktree_path=worktree_path,
+        credentials=credentials,
+        reused=True,
+    )
     await replay_terminal_status(o, event, build)
 
 

--- a/nixbot/nixbot/build_run.py
+++ b/nixbot/nixbot/build_run.py
@@ -17,6 +17,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from . import db
+from .after_build import after_build
 from .build_scheduler import (
     AttributeResult,
     AttributeStatus,
@@ -394,7 +395,9 @@ async def _run_build_inner(
     )
     # Builds start as soon as the first eval batch arrives.
     build_task = asyncio.create_task(
-        build_attributes(o, event, build, worktree_path, jobs_queue)
+        build_attributes(
+            o, event, build, worktree_path, jobs_queue, credentials=credentials
+        )
     )
     cancel_wait = asyncio.ensure_future(cancel_event.wait())
     try:
@@ -426,16 +429,13 @@ async def _run_build_inner(
         # missed (e.g. eval runners without on_jobs support).
         await jobs_queue.put(list(eval_result.jobs))
         await jobs_queue.put(None)
-        status = await build_task
+        await build_task
     except BaseException:
         # Reap both tasks or the build task leaks forever blocked
         # on the jobs queue and the evaluator process outlives the
         # build (nix_eval kills the evaluator on cancellation).
         await _reap(eval_task, build_task)
         raise
-
-    if status == BuildStatus.SUCCEEDED:
-        await o.maybe_run_effects(event, build, worktree_path, credentials)
 
 
 async def _reusable_eval_jobs(
@@ -485,11 +485,15 @@ async def _try_reuse_eval(
     await db.set_build_status(o.pool, build.id_, BuildStatus.BUILDING)
     await o.reporter.eval_finished(event, build, EvalReport(success=True, jobs=reused))
     # cache_failures=False: see _ReadOnlyFailedBuildCache.
-    status = await build_attributes(
-        o, event, build, worktree_path, reused, cache_failures=False
+    await build_attributes(
+        o,
+        event,
+        build,
+        worktree_path,
+        reused,
+        credentials=credentials,
+        cache_failures=False,
     )
-    if status == BuildStatus.SUCCEEDED:
-        await o.maybe_run_effects(event, build, worktree_path, credentials)
     return True
 
 
@@ -500,6 +504,7 @@ async def build_attributes(  # noqa: PLR0913
     worktree_path: Path,
     jobs: Sequence[NixEvalJob] | asyncio.Queue[list[NixEvalJob] | None],
     *,
+    credentials: FetchCredentials | None,
     cache_failures: bool = True,
 ) -> str:
     """Schedule the attribute builds, persist their results, and
@@ -576,12 +581,9 @@ async def build_attributes(  # noqa: PLR0913
         eval_success=True,
     )
     o.release_run(build.id_)
-
-    if status == BuildStatus.SUCCEEDED:
-        await o.refresh_schedules(event)
-    refreshed = await q.get_build(o.pool, id_=build.id_)
-    if refreshed is not None:
-        await o.deliver_events(event, refreshed)
+    await after_build(
+        o, event, build, status, worktree_path=worktree_path, credentials=credentials
+    )
     return status
 
 

--- a/nixbot/nixbot/rerun_exec.py
+++ b/nixbot/nixbot/rerun_exec.py
@@ -112,20 +112,17 @@ async def rerun_pending_attributes(
             # the previous run may have left it red or pending.
             await o.reporter.eval_finished(event, build, EvalReport(success=True))
             # cache_failures=False: see _ReadOnlyFailedBuildCache.
-            status = await build_run.build_attributes(
+            # effects_started keeps a recovered, already-deployed
+            # build from re-deploying.
+            await build_run.build_attributes(
                 o,
                 event,
                 build,
                 worktree_path,
                 pending_jobs,
+                credentials=credentials,
                 cache_failures=False,
             )
-            if status == BuildStatus.SUCCEEDED:
-                # Crash recovery before effects started. The
-                # started-flag keeps already-deployed builds from
-                # re-deploying.
-                await o.maybe_run_effects(event, build, worktree_path, credentials)
-                await o.refresh_schedules(event)
     finally:
         o.canceller.complete(build.id_)
         o.release_run(build.id_)


### PR DESCRIPTION
Fresh builds, reruns and reused builds each had their own idea of what happens
once a build settles. They now share one pipeline that runs effects, refreshes
schedules and queues event deliveries, with every step isolated so a failing one
does not skip the rest.
