### PR TITLE
Check onSchedule effects and filter events by modified paths

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -134,8 +134,8 @@ nbo effects run --event comment --command apply --permission admin apply
 ```
 
 For `onEvent` effects, `--event KIND` plus flags describing the event (`--pr`,
-`--actor`, `--permission`, `--label`, `--command`, ...) stand in for a real
-delivery, and `list` then shows why each effect would be skipped.
+`--actor`, `--permission`, `--label`, `--modified`, `--command`, ...) stand in
+for a real delivery, and `list` then shows why each effect would be skipped.
 
 ## Exit codes
 

--- a/docs/EFFECTS.md
+++ b/docs/EFFECTS.md
@@ -308,6 +308,7 @@ effect that does not match is listed as skipped with the reason.
 | `labels = [ "deploy" ]`             | the PR has all of these labels                                                                  |
 | `branches = [ "main" "release-*" ]` | glob on the PR base branch, or the built branch                                                 |
 | `commands = [ "plan" ]`             | `comment`: the `/command` used                                                                  |
+| `modified = [ "terraform/*" ]`      | a file the PR changes matches a glob; pull request events only                                  |
 | `status = [ "failed" ]`             | status of the build in the payload                                                              |
 | `transition = "broke"` / `"fixed"`  | build status changed against the previous finished build of that branch or PR                   |
 
@@ -355,9 +356,9 @@ $ nbo effects run --event comment --command apply --args "-target=null" \
 
 `list` prints every effect of that kind with the reason it would be skipped, so
 a `when` can be tried without pushing. Flags cover what `when` looks at: `--pr`,
-`--actor`, `--permission`, `--author-permission`, `--label`, `--command`,
-`--args`, `--build-status`, `--previous-build-status`. A payload recorded by
-nixbot can be used instead with `--payload FILE`.
+`--actor`, `--permission`, `--author-permission`, `--label`, `--modified`,
+`--command`, `--args`, `--build-status`, `--previous-build-status`. A payload
+recorded by nixbot can be used instead with `--payload FILE`.
 
 ## Secrets on the server
 

--- a/nixbot/nixbot/deliver.py
+++ b/nixbot/nixbot/deliver.py
@@ -168,45 +168,23 @@ async def deliver(s: CIService, d: Delivery, *, last_attempt: bool = False) -> N
     code_rev = await repos.rev_parse(info.key, f"refs/heads/{info.default_branch}")
     cached = await s.event_listings.get(s, info, code_rev, credentials)
     listing = cached.effects.get(d.kind, {})
-    if cached.error is not None:
-        await builds_q.record_effect_eval_error(
-            s.pool,
-            build_id=build.id_,
-            source="delivery",
-            error=cached.error[-8000:],
-            code_rev=code_rev,
-        )
-    else:
-        await builds_q.clear_effect_eval_error(
-            s.pool, build_id=build.id_, source="delivery"
-        )
+    await _record_listing_error(s, build, cached.error, code_rev)
     if not listing:
         return
     try:
         if d.command is not None and d.actor and await s.forge_pr.is_self(d.actor):
             return
         payload = await _payload(s, project, info, build, d)
+        if "pullRequest" in payload and any(
+            "modified" in m.when for m in listing.values()
+        ):
+            payload["modifiedFiles"] = await _modified_files(
+                s, info, payload["pullRequest"], credentials
+            )
     except ForgeError as e:
         if e.transient and not last_attempt:
             raise TransientError(str(e)) from e
-        # Record why nothing ran rather than matching with missing data,
-        # which would look like "no permission".
-        logger.warning(
-            "delivery failed", extra={"build_id": build.id_, "error": str(e)}
-        )
-        for name in listing:
-            await ev_q.upsert_event_effect(
-                s.pool,
-                build_id=build.id_,
-                kind=d.kind,
-                name=name,
-                status="failed",
-                skip_reason=f"forge lookup failed: {e}",
-                payload="{}",
-                code_rev=code_rev,
-                actor=d.actor,
-                lock=None,
-            )
+        await _fail_listing(s, d, build, listing, code_rev, e)
         return
     await ev_q.supersede_event_effects(
         s.pool,
@@ -218,6 +196,53 @@ async def deliver(s: CIService, d: Delivery, *, last_attempt: bool = False) -> N
         command=d.command,
     )
     await _match_and_enqueue(s, d, info, build, listing, payload, code_rev)
+
+
+async def _record_listing_error(
+    s: CIService, build: BuildRecord, error: str | None, code_rev: str
+) -> None:
+    """Show a broken onEvent on the build page instead of silently
+    delivering nothing."""
+    if error is None:
+        await builds_q.clear_effect_eval_error(
+            s.pool, build_id=build.id_, source="delivery"
+        )
+        return
+    await builds_q.record_effect_eval_error(
+        s.pool,
+        build_id=build.id_,
+        source="delivery",
+        error=error[-8000:],
+        code_rev=code_rev,
+    )
+
+
+async def _fail_listing(  # noqa: PLR0913
+    s: CIService,
+    d: Delivery,
+    build: BuildRecord,
+    listing: dict[str, EventEffectMeta],
+    code_rev: str,
+    error: Exception,
+) -> None:
+    """The forge stayed broken. Record why nothing ran rather than
+    matching with missing data, which would look like "no permission"."""
+    logger.warning(
+        "delivery failed", extra={"build_id": build.id_, "error": str(error)}
+    )
+    for name in listing:
+        await ev_q.upsert_event_effect(
+            s.pool,
+            build_id=build.id_,
+            kind=d.kind,
+            name=name,
+            status="failed",
+            skip_reason=f"forge lookup failed: {error}",
+            payload="{}",
+            code_rev=code_rev,
+            actor=d.actor,
+            lock=None,
+        )
 
 
 async def _match_and_enqueue(  # noqa: PLR0913
@@ -287,6 +312,23 @@ async def _match_and_enqueue(  # noqa: PLR0913
             "skipped": len(listing) - len(names),
         },
     )
+
+
+async def _modified_files(
+    s: CIService,
+    info: RepoInfo,
+    pr: dict[str, Any],
+    credentials: FetchCredentials | None,
+) -> list[str]:
+    """The PR's changed files for `when.modified`, from the mirror."""
+    base = f"refs/heads/{pr['baseRef']}"
+    try:
+        await s.orchestrator.repos.fetch(
+            info.key, info.clone_url, [f"+{base}:{base}"], credentials
+        )
+        return await s.orchestrator.repos.changed_files(info.key, base, pr["headRev"])
+    except GitError as e:
+        raise TransientError(str(e)) from e
 
 
 async def _payload(

--- a/nixbot/nixbot/effect_checks.py
+++ b/nixbot/nixbot/effect_checks.py
@@ -1,9 +1,11 @@
 """Effect checks, stored as effect_runs of kind 'check'. Every build
-evaluates the onPush/onEvent effects of its own commit and builds their
-dependencies without running them, the way hercules-ci-agent treats a
-`runIf false` effect. That turns a pull request red when it breaks an
-effect, before the effect would run on the default branch. Check names
-are `<kind>.<effect>`, kind being `push` or an event kind."""
+evaluates the onPush/onEvent/onSchedule effects of its own commit and
+builds their dependencies without running them, the way hercules-ci-agent
+treats a `runIf false` effect. That turns a pull request red when it
+breaks an effect, before the effect would run on the default branch.
+Check names are `<kind>.<effect>`; kind is `push`, an event kind, or
+`schedule.<schedule>`.
+"""
 
 from __future__ import annotations
 
@@ -29,6 +31,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 KIND = "check"
+# Prefix of a schedule check name: schedule.<schedule>.<effect>.
+SCHEDULE = "schedule"
 
 
 def build_context(
@@ -77,19 +81,25 @@ async def discover_checks(
     worktree_path: Path,
     gated_push_effects: list[str],
 ) -> list[str] | None:
-    """Names of the checks this build should run: all onEvent effects of
-    the built commit, plus the onPush effects that are gated off on this
-    ref and so would otherwise go untested. None if onEvent does not
-    evaluate."""
+    """Names of the checks this build should run: all onEvent and
+    onSchedule effects of the built commit, plus the onPush effects that
+    are gated off on this ref and so would otherwise go untested. None if
+    the definitions do not evaluate."""
     ctx = build_context(o, event, worktree_path)
     try:
         listing = await o.effects.list_all_event_effects(ctx)
+        schedules = await o.effects.list_scheduled_effects(ctx)
     except (EffectError, OSError) as e:
         await record_eval_error(o, build, "onEvent", e)
         return None
     await record_eval_error(o, build, "onEvent", None)
     names = [f"push.{n}" for n in gated_push_effects]
     names += [f"{kind}.{n}" for kind, effects in listing.items() for n in effects]
+    names += [
+        f"schedule.{schedule}.{n}"
+        for schedule, meta in schedules.items()
+        for n in meta.get("effects", ())
+    ]
     return names
 
 
@@ -109,6 +119,18 @@ async def enqueue_checks(
     )
 
 
+async def _check(o: Orchestrator, ctx: EffectsContext, name: str) -> None:
+    """Dispatch a check name back to the effect it was listed from."""
+    kind, _, effect = name.partition(".")
+    if kind == "push":
+        await o.effects.check_effect(ctx, effect)
+    elif kind == SCHEDULE:
+        schedule, _, effect = effect.partition(".")
+        await o.effects.check_scheduled_effect(ctx, schedule, effect)
+    else:
+        await o.effects.check_event_effect(ctx, kind, effect)
+
+
 async def run_check_item(
     o: Orchestrator,
     info: RepoInfo,
@@ -119,7 +141,6 @@ async def run_check_item(
     row = await q.effect_run(o.pool, build_id=build.id_, kind=KIND, name=name)
     if row is None or row.status != "pending":
         return
-    kind, _, effect = name.partition(".")
     run_id = await builds_q.start_effect(
         o.pool, build_id=build.id_, kind=KIND, name=name, status="running"
     )
@@ -134,10 +155,7 @@ async def run_check_item(
             ):
                 ctx = build_context(o, event, worktree_path)
                 ctx.log = writer.write
-                if kind == "push":
-                    await o.effects.check_effect(ctx, effect)
-                else:
-                    await o.effects.check_event_effect(ctx, kind, effect)
+                await _check(o, ctx, name)
                 success = True
         except EffectError as e:
             await writer.write(f"error: {e}\n".encode())

--- a/nixbot/nixbot/effects.py
+++ b/nixbot/nixbot/effects.py
@@ -181,6 +181,15 @@ async def check_event_effect(ctx: EffectsContext, kind: str, effect: str) -> Non
     )
 
 
+async def check_scheduled_effect(
+    ctx: EffectsContext, schedule: str, effect: str
+) -> None:
+    """Build an onSchedule effect's dependencies. Raises EffectError."""
+    await _with_timeout(
+        nixbot_effects.check_scheduled_effect(ctx, schedule, effect), "effect check"
+    )
+
+
 async def list_scheduled_effects(ctx: EffectsContext) -> dict:
     """The onSchedule definitions on the default branch."""
     return await _with_timeout(
@@ -273,6 +282,9 @@ class EffectsBackend(Protocol):
     async def check_event_effect(
         self, ctx: EffectsContext, kind: str, effect: str
     ) -> None: ...
+    async def check_scheduled_effect(
+        self, ctx: EffectsContext, schedule: str, effect: str
+    ) -> None: ...
     async def run_effect(
         self, ctx: EffectsContext, effect: str, log_write: LogWrite | None = None
     ) -> bool: ...
@@ -299,6 +311,7 @@ class NixEffects:
     list_scheduled_effects = staticmethod(list_scheduled_effects)
     check_effect = staticmethod(check_effect)
     check_event_effect = staticmethod(check_event_effect)
+    check_scheduled_effect = staticmethod(check_scheduled_effect)
     run_effect = staticmethod(run_effect)
     run_event_effect = staticmethod(run_event_effect)
     run_scheduled_effect = staticmethod(run_scheduled_effect)

--- a/nixbot/nixbot/gitrepo.py
+++ b/nixbot/nixbot/gitrepo.py
@@ -361,6 +361,17 @@ class RepoManager:
         except GitError:
             return None
 
+    async def changed_files(
+        self, project_key: str, base_rev: str, head_rev: str
+    ) -> list[str]:
+        """Files the head changed against the merge base, as `when.modified`
+        sees them."""
+        out = await run_git(
+            ["diff", "--name-only", f"{base_rev}...{head_rev}"],
+            cwd=self.clone_path(project_key),
+        )
+        return out.split()
+
     async def create_worktree(
         self,
         project_key: str,

--- a/nixbot/nixbot/tests/support.py
+++ b/nixbot/nixbot/tests/support.py
@@ -109,6 +109,11 @@ class FakeEffects:
     async def check_event_effect(self, _ctx: Any, kind: str, effect: str) -> None:
         self.checked.append(f"{kind}.{effect}")
 
+    async def check_scheduled_effect(
+        self, _ctx: Any, schedule: str, effect: str
+    ) -> None:
+        self.checked.append(f"schedule.{schedule}.{effect}")
+
     async def run_effect(self, _ctx: Any, effect: str, _log: Any = None) -> bool:
         self.ran.append(effect)
         return True

--- a/nixbot/nixbot/tests/test_deliver.py
+++ b/nixbot/nixbot/tests/test_deliver.py
@@ -140,6 +140,7 @@ async def env(
         "build_id": build_id,
         "sha": sha,
         "forge": forge,
+        "fake": fake,
         "ran": ran,
         "repo": repo,
         "listing": listing,
@@ -200,6 +201,28 @@ async def test_permission_denied_records_reason(env: dict[str, Any]) -> None:
         "needs write access (actor github:mallory: none, author github:dave: none)"
     )
     assert env["ran"] == []
+
+
+async def test_modified_files_gate(env: dict[str, Any]) -> None:
+    """when.modified matches the files the PR head adds on top of its
+    base branch, fetched from the mirror."""
+    svc, build_id, repo = env["service"], env["build_id"], env["repo"]
+    git(repo, "checkout", "-q", "-b", "feature")
+    (repo / "terraform").mkdir()
+    (repo / "terraform" / "main.tf").write_text("# tf\n")
+    git(repo, "add", ".")
+    git(repo, "commit", "-qm", "add terraform")
+    head = git(repo, "rev-parse", "HEAD")
+    git(repo, "checkout", "-q", "main")
+    env["forge"].pr = replace(env["forge"].pr, head_rev=head, base_ref="main")
+    env["listings"]["pull_request"] = {
+        "tf": EventEffectMeta(when={"modified": ["terraform/*"]}),
+        "docs": EventEffectMeta(when={"modified": ["docs/*"]}),
+    }
+    await _deliver(svc, build_id, "github:alice")
+    rows = await _rows(svc, build_id)
+    assert rows["tf"]["status"] == "succeeded"
+    assert rows["docs"]["skip_reason"] == "no modified file matches docs/*"
 
 
 async def test_forge_outage_is_retried(env: dict[str, Any]) -> None:

--- a/nixbot/nixbot/tests/test_orchestrator.py
+++ b/nixbot/nixbot/tests/test_orchestrator.py
@@ -1188,6 +1188,7 @@ async def test_pr_worktree_config_cannot_grant_effects(
     base = git(upstream, "rev-parse", "HEAD")
 
     fake = patch_effects(monkeypatch)
+    fake.schedules = {"nightly": {"when": {}, "effects": ["gc"]}}
     ran = fake.ran
     orchestrator, reporter, project = await make_env(
         FakeEvalRunner([mk_job("a")]),
@@ -1211,12 +1212,13 @@ async def test_pr_worktree_config_cannot_grant_effects(
     )
     # Listed for visibility (Mic92/nixbot#106), never queued or reported.
     assert await effect_statuses(pool, build.id_) == {"deploy": "skipped"}
-    # The gated effect's dependencies were still built as a check.
-    assert fake.checked == ["deploy"]
+    # The gated effect and the scheduled effect were built as checks.
+    assert sorted(fake.checked) == ["deploy", "schedule.nightly.gc"]
     assert await effect_statuses(pool, build.id_, "check") == {
-        "push.deploy": "succeeded"
+        "push.deploy": "succeeded",
+        "schedule.nightly.gc": "succeeded",
     }
-    # The PR gets an effects status for its checks: started 1, 0 failed.
+    # The PR gets an effects status for its checks: started 2, 0 failed.
     kinds = [e[0] for e in reporter.events if e[0].startswith("effect")]
     assert kinds == ["effects-started", "effects-finished"]
 

--- a/nixbot_cli/nixbot_cli/effects.py
+++ b/nixbot_cli/nixbot_cli/effects.py
@@ -95,6 +95,7 @@ def _payload_from_args(args: argparse.Namespace) -> dict[str, Any]:
         permission=args.permission,
         author_permission=args.author_permission,
         labels=args.labels,
+        modified=args.modified,
         command=args.command,
         args=args.args,
         status=args.build_status,
@@ -206,6 +207,13 @@ def _add_event_flags(parser: argparse.ArgumentParser) -> None:
         dest="labels",
         metavar="LABEL",
         help="a label on the pull request (repeatable)",
+    )
+    parser.add_argument(
+        "--modified",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="a file the pull request changes (repeatable)",
     )
     parser.add_argument("--command", metavar="NAME", help="the /command commented")
     parser.add_argument(

--- a/nixbot_effects/nixbot_effects/__init__.py
+++ b/nixbot_effects/nixbot_effects/__init__.py
@@ -8,6 +8,7 @@ from .errors import EffectError
 from .eval import (
     check_effect,
     check_event_effect,
+    check_scheduled_effect,
     list_all_event_effects,
     list_effects,
     list_event_effects,
@@ -24,6 +25,7 @@ __all__ = [
     "EventEffectMeta",
     "check_effect",
     "check_event_effect",
+    "check_scheduled_effect",
     "list_all_event_effects",
     "list_effects",
     "list_event_effects",

--- a/nixbot_effects/nixbot_effects/eval.py
+++ b/nixbot_effects/nixbot_effects/eval.py
@@ -377,6 +377,22 @@ async def check_effect(opts: EffectsOptions, effect: str) -> None:
             await build_derivation(drv, opts)
 
 
+async def check_scheduled_effect(
+    opts: EffectsOptions, schedule: str, effect: str
+) -> None:
+    """Build an onSchedule effect's dependencies without running it."""
+    with_gcroot = _with_gcroot()
+    async with with_gcroot as gcroot:
+        drv = await instantiate_effect_deps(
+            f"let e = ({await scheduled_effect_function(opts)})"
+            f".{schedule}.outputs.effects.{effect}; in",
+            opts,
+            gcroot,
+        )
+        if drv:
+            await build_derivation(drv, opts)
+
+
 async def check_event_effect(opts: EffectsOptions, kind: str, effect: str) -> None:
     """Build an onEvent effect's dependencies without running it."""
     with_gcroot = _with_gcroot()

--- a/nixbot_effects/nixbot_effects/match.py
+++ b/nixbot_effects/nixbot_effects/match.py
@@ -13,7 +13,7 @@ from .errors import EffectError
 
 KINDS = ("pull_request", "pull_request_closed", "comment", "build_finished")
 WHEN_KEYS = frozenset(
-    {"permission", "labels", "branches", "commands", "status", "transition"}
+    {"permission", "labels", "branches", "commands", "modified", "status", "transition"}
 )
 _LEVELS = {None: 0, "none": 0, "read": 1, "write": 2, "admin": 3}
 _TRANSITIONS = {"broke", "fixed"}
@@ -90,6 +90,18 @@ def _commands(when: dict[str, Any], payload: Payload) -> str | None:
     return None if cmd in want else f"command /{cmd} not in {', '.join(want)}"
 
 
+def _modified(when: dict[str, Any], payload: Payload) -> str | None:
+    globs = when.get("modified")
+    if not globs:
+        return None
+    files = payload.get("modifiedFiles")
+    if files is None:
+        return "modified files are only known for pull request events"
+    if any(fnmatchcase(f, g) for g in globs for f in files):
+        return None
+    return f"no modified file matches {', '.join(globs)}"
+
+
 def _status(when: dict[str, Any], payload: Payload) -> str | None:
     want = when.get("status")
     if not want:
@@ -115,7 +127,15 @@ def _transition(when: dict[str, Any], payload: Payload) -> str | None:
     return None if ok else f"not a {want} transition ({prev or 'none'} -> {now})"
 
 
-_CHECKS = (_commands, _permission, _labels, _branches, _status, _transition)
+_CHECKS = (
+    _commands,
+    _permission,
+    _labels,
+    _branches,
+    _modified,
+    _status,
+    _transition,
+)
 
 
 def skip_reason(when: dict[str, Any], payload: Payload) -> str | None:
@@ -135,6 +155,7 @@ def event_payload(  # noqa: PLR0913
     author: str | None = None,
     author_permission: str | None = None,
     labels: list[str] | None = None,
+    modified: list[str] | None = None,
     command: str | None = None,
     args: str = "",
     status: str = "succeeded",
@@ -162,6 +183,8 @@ def event_payload(  # noqa: PLR0913
                 else permission,
             },
         }
+        # A pull request always has a file list, even an empty one.
+        payload["modifiedFiles"] = modified or []
     if command is not None:
         payload["command"] = command
         payload["args"] = args

--- a/nixbot_effects/nixbot_effects/tests/test_on_event.py
+++ b/nixbot_effects/nixbot_effects/tests/test_on_event.py
@@ -136,6 +136,22 @@ def test_labels_branches_commands_status() -> None:
     )
 
 
+def test_modified() -> None:
+    payload = {"pullRequest": PR, "modifiedFiles": ["terraform/main.tf", "README.md"]}
+    assert skip_reason({"modified": ["terraform/*"]}, payload) is None
+    # A pull request without matching files, not "files unknown".
+    assert skip_reason({"modified": ["docs/*"]}, event_payload(pr=7)) == (
+        "no modified file matches docs/*"
+    )
+    assert skip_reason({"modified": ["docs/*", "*.nix"]}, payload) == (
+        "no modified file matches docs/*, *.nix"
+    )
+    # Events without a pull request carry no file list.
+    assert skip_reason({"modified": ["*"]}, {"build": BUILD}) == (
+        "modified files are only known for pull request events"
+    )
+
+
 def test_transition() -> None:
     def build(now: str, prev: str | None) -> dict:
         return {"build": {**BUILD, "status": now, "previousStatus": prev}}
@@ -158,8 +174,10 @@ def test_event_payload_from_fields() -> None:
         actor="github:alice",
         permission="write",
         labels=["preview"],
+        modified=["terraform/main.tf"],
     )
     assert skip_reason({"permission": "write", "labels": ["preview"]}, payload) is None
+    assert skip_reason({"modified": ["terraform/*"]}, payload) is None
     assert skip_reason({"permission": "admin"}, payload) == (
         "needs admin access (actor github:alice: write, author github:alice: write)"
     )


### PR DESCRIPTION
Review follow-ups from #188.

`onSchedule` effects are checked at build time like onPush and onEvent ones, so
a pull request breaking a scheduled effect no longer stays green.

`when.modified = [ "terraform/*" ]` runs an event effect only when the pull
request touches a matching path, which keeps a plan effect quiet on unrelated
pull requests. The file list also reaches the effect as `modifiedFiles` in
`/run/event.json`.
