### PR TITLE
metrics: export upload queue depth, retrying paths and oldest age

### DIFF
--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -13,6 +13,7 @@ __all__: collections.abc.Sequence[str] = (
     "MetricsBuildDurationRow",
     "MetricsEvalDurationRow",
     "MetricsProjectsRow",
+    "MetricsUploadQueueRow",
     "QueryResults",
     "WebAttributeCountsRow",
     "WebAttributeHistoryRow",
@@ -32,6 +33,7 @@ __all__: collections.abc.Sequence[str] = (
     "metrics_eval_duration",
     "metrics_projects",
     "metrics_queue_depth",
+    "metrics_upload_queue",
     "web_attribute_counts",
     "web_attribute_history",
     "web_attribute_neighbor_numbers",
@@ -248,6 +250,14 @@ class MetricsProjectsRow:
 class MetricsEvalDurationRow:
     total: int
     count: int
+
+
+@dataclasses.dataclass()
+class MetricsUploadQueueRow:
+    uploader: str
+    depth: int
+    retrying: int
+    oldest_age: float
 
 
 @dataclasses.dataclass()
@@ -483,6 +493,15 @@ FROM projects
 METRICS_EVAL_DURATION: typing.Final[str] = """-- name: MetricsEvalDuration :one
 SELECT coalesce(sum(eval_duration_ms), 0)::float / 1000 AS total, count(*) AS count
 FROM builds WHERE eval_duration_ms IS NOT NULL
+"""
+
+METRICS_UPLOAD_QUEUE: typing.Final[str] = """-- name: MetricsUploadQueue :many
+SELECT
+    uploader,
+    count(*) AS depth,
+    count(*) FILTER (WHERE attempts > 0) AS retrying,
+    coalesce(extract(epoch FROM now() - min(created_at)), 0)::float AS oldest_age
+FROM upload_queue GROUP BY uploader
 """
 
 WEB_EVAL_STATS: typing.Final[str] = """-- name: WebEvalStats :many
@@ -936,6 +955,13 @@ async def metrics_eval_duration(conn: ConnectionLike) -> MetricsEvalDurationRow 
     if row is None:
         return None
     return MetricsEvalDurationRow(total=row[0], count=row[1])
+
+
+def metrics_upload_queue(conn: ConnectionLike) -> QueryResults[MetricsUploadQueueRow]:
+    def _decode_hook(row: asyncpg.Record) -> MetricsUploadQueueRow:
+        return MetricsUploadQueueRow(uploader=row[0], depth=row[1], retrying=row[2], oldest_age=row[3])
+
+    return QueryResults(conn, METRICS_UPLOAD_QUEUE, _decode_hook)
 
 
 def web_eval_stats(conn: ConnectionLike, *, build_id: int, by_alloc: bool, limit_: int) -> QueryResults[WebEvalStatsRow]:

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -212,6 +212,14 @@ FROM projects;
 SELECT coalesce(sum(eval_duration_ms), 0)::float / 1000 AS total, count(*) AS count
 FROM builds WHERE eval_duration_ms IS NOT NULL;
 
+-- name: MetricsUploadQueue :many
+SELECT
+    uploader,
+    count(*) AS depth,
+    count(*) FILTER (WHERE attempts > 0) AS retrying,
+    coalesce(extract(epoch FROM now() - min(created_at)), 0)::float AS oldest_age
+FROM upload_queue GROUP BY uploader;
+
 -- name: WebEvalStats :many
 -- Attributes with eval stats, most expensive first.
 SELECT attr, status, eval_wall_ms, eval_alloc_bytes FROM build_attributes

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -463,11 +463,24 @@ def test_metrics_are_gauges(client: WebHarness) -> None:
     # Table-derived series shrink, so they must not be counters — and
     # per Prometheus conventions non-monotonic series must not be
     # named _total either.
-    text = client.get("/metrics").text
+    ctx = client.ctx
+    client.loop.run_until_complete(
+        ctx.pool.execute(
+            "INSERT INTO upload_queue (uploader, path, attempts)"
+            " VALUES ('cache', '/nix/store/a', 0), ('cache', '/nix/store/b', 1)"
+        )
+    )
+    try:
+        text = client.get("/metrics").text
+    finally:
+        client.loop.run_until_complete(ctx.pool.execute("DELETE FROM upload_queue"))
     assert "# TYPE nixbot_builds gauge" in text
     assert "# TYPE nixbot_attributes gauge" in text
     assert "_total" not in text
     assert "counter" not in text
+    assert 'nixbot_upload_queue_depth{uploader="cache"} 2' in text
+    assert 'nixbot_upload_queue_retrying{uploader="cache"} 1' in text
+    assert 'nixbot_upload_queue_oldest_age_seconds{uploader="cache"}' in text
 
 
 def test_metrics_are_cached(client: WebHarness) -> None:

--- a/nixbot/nixbot/web/metrics.py
+++ b/nixbot/nixbot/web/metrics.py
@@ -68,6 +68,32 @@ async def render_metrics(pool: asyncpg.Pool) -> str:
     lines.append(f'nixbot_projects{{state="enabled"}} {projects.enabled}')
     lines.append(f'nixbot_projects{{state="total"}} {projects.total}')
 
+    uploads = await gen.metrics_upload_queue(pool)
+    lines.append(
+        "# HELP nixbot_upload_queue_depth Store paths waiting for a binary-cache push."
+    )
+    lines.append("# TYPE nixbot_upload_queue_depth gauge")
+    lines.extend(
+        f'nixbot_upload_queue_depth{{uploader="{u.uploader}"}} {u.depth}'
+        for u in uploads
+    )
+    lines.append(
+        "# HELP nixbot_upload_queue_retrying Queued paths whose push failed at least once."
+    )
+    lines.append("# TYPE nixbot_upload_queue_retrying gauge")
+    lines.extend(
+        f'nixbot_upload_queue_retrying{{uploader="{u.uploader}"}} {u.retrying}'
+        for u in uploads
+    )
+    lines.append(
+        "# HELP nixbot_upload_queue_oldest_age_seconds Age of the oldest queued path."
+    )
+    lines.append("# TYPE nixbot_upload_queue_oldest_age_seconds gauge")
+    lines.extend(
+        f'nixbot_upload_queue_oldest_age_seconds{{uploader="{u.uploader}"}} {u.oldest_age}'
+        for u in uploads
+    )
+
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
With uploads now asynchronous a stuck or failing cache push is no longer
visible as a failed build, so expose the queue for alerting.

Change-Id: Ia9bd37b467642214381a07e88c10eed038be9b40

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>