### PR TITLE
metrics: export effect run counts, oldest running effect and schedule lag

### DIFF
--- a/nixbot/nixbot/db_gen/web.py
+++ b/nixbot/nixbot/db_gen/web.py
@@ -11,8 +11,11 @@ __all__: collections.abc.Sequence[str] = (
     "MetricsAttributeCountsRow",
     "MetricsBuildCountsRow",
     "MetricsBuildDurationRow",
+    "MetricsEffectCountsRow",
+    "MetricsEffectOldestRunningRow",
     "MetricsEvalDurationRow",
     "MetricsProjectsRow",
+    "MetricsScheduleLagRow",
     "MetricsUploadQueueRow",
     "QueryResults",
     "WebAttributeCountsRow",
@@ -30,9 +33,12 @@ __all__: collections.abc.Sequence[str] = (
     "metrics_attribute_counts",
     "metrics_build_counts",
     "metrics_build_duration",
+    "metrics_effect_counts",
+    "metrics_effect_oldest_running",
     "metrics_eval_duration",
     "metrics_projects",
     "metrics_queue_depth",
+    "metrics_schedule_lag",
     "metrics_upload_queue",
     "web_attribute_counts",
     "web_attribute_history",
@@ -258,6 +264,25 @@ class MetricsUploadQueueRow:
     depth: int
     retrying: int
     oldest_age: float
+
+
+@dataclasses.dataclass()
+class MetricsEffectCountsRow:
+    owner: str
+    status: str
+    count: int
+
+
+@dataclasses.dataclass()
+class MetricsEffectOldestRunningRow:
+    owner: str
+    age: float
+
+
+@dataclasses.dataclass()
+class MetricsScheduleLagRow:
+    schedules: int
+    lag: float
 
 
 @dataclasses.dataclass()
@@ -502,6 +527,21 @@ SELECT
     count(*) FILTER (WHERE attempts > 0) AS retrying,
     coalesce(extract(epoch FROM now() - min(created_at)), 0)::float AS oldest_age
 FROM upload_queue GROUP BY uploader
+"""
+
+METRICS_EFFECT_COUNTS: typing.Final[str] = """-- name: MetricsEffectCounts :many
+SELECT owner, status, count(*) AS count FROM effect_runs GROUP BY owner, status
+"""
+
+METRICS_EFFECT_OLDEST_RUNNING: typing.Final[str] = """-- name: MetricsEffectOldestRunning :many
+SELECT owner, extract(epoch FROM now() - min(started_at))::float AS age
+FROM effect_runs WHERE status IN ('pending', 'running') GROUP BY owner
+"""
+
+METRICS_SCHEDULE_LAG: typing.Final[str] = """-- name: MetricsScheduleLag :one
+SELECT count(*) AS schedules,
+       coalesce(extract(epoch FROM now() - max(last_run)), 0)::float AS lag
+FROM scheduled_effects JOIN projects p ON p.id = project_id WHERE p.enabled
 """
 
 WEB_EVAL_STATS: typing.Final[str] = """-- name: WebEvalStats :many
@@ -962,6 +1002,27 @@ def metrics_upload_queue(conn: ConnectionLike) -> QueryResults[MetricsUploadQueu
         return MetricsUploadQueueRow(uploader=row[0], depth=row[1], retrying=row[2], oldest_age=row[3])
 
     return QueryResults(conn, METRICS_UPLOAD_QUEUE, _decode_hook)
+
+
+def metrics_effect_counts(conn: ConnectionLike) -> QueryResults[MetricsEffectCountsRow]:
+    def _decode_hook(row: asyncpg.Record) -> MetricsEffectCountsRow:
+        return MetricsEffectCountsRow(owner=row[0], status=row[1], count=row[2])
+
+    return QueryResults(conn, METRICS_EFFECT_COUNTS, _decode_hook)
+
+
+def metrics_effect_oldest_running(conn: ConnectionLike) -> QueryResults[MetricsEffectOldestRunningRow]:
+    def _decode_hook(row: asyncpg.Record) -> MetricsEffectOldestRunningRow:
+        return MetricsEffectOldestRunningRow(owner=row[0], age=row[1])
+
+    return QueryResults(conn, METRICS_EFFECT_OLDEST_RUNNING, _decode_hook)
+
+
+async def metrics_schedule_lag(conn: ConnectionLike) -> MetricsScheduleLagRow | None:
+    row = await conn.fetchrow(METRICS_SCHEDULE_LAG)
+    if row is None:
+        return None
+    return MetricsScheduleLagRow(schedules=row[0], lag=row[1])
 
 
 def web_eval_stats(conn: ConnectionLike, *, build_id: int, by_alloc: bool, limit_: int) -> QueryResults[WebEvalStatsRow]:

--- a/nixbot/nixbot/queries/web.sql
+++ b/nixbot/nixbot/queries/web.sql
@@ -220,6 +220,19 @@ SELECT
     coalesce(extract(epoch FROM now() - min(created_at)), 0)::float AS oldest_age
 FROM upload_queue GROUP BY uploader;
 
+-- name: MetricsEffectCounts :many
+SELECT owner, status, count(*) AS count FROM effect_runs GROUP BY owner, status;
+
+-- name: MetricsEffectOldestRunning :many
+SELECT owner, extract(epoch FROM now() - min(started_at))::float AS age
+FROM effect_runs WHERE status IN ('pending', 'running') GROUP BY owner;
+
+-- name: MetricsScheduleLag :one
+-- Coarse scheduler liveness: time since any schedule last fired.
+SELECT count(*) AS schedules,
+       coalesce(extract(epoch FROM now() - max(last_run)), 0)::float AS lag
+FROM scheduled_effects JOIN projects p ON p.id = project_id WHERE p.enabled;
+
 -- name: WebEvalStats :many
 -- Attributes with eval stats, most expensive first.
 SELECT attr, status, eval_wall_ms, eval_alloc_bytes FROM build_attributes

--- a/nixbot/nixbot/tests/test_web.py
+++ b/nixbot/nixbot/tests/test_web.py
@@ -470,10 +470,20 @@ def test_metrics_are_gauges(client: WebHarness) -> None:
             " VALUES ('cache', '/nix/store/a', 0), ('cache', '/nix/store/b', 1)"
         )
     )
+    effect_id = client.loop.run_until_complete(
+        ctx.pool.fetchval(
+            "INSERT INTO effect_runs (project_id, kind, build_id, name, status)"
+            " SELECT project_id, 'push', id, 'deploy', 'running' FROM builds LIMIT 1"
+            " RETURNING id"
+        )
+    )
     try:
         text = client.get("/metrics").text
     finally:
         client.loop.run_until_complete(ctx.pool.execute("DELETE FROM upload_queue"))
+        client.loop.run_until_complete(
+            ctx.pool.execute("DELETE FROM effect_runs WHERE id = $1", effect_id)
+        )
     assert "# TYPE nixbot_builds gauge" in text
     assert "# TYPE nixbot_attributes gauge" in text
     assert "_total" not in text
@@ -481,6 +491,8 @@ def test_metrics_are_gauges(client: WebHarness) -> None:
     assert 'nixbot_upload_queue_depth{uploader="cache"} 2' in text
     assert 'nixbot_upload_queue_retrying{uploader="cache"} 1' in text
     assert 'nixbot_upload_queue_oldest_age_seconds{uploader="cache"}' in text
+    assert 'nixbot_effects{owner="build",status="running"} ' in text
+    assert 'nixbot_effects_oldest_running_age_seconds{owner="build"}' in text
 
 
 def test_metrics_are_cached(client: WebHarness) -> None:

--- a/nixbot/nixbot/web/metrics.py
+++ b/nixbot/nixbot/web/metrics.py
@@ -68,6 +68,30 @@ async def render_metrics(pool: asyncpg.Pool) -> str:
     lines.append(f'nixbot_projects{{state="enabled"}} {projects.enabled}')
     lines.append(f'nixbot_projects{{state="total"}} {projects.total}')
 
+    lines.append("# HELP nixbot_effects Effect runs by owner and status.")
+    lines.append("# TYPE nixbot_effects gauge")
+    lines.extend(
+        f'nixbot_effects{{owner="{e.owner}",status="{e.status}"}} {e.count}'
+        for e in await gen.metrics_effect_counts(pool)
+    )
+    lines.append(
+        "# HELP nixbot_effects_oldest_running_age_seconds"
+        " Age of the longest pending or running effect."
+    )
+    lines.append("# TYPE nixbot_effects_oldest_running_age_seconds gauge")
+    lines.extend(
+        f'nixbot_effects_oldest_running_age_seconds{{owner="{e.owner}"}} {e.age}'
+        for e in await gen.metrics_effect_oldest_running(pool)
+    )
+    sched = expect(await gen.metrics_schedule_lag(pool))
+    if sched.schedules:
+        lines.append(
+            "# HELP nixbot_scheduled_effect_lag_seconds"
+            " Time since any scheduled effect last ran."
+        )
+        lines.append("# TYPE nixbot_scheduled_effect_lag_seconds gauge")
+        lines.append(f"nixbot_scheduled_effect_lag_seconds {sched.lag}")
+
     uploads = await gen.metrics_upload_queue(pool)
     lines.append(
         "# HELP nixbot_upload_queue_depth Store paths waiting for a binary-cache push."


### PR DESCRIPTION
A hung deploy effect or a scheduler that silently stopped firing does
not surface as a failed build; these gauges make both alertable.

Change-Id: I6fb2477d649c52670e936f39eb3b47e46f5ec960

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>