### PR TITLE
Retry work items that fail on a flaky forge

### DIFF
--- a/docs/EFFECTS.md
+++ b/docs/EFFECTS.md
@@ -277,7 +277,9 @@ effects.
 
 Comments by bots (GitHub apps, nixbot's own account on Gitea/GitLab) are
 ignored. A `/command` for an effect that is still running from an earlier
-comment is answered with a note instead of being queued twice.
+comment is answered with a note instead of being queued twice. Deliveries are
+queued in the database and retried with backoff while the forge API is
+unavailable; webhooks sent while nixbot itself is down are not replayed.
 
 The event is passed to the script as JSON in `$NIXBOT_EVENT_JSON`
 (`/run/event.json`) and, for the common fields, as environment variables:

--- a/nixbot/nixbot/config.py
+++ b/nixbot/nixbot/config.py
@@ -383,6 +383,8 @@ class Config(BaseModel):
     session_lifetime: int = 30 * 24 * 60 * 60
     # TTL for the per-user accessible-repo-set cache in seconds.
     repo_acl_cache_ttl: int = 60 * 60
+    # First retry delay for work that failed on a flaky forge, doubled per attempt.
+    work_retry_backoff: float = 30
 
     http_port: int = 8010
     http_unix_socket: Path | None = None

--- a/nixbot/nixbot/db_gen/work_queue.py
+++ b/nixbot/nixbot/db_gen/work_queue.py
@@ -12,6 +12,7 @@ __all__: collections.abc.Sequence[str] = (
     "enqueue_effect_items",
     "enqueue_work_item",
     "finish_work_item",
+    "retry_work_item",
     "settle_interrupted_work",
 )
 
@@ -31,12 +32,15 @@ class ClaimNextWorkItemRow:
     kind: str
     dedup_key: str
     payload: str
+    attempts: int
 
 
 ENQUEUE_WORK_ITEM: typing.Final[str] = """-- name: EnqueueWorkItem :one
 
-INSERT INTO work_queue (kind, dedup_key, payload)
-VALUES ($1, $2, $3::jsonb)
+INSERT INTO work_queue (kind, dedup_key, payload, not_before)
+VALUES ($1, $2, $3::jsonb,
+        CASE WHEN $4::double precision > 0
+             THEN now() + make_interval(secs => $4::double precision) END)
 ON CONFLICT (kind, dedup_key, md5(payload::text))
 WHERE status = 'pending'
 DO NOTHING
@@ -61,6 +65,7 @@ UPDATE work_queue SET status = 'running', claimed_at = now()
 WHERE id = (
     SELECT id FROM work_queue w
     WHERE w.status = 'pending'
+      AND (w.not_before IS NULL OR w.not_before <= now())
       AND NOT EXISTS (
         SELECT 1 FROM work_queue r
         WHERE r.dedup_key = w.dedup_key
@@ -81,13 +86,25 @@ WHERE id = (
     FOR UPDATE SKIP LOCKED
     LIMIT 1
 )
-RETURNING id, kind, dedup_key, payload
+RETURNING id, kind, dedup_key, payload, attempts
 """
 
 FINISH_WORK_ITEM: typing.Final[str] = """-- name: FinishWorkItem :exec
 UPDATE work_queue
 SET status = $2, error = $3, finished_at = now()
 WHERE id = $1
+"""
+
+RETRY_WORK_ITEM: typing.Final[str] = """-- name: RetryWorkItem :execrows
+UPDATE work_queue w SET status = 'pending', claimed_at = NULL,
+    attempts = w.attempts + 1, error = $1::text,
+    not_before = now() + make_interval(secs => $2::double precision)
+WHERE w.id = $3::bigint AND NOT EXISTS (
+    SELECT 1 FROM work_queue p
+    WHERE p.kind = w.kind AND p.dedup_key = w.dedup_key
+      AND md5(p.payload::text) = md5(w.payload::text)
+      AND p.status = 'pending' AND p.id <> w.id
+)
 """
 
 SETTLE_INTERRUPTED_WORK: typing.Final[str] = """-- name: SettleInterruptedWork :exec
@@ -115,8 +132,8 @@ WHERE finished_at IS NOT NULL
 """
 
 
-async def enqueue_work_item(conn: ConnectionLike, *, kind: str, dedup_key: str, payload: str) -> int | None:
-    row = await conn.fetchrow(ENQUEUE_WORK_ITEM, kind, dedup_key, payload)
+async def enqueue_work_item(conn: ConnectionLike, *, kind: str, dedup_key: str, payload: str, delay: float) -> int | None:
+    row = await conn.fetchrow(ENQUEUE_WORK_ITEM, kind, dedup_key, payload, delay)
     if row is None:
         return None
     return row[0]
@@ -130,11 +147,16 @@ async def claim_next_work_item(conn: ConnectionLike) -> ClaimNextWorkItemRow | N
     row = await conn.fetchrow(CLAIM_NEXT_WORK_ITEM)
     if row is None:
         return None
-    return ClaimNextWorkItemRow(id_=row[0], kind=row[1], dedup_key=row[2], payload=row[3])
+    return ClaimNextWorkItemRow(id_=row[0], kind=row[1], dedup_key=row[2], payload=row[3], attempts=row[4])
 
 
 async def finish_work_item(conn: ConnectionLike, *, id_: int, status: str, error: str | None) -> None:
     await conn.execute(FINISH_WORK_ITEM, id_, status, error)
+
+
+async def retry_work_item(conn: ConnectionLike, *, error: str, delay: float, id_: int) -> int:
+    r = await conn.execute(RETRY_WORK_ITEM, error, delay, id_)
+    return int(n) if (p := r.split()) and (n := p[-1]).isdigit() else 0
 
 
 async def settle_interrupted_work(conn: ConnectionLike) -> None:

--- a/nixbot/nixbot/deliver.py
+++ b/nixbot/nixbot/deliver.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any
 
 from nixbot_effects import EffectError, EventEffectMeta
@@ -22,7 +22,9 @@ from .db_gen import events as ev_q
 from .db_gen import work_queue as wq
 from .effects import effects_context
 from .forge import ForgeError
+from .gitrepo import GitError
 from .repos import repo_info
+from .work_queue import TransientError
 
 if TYPE_CHECKING:
     from .db import BuildRecord
@@ -36,8 +38,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class Delivery:
-    """What the hook site knows. PR metadata and permissions are
-    filled in by `deliver`."""
+    """An event to deliver, as stored in the work queue. Only what the
+    webhook or build knew; PR metadata and permissions are looked up
+    when it is delivered."""
 
     kind: str
     build_id: int
@@ -49,11 +52,7 @@ class Delivery:
     failed_attrs: list[str] | None = None
 
     def as_payload(self) -> dict[str, Any]:
-        return {k: v for k, v in self.__dict__.items() if v is not None}
-
-    @classmethod
-    def from_payload(cls, p: dict[str, Any]) -> Delivery:
-        return cls(**p)
+        return {k: v for k, v in asdict(self).items() if v is not None}
 
 
 @dataclass
@@ -64,15 +63,14 @@ class EventListing:
 
 
 class EventListingCache:
-    """`onEvent` of a project's default branch, per rev. All kinds come
-    from one evaluation, so a project without onEvent costs one nix
-    eval per default-branch push and nothing per delivery after. A
-    failed evaluation is cached too."""
+    """The default branch's `onEvent` effects per project, evaluated once
+    per default-branch rev. Deliveries in between reuse the result, so a
+    project without onEvent pays one nix eval per push to the default
+    branch. Evaluation errors are cached the same way."""
 
     def __init__(self) -> None:
         self._cache: dict[int, EventListing] = {}
-        # Concurrent deliveries of one project share one evaluation
-        # (and one worktree path).
+        # One evaluation (and worktree) per project at a time.
         self._locks: dict[int, asyncio.Lock] = {}
 
     async def get(
@@ -142,13 +140,13 @@ def build_payload(base_url: str, info: RepoInfo, build: BuildRecord) -> dict[str
 def event_dedup_key(
     project_id: int, build_id: int, kind: str, name: str, lock: str | None
 ) -> str:
-    # Same lock key scheme as onPush effects so both serialise together.
+    # onPush effects use the same lock key, so a lock is shared across both.
     if lock is not None:
         return f"effect-lock-{project_id}-{lock}"
     return f"build-{build_id}-{kind}-{name}"
 
 
-async def deliver(s: CIService, d: Delivery) -> None:
+async def deliver(s: CIService, d: Delivery, *, last_attempt: bool = False) -> None:
     build = await builds_q.get_build(s.pool, id_=d.build_id)
     if build is None:
         return
@@ -158,12 +156,15 @@ async def deliver(s: CIService, d: Delivery) -> None:
     info = repo_info(project)
     credentials = await s.credentials_provider(info.forge).get(info.clone_url)
     repos = s.orchestrator.repos
-    await repos.fetch(
-        info.key,
-        info.clone_url,
-        [f"+refs/heads/{info.default_branch}:refs/heads/{info.default_branch}"],
-        credentials,
-    )
+    try:
+        await repos.fetch(
+            info.key,
+            info.clone_url,
+            [f"+refs/heads/{info.default_branch}:refs/heads/{info.default_branch}"],
+            credentials,
+        )
+    except GitError as e:
+        raise TransientError(str(e)) from e
     code_rev = await repos.rev_parse(info.key, f"refs/heads/{info.default_branch}")
     cached = await s.event_listings.get(s, info, code_rev, credentials)
     listing = cached.effects.get(d.kind, {})
@@ -182,9 +183,14 @@ async def deliver(s: CIService, d: Delivery) -> None:
     if not listing:
         return
     try:
+        if d.command is not None and d.actor and await s.forge_pr.is_self(d.actor):
+            return
         payload = await _payload(s, project, info, build, d)
     except ForgeError as e:
-        # Never degrade to "no permission": record why nothing ran.
+        if e.transient and not last_attempt:
+            raise TransientError(str(e)) from e
+        # Record why nothing ran rather than matching with missing data,
+        # which would look like "no permission".
         logger.warning(
             "delivery failed", extra={"build_id": build.id_, "error": str(e)}
         )
@@ -225,8 +231,8 @@ async def _match_and_enqueue(  # noqa: PLR0913
 ) -> None:
     names: list[str] = []
     keys: list[str] = []
-    # Rows running right now cannot take a second run. Tell the
-    # commenter instead of dropping the command silently.
+    # Effects still running from an earlier event. A /command for one
+    # of them gets a reply instead of silently doing nothing.
     busy: list[str] = []
     payload_json = json.dumps(payload)
     for name, meta in listing.items():

--- a/nixbot/nixbot/forge/base.py
+++ b/nixbot/nixbot/forge/base.py
@@ -30,6 +30,12 @@ class ForgeError(Exception):
         super().__init__(message)
         self.status_code = status_code
 
+    @property
+    def transient(self) -> bool:
+        """Worth retrying later: network errors, 5xx, rate limits."""
+        c = self.status_code
+        return c is None or c >= 500 or c == 429  # noqa: PLR2004
+
 
 def check_response(response: httpx.Response, forge_name: str) -> None:
     """Raise ForgeError for HTTP error responses."""

--- a/nixbot/nixbot/migrations/0030_work_retry.sql
+++ b/nixbot/nixbot/migrations/0030_work_retry.sql
@@ -1,0 +1,5 @@
+-- Transient failures (forge 5xx, rate limits) put the item back to
+-- pending with a delay instead of failing it.
+ALTER TABLE work_queue
+    ADD COLUMN attempts INT NOT NULL DEFAULT 0,
+    ADD COLUMN not_before TIMESTAMPTZ;

--- a/nixbot/nixbot/queries/work_queue.sql
+++ b/nixbot/nixbot/queries/work_queue.sql
@@ -1,8 +1,10 @@
 -- Work queue (work_queue.py).
 
 -- name: EnqueueWorkItem :one
-INSERT INTO work_queue (kind, dedup_key, payload)
-VALUES ($1, $2, sqlc.arg(payload)::jsonb)
+INSERT INTO work_queue (kind, dedup_key, payload, not_before)
+VALUES ($1, $2, sqlc.arg(payload)::jsonb,
+        CASE WHEN sqlc.arg(delay)::double precision > 0
+             THEN now() + make_interval(secs => sqlc.arg(delay)::double precision) END)
 ON CONFLICT (kind, dedup_key, md5(payload::text))
 WHERE status = 'pending'
 DO NOTHING
@@ -34,6 +36,7 @@ UPDATE work_queue SET status = 'running', claimed_at = now()
 WHERE id = (
     SELECT id FROM work_queue w
     WHERE w.status = 'pending'
+      AND (w.not_before IS NULL OR w.not_before <= now())
       AND NOT EXISTS (
         SELECT 1 FROM work_queue r
         WHERE r.dedup_key = w.dedup_key
@@ -54,12 +57,25 @@ WHERE id = (
     FOR UPDATE SKIP LOCKED
     LIMIT 1
 )
-RETURNING id, kind, dedup_key, payload;
+RETURNING id, kind, dedup_key, payload, attempts;
 
 -- name: FinishWorkItem :exec
 UPDATE work_queue
 SET status = $2, error = sqlc.narg(error), finished_at = now()
 WHERE id = $1;
+
+-- name: RetryWorkItem :execrows
+-- Back to pending after a transient failure, keeping its place in the
+-- per-key FIFO. No row when an identical pending item exists already.
+UPDATE work_queue w SET status = 'pending', claimed_at = NULL,
+    attempts = w.attempts + 1, error = sqlc.arg(error)::text,
+    not_before = now() + make_interval(secs => sqlc.arg(delay)::double precision)
+WHERE w.id = sqlc.arg(id)::bigint AND NOT EXISTS (
+    SELECT 1 FROM work_queue p
+    WHERE p.kind = w.kind AND p.dedup_key = w.dedup_key
+      AND md5(p.payload::text) = md5(w.payload::text)
+      AND p.status = 'pending' AND p.id <> w.id
+);
 
 -- name: SettleInterruptedWork :exec
 -- Startup sweep over rows the previous process died holding: requeue

--- a/nixbot/nixbot/service.py
+++ b/nixbot/nixbot/service.py
@@ -33,7 +33,6 @@ from .events import (
     effects_event_for_build,
     event_for_build,
 )
-from .forge import ForgeError
 from .forge_pr import ForgePrClient
 from .gitrepo import (
     CredentialsProvider,
@@ -59,7 +58,13 @@ from .webhooks import (
     is_merge_queue_branch,
     should_build_branch,
 )
-from .work_queue import WorkItem, WorkQueue
+from .work_queue import (
+    MAX_WORK_ATTEMPTS,
+    TransientError,
+    WorkItem,
+    WorkQueue,
+    work_retry_delay,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine, Sequence
@@ -98,27 +103,6 @@ class PullBasedCredentialsProvider:
             ssh_private_key_file=repo.ssh_private_key_file,
             ssh_known_hosts_file=repo.ssh_known_hosts_file,
         )
-
-
-MAX_REPORT_ATTEMPTS = 5
-REPORT_BACKOFF_SECONDS = 30
-MAX_REPORT_DELAY_SECONDS = 3600
-
-
-def _report_payload(build_id: int, attempt: int, error: Exception) -> dict[str, Any]:
-    payload: dict[str, Any] = {"build_id": build_id, "attempt": attempt}
-    # Forges send Retry-After on rate limits. Honoring it is required
-    # (e.g. GitHub secondary limits escalate when ignored).
-    retry_after = getattr(error, "retry_after", None)
-    if retry_after is not None:
-        payload["retry_at"] = time.time() + min(retry_after, MAX_REPORT_DELAY_SECONDS)
-    return payload
-
-
-def _report_delay(attempt: int, retry_at: float | None) -> float:
-    backoff = min(REPORT_BACKOFF_SECONDS * (attempt - 1), 300)
-    hinted = max(0.0, retry_at - time.time()) if retry_at is not None else 0.0
-    return min(max(backoff, hinted), MAX_REPORT_DELAY_SECONDS)
 
 
 @dataclass
@@ -190,7 +174,14 @@ class RetryingReporter:
                 "status post failed; queueing a retry", extra={"build_id": build.id_}
             )
             await self.service.enqueue_work(
-                "report", f"report-{build.id_}", _report_payload(build.id_, 1, e)
+                "report",
+                f"report-{build.id_}",
+                {"build_id": build.id_},
+                delay=work_retry_delay(
+                    1,
+                    getattr(e, "retry_after", None),
+                    self.service.config.work_retry_backoff,
+                ),
             )
 
 
@@ -255,47 +246,21 @@ class CIService:
     async def submit(self, event: WebhookEvent) -> None:
         if isinstance(event, PrClosed):
             await self._submit_pr_closed(event)
-            return
-        if isinstance(event, PrComment):
-            try:
-                if await self.forge_pr.is_self(event.actor):
-                    return
-            except ForgeError:
-                logger.warning("bot user lookup failed", exc_info=True)
+        elif isinstance(event, PrComment):
             await self._deliver_for_pr(
-                event.forge,
-                event.forge_repo_id,
-                Delivery(
-                    kind="comment",
-                    build_id=0,
-                    actor=event.actor,
-                    pr_number=event.pr_number,
-                    command=event.command,
-                    args=event.args,
-                ),
+                event, "comment", command=event.command, args=event.args
             )
-            return
-        if isinstance(event, PrLabeled):
-            await self._deliver_for_pr(
-                event.forge,
-                event.forge_repo_id,
-                Delivery(
-                    kind="pull_request",
-                    build_id=0,
-                    actor=event.actor,
-                    pr_number=event.pr_number,
-                ),
-            )
-            return
-        if isinstance(event, CheckRerequested):
+        elif isinstance(event, PrLabeled):
+            await self._deliver_for_pr(event, "pull_request")
+        elif isinstance(event, CheckRerequested):
             await self._submit_rerequest(event)
-            return
-        await self._submit_change(event)
+        else:
+            await self._submit_change(event)
 
     async def _submit_pr_closed(self, event: PrClosed) -> None:
         if not event.merged:
-            # No cancel on merge: the merge push reuses the PR build
-            # (same post-merge tree hash).
+            # A merged PR is not cancelled: the merge commit has the same
+            # tree, so its push reuses the PR build.
             project = await self.repo_store.by_forge_id(
                 event.forge, event.forge_repo_id
             )
@@ -308,37 +273,40 @@ class CIService:
                 forge_repo_id=event.forge_repo_id,
                 pr_number=event.pr_number,
             )
-        await self._deliver_for_pr(
-            event.forge,
-            event.forge_repo_id,
-            Delivery(
-                kind="pull_request_closed",
-                build_id=0,
-                actor=event.actor,
-                pr_number=event.pr_number,
-            ),
-        )
+        await self._deliver_for_pr(event, "pull_request_closed")
 
     async def _deliver_for_pr(
-        self, forge: str, forge_repo_id: str, d: Delivery
+        self,
+        event: PrClosed | PrComment | PrLabeled,
+        kind: str,
+        *,
+        command: str | None = None,
+        args: str | None = None,
     ) -> None:
-        """Attach a PR-scoped delivery to the PR's latest build. PRs nixbot
+        """Queue a PR event against the PR's latest build. PRs nixbot
         never built (filtered, disabled) get no event effects."""
-        project = await self.repo_store.by_forge_id(forge, forge_repo_id)
-        if project is None or not project.enabled or d.pr_number is None:
+        project = await self.repo_store.by_forge_id(event.forge, event.forge_repo_id)
+        if project is None or not project.enabled:
             return
         build = await ev_q.latest_build_for_pr(
-            self.pool, project_id=project.id_, pr_number=d.pr_number
+            self.pool, project_id=project.id_, pr_number=event.pr_number
         )
         if build is None:
             return
         # pull_request means "this PR head built green" (docs/EFFECTS.md).
-        if d.kind == "pull_request" and build.status != BuildStatus.SUCCEEDED:
+        if kind == "pull_request" and build.status != BuildStatus.SUCCEEDED:
             return
-        d = dataclasses.replace(d, build_id=build.id_)
-        # Per PR: deliveries for one PR are matched in order.
+        d = Delivery(
+            kind=kind,
+            build_id=build.id_,
+            actor=event.actor,
+            pr_number=event.pr_number,
+            command=command,
+            args=args,
+        )
+        # One queue key per PR so its events are matched in order.
         await self.enqueue_work(
-            "deliver", f"deliver-{project.id_}-pr-{d.pr_number}", d.as_payload()
+            "deliver", f"deliver-{project.id_}-pr-{event.pr_number}", d.as_payload()
         )
 
     async def _submit_rerequest(self, event: CheckRerequested) -> None:
@@ -506,9 +474,9 @@ class CIService:
         )
 
     async def enqueue_work(
-        self, kind: str, dedup_key: str, payload: dict[str, Any]
+        self, kind: str, dedup_key: str, payload: dict[str, Any], *, delay: float = 0
     ) -> None:
-        await WorkQueue(self.pool).enqueue(kind, dedup_key, payload)
+        await WorkQueue(self.pool).enqueue(kind, dedup_key, payload, delay=delay)
         self._work_event.set()
 
     def wake_work(self) -> None:
@@ -539,6 +507,28 @@ class CIService:
     async def _execute_work(self, queue: WorkQueue, item: WorkItem) -> None:
         try:
             await self._dispatch_work(item)
+        except TransientError as e:
+            delay = work_retry_delay(
+                item.attempts + 1, e.retry_after, self.config.work_retry_backoff
+            )
+            if item.attempts + 1 < MAX_WORK_ATTEMPTS and await queue.retry(
+                item.id, delay=delay, error=str(e)
+            ):
+                logger.warning(
+                    "work item failed, retrying",
+                    extra={
+                        "work_id": item.id,
+                        "kind": item.kind,
+                        "in": delay,
+                        "error": str(e),
+                    },
+                )
+            else:
+                logger.exception(
+                    "work item failed, giving up",
+                    extra={"work_id": item.id, "kind": item.kind, "error": str(e)},
+                )
+                await queue.finish(item.id, error=str(e))
         except Exception as e:
             logger.exception("work item failed", extra={"work_id": item.id})
             await queue.finish(item.id, error=str(e) or type(e).__name__)
@@ -570,13 +560,13 @@ class CIService:
                 payload["build_id"], payload["name"], payload.get("kind", "push")
             )
         elif item.kind == "deliver":
-            await deliver(self, Delivery.from_payload(payload))
-        elif item.kind == "report":
-            await self._re_report(
-                payload["build_id"],
-                payload.get("attempt", 1),
-                payload.get("retry_at"),
+            await deliver(
+                self,
+                Delivery(**payload),
+                last_attempt=item.attempts + 1 >= MAX_WORK_ATTEMPTS,
             )
+        elif item.kind == "report":
+            await self._re_report(payload["build_id"])
         elif item.kind == "refresh-schedules":
             await schedule_runner.refresh_schedules(
                 self, payload["project_id"], payload["rev"]
@@ -596,14 +586,8 @@ class CIService:
             msg = f"unknown work kind {item.kind!r}"
             raise ValueError(msg)
 
-    async def _re_report(
-        self, build_id: int, attempt: int, retry_at: float | None = None
-    ) -> None:
-        """Re-post the build summary from database state. Waits for the
-        larger of the attempt backoff and the forge's Retry-After."""
-        delay = _report_delay(attempt, retry_at)
-        if delay > 0:
-            await asyncio.sleep(delay)
+    async def _re_report(self, build_id: int) -> None:
+        """Re-post the build summary from database state."""
         build = await builds_q.get_build(self.orchestrator.pool, id_=build_id)
         if build is None:
             return
@@ -614,12 +598,10 @@ class CIService:
         rows = await builds_q.attribute_statuses(self.pool, build_id=build_id)
         reporter = self.orchestrator.reporter
         if isinstance(reporter, RetryingReporter):
-            # Post via the inner reporter: the wrapper would enqueue a
-            # competing attempt-1 item on failure.
+            # The wrapper would enqueue a competing item on failure.
             reporter = reporter.inner
         try:
-            # Empty results: only the summary is re-posted. Per-attribute
-            # statuses were already posted (or cached) inline.
+            # Per-attribute statuses were already posted (or cached) inline.
             await reporter.build_finished(
                 event,
                 build,
@@ -631,13 +613,9 @@ class CIService:
                 ),
             )
         except Exception as e:
-            if attempt < MAX_REPORT_ATTEMPTS:
-                await self.enqueue_work(
-                    "report",
-                    f"report-{build_id}",
-                    _report_payload(build_id, attempt + 1, e),
-                )
-            raise
+            raise TransientError(
+                str(e), retry_after=getattr(e, "retry_after", None)
+            ) from e
 
     async def _restart_event_effect(self, payload: dict[str, Any]) -> None:
         build = await builds_q.get_build(self.pool, id_=payload["build_id"])

--- a/nixbot/nixbot/tests/support.py
+++ b/nixbot/nixbot/tests/support.py
@@ -40,6 +40,7 @@ from nixbot.models import CacheStatus, NixEvalJobSuccess
 
 def make_config(dsn: str, state_dir: Path, **kwargs: Any) -> Config:
     """A minimal valid Config for service-level tests."""
+    kwargs.setdefault("work_retry_backoff", 0)
     return Config(
         db_url=dsn,
         build_systems=["x86_64-linux"],

--- a/nixbot/nixbot/tests/test_control.py
+++ b/nixbot/nixbot/tests/test_control.py
@@ -19,12 +19,7 @@ from nixbot.bootstrap import build_service
 from nixbot.db_gen import builds as builds_q
 from nixbot.events import BuildResult, ChangeEvent, NullStatusReporter
 from nixbot.executor import attribute_log_path
-from nixbot.service import (
-    MAX_REPORT_ATTEMPTS,
-    RetryingReporter,
-    _report_delay,
-    repo_info,
-)
+from nixbot.service import RetryingReporter, repo_info
 from nixbot.status import StatusPostError, _raise_for_status
 from nixbot.visibility import AccessCache, VisibilityService
 from nixbot.web.control_routes import (
@@ -32,6 +27,7 @@ from nixbot.web.control_routes import (
     create_control_router,
 )
 from nixbot.web.token_routes import create_token_router
+from nixbot.work_queue import MAX_WORK_ATTEMPTS, work_retry_delay
 
 from .support import (
     WebHarness,
@@ -805,20 +801,18 @@ def test_retry_after_parsing() -> None:
     _raise_for_status(httpx.Response(201), "acme/widget")  # must not raise
 
 
-def test_report_delay_honors_retry_after() -> None:
+def test_work_retry_delay_honors_retry_after() -> None:
     # The forge hint dominates the attempt backoff and is capped.
-    assert _report_delay(1, None) == 0
-    assert _report_delay(2, None) == 30
-    assert _report_delay(2, time.time() + 240) == pytest.approx(240, abs=2)
-    assert _report_delay(1, time.time() + 7200) == 3600
+    assert work_retry_delay(1, None, 30) == 30
+    assert work_retry_delay(2, None, 30) == 60
+    assert work_retry_delay(2, 240, 30) == 240
+    assert work_retry_delay(1, 7200, 30) == 3600
+    assert work_retry_delay(20, None, 30) == 900
 
 
-async def test_report_retry(
-    postgres_dsn: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_report_retry(postgres_dsn: str, tmp_path: Path) -> None:
     """A failed terminal status post is retried from database state and
-    gives up after MAX_REPORT_ATTEMPTS instead of looping."""
-    monkeypatch.setattr("nixbot.service.REPORT_BACKOFF_SECONDS", 0)
+    gives up after MAX_WORK_ATTEMPTS instead of looping."""
 
     config = make_config(postgres_dsn, tmp_path / "state")
     service, _app = await build_service(config)
@@ -868,12 +862,12 @@ async def test_report_retry(
         fail = True
         await wrapper.build_finished(event, build, BuildResult("succeeded", 0, []))
         await service.drain_work()
-        assert len(posts) == MAX_REPORT_ATTEMPTS + 1  # inline + retries
-        failed = await pool.fetchval(
-            "SELECT count(*) FROM work_queue "
+        assert len(posts) == MAX_WORK_ATTEMPTS + 1  # inline + retries
+        row = await pool.fetchrow(
+            "SELECT count(*), max(attempts) AS attempts FROM work_queue "
             "WHERE kind = 'report' AND status = 'failed'"
         )
-        assert failed == MAX_REPORT_ATTEMPTS
+        assert (row["count"], row["attempts"]) == (1, MAX_WORK_ATTEMPTS - 1)
     finally:
         await pool.close()
 

--- a/nixbot/nixbot/tests/test_deliver.py
+++ b/nixbot/nixbot/tests/test_deliver.py
@@ -20,6 +20,7 @@ from nixbot.forge import ForgeError
 from nixbot.forge_pr import PullRequestInfo
 from nixbot.repos import repo_info
 from nixbot.webhooks import PrClosed, PrComment, PrLabeled
+from nixbot.work_queue import MAX_WORK_ATTEMPTS
 
 from .support import FakeEffects, git, insert_build
 from .test_service import git_repo, make_service, seed_project, service  # noqa: F401
@@ -49,7 +50,8 @@ class FakeForgePr:
     def __init__(self, pr: PullRequestInfo, perms: dict[str, str]) -> None:
         self.pr = pr
         self.perms = perms
-        self.fail = False
+        # HTTP status of the next pull_request() calls, popped per call.
+        self.fail: list[int] = []
         self.comments: list[str] = []
 
     async def comment(self, _info: Any, _n: int, body: str, _marker: Any) -> None:
@@ -57,8 +59,9 @@ class FakeForgePr:
 
     async def pull_request(self, _info: Any, number: int) -> PullRequestInfo:
         if self.fail:
-            msg = "boom"
-            raise ForgeError(msg, status_code=502)
+            status = self.fail.pop(0)
+            msg = f"boom {status}"
+            raise ForgeError(msg, status_code=status)
         assert number == self.pr.number
         return self.pr
 
@@ -199,13 +202,34 @@ async def test_permission_denied_records_reason(env: dict[str, Any]) -> None:
     assert env["ran"] == []
 
 
-async def test_forge_failure_fails_rows(env: dict[str, Any]) -> None:
-    svc, build_id = env["service"], env["build_id"]
-    env["forge"].fail = True
+async def test_forge_outage_is_retried(env: dict[str, Any]) -> None:
+    """A 5xx from the forge requeues the delivery with backoff instead of
+    dropping the event. A 404 is final."""
+    svc, build_id, pool = env["service"], env["build_id"], env["service"].pool
+    env["forge"].fail = [502, 503]
+    await _deliver(svc, build_id, "github:alice")
+    rows = await _rows(svc, build_id)
+    assert rows["plan"]["status"] == "succeeded"
+    item = await pool.fetchrow(
+        "SELECT status, attempts FROM work_queue WHERE kind = 'deliver'"
+        " ORDER BY id DESC LIMIT 1"
+    )
+    assert (item["status"], item["attempts"]) == ("done", 2)
+
+    env["forge"].fail = [404]
     await _deliver(svc, build_id, "github:alice")
     rows = await _rows(svc, build_id)
     assert {r["status"] for r in rows.values()} == {"failed"}
     assert "forge lookup failed" in rows["plan"]["skip_reason"]
+
+
+async def test_forge_outage_gives_up(env: dict[str, Any]) -> None:
+    svc, build_id = env["service"], env["build_id"]
+    env["forge"].fail = [502] * (MAX_WORK_ATTEMPTS + 1)
+    await _deliver(svc, build_id, "github:alice")
+    rows = await _rows(svc, build_id)
+    assert "forge lookup failed" in rows["plan"]["skip_reason"]
+    assert env["forge"].fail == [502]
     assert env["ran"] == []
 
 

--- a/nixbot/nixbot/work_queue.py
+++ b/nixbot/nixbot/work_queue.py
@@ -15,12 +15,22 @@ import asyncpg
 from .db_gen import work_queue as q
 
 
+class TransientError(Exception):
+    """Raised by a work handler when the item should be retried later,
+    e.g. the forge API was down. retry_after carries a Retry-After hint."""
+
+    def __init__(self, message: str, retry_after: float | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
 @dataclass(frozen=True)
 class WorkItem:
     id: int
     kind: str
     dedup_key: str
     payload: dict[str, Any]
+    attempts: int = 0
 
 
 class WorkQueue:
@@ -28,7 +38,12 @@ class WorkQueue:
         self.pool = pool
 
     async def enqueue(
-        self, kind: str, dedup_key: str, payload: dict[str, Any] | None = None
+        self,
+        kind: str,
+        dedup_key: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        delay: float = 0,
     ) -> bool:
         """Returns False when an identical pending item already exists."""
         return (
@@ -37,6 +52,7 @@ class WorkQueue:
                 kind=kind,
                 dedup_key=dedup_key,
                 payload=json.dumps(payload or {}),
+                delay=delay,
             )
             is not None
         )
@@ -56,6 +72,7 @@ class WorkQueue:
             kind=row.kind,
             dedup_key=row.dedup_key,
             payload=json.loads(row.payload),
+            attempts=row.attempts,
         )
 
     async def _claim_row(self) -> q.ClaimNextWorkItemRow | None:
@@ -69,6 +86,17 @@ class WorkQueue:
             error=error,
         )
 
+    async def retry(self, item_id: int, *, delay: float, error: str) -> bool:
+        """Put a claimed item back to pending, due after `delay` seconds.
+        False when an identical item is pending anyway."""
+        try:
+            n = await q.retry_work_item(
+                self.pool, id_=item_id, error=error, delay=delay
+            )
+        except asyncpg.UniqueViolationError:
+            return False
+        return n > 0
+
     async def settle_interrupted(self) -> None:
         """Startup: requeue work the previous process died holding.
         Executors are idempotent against completed state (existing
@@ -80,3 +108,16 @@ class WorkQueue:
 
     async def cleanup(self, retention_days: int) -> None:
         await q.cleanup_work_queue(self.pool, retention_days=retention_days)
+
+
+MAX_WORK_ATTEMPTS = 6
+MAX_WORK_DELAY_SECONDS = 3600
+
+
+def work_retry_delay(attempt: int, retry_after: float | None, base: float) -> float:
+    """Exponential backoff starting at `base` seconds, but never shorter
+    than the forge's Retry-After: GitHub escalates rate limits when it
+    is ignored."""
+    backoff = min(base * 2 ** (attempt - 1), 900)
+    hinted = retry_after or 0.0
+    return min(max(backoff, hinted), MAX_WORK_DELAY_SECONDS)


### PR DESCRIPTION
A forge 5xx while looking up the pull request dropped the event: the delivery
recorded failed rows and was done. Work items now go back to pending with
exponential backoff, honouring Retry-After, and give up only after several
attempts.

The `report` kind had its own retry loop with the same purpose; it now uses this
one.
