### PR TITLE
status: drive per-attribute posts from the whole build

### DIFF
--- a/checks/nixbot-gitlab.nix
+++ b/checks/nixbot-gitlab.nix
@@ -124,9 +124,13 @@
           chmod 644 /var/lib/secrets/gitlab-token
 
           # The legacy-import topic enables the project on first discovery.
-          curl -fs -X POST -H "PRIVATE-TOKEN: $TOKEN" -H 'Content-Type: application/json' \
-            -d '{"name":"test-flake","visibility":"public","topics":["build-with-buildbot"]}' \
-            http://gitlab/api/v4/projects > /dev/null
+          # gitaly may not be ready yet even though the web UI answers.
+          timeout 300 bash -c 'until curl -fs -H "PRIVATE-TOKEN: $0" http://gitlab/api/v4/projects/root%2Ftest-flake > /dev/null; do
+            curl -s -X POST -H "PRIVATE-TOKEN: $0" -H "Content-Type: application/json" \
+              -d "{\"name\":\"test-flake\",\"visibility\":\"public\",\"topics\":[\"build-with-buildbot\"]}" \
+              http://gitlab/api/v4/projects | jq -c "{id, message, error}"
+            sleep 5
+          done' "$TOKEN"
 
           mkdir -p /tmp/test-flake
           cd /tmp/test-flake

--- a/checks/nixbot-gitlab.nix
+++ b/checks/nixbot-gitlab.nix
@@ -192,6 +192,12 @@
         retry(hook_registered, timeout_seconds=300)
 
     with subtest("push delivers the webhook"):
+        # Hooks are delivered by sidekiq, which setup-gitlab restarted and
+        # which needs minutes to boot Rails again on a loaded builder.
+        gitlab.wait_until_succeeds(
+            "journalctl -u gitlab-sidekiq _SYSTEMD_INVOCATION_ID=$(systemctl show -P InvocationID gitlab-sidekiq) | grep -q 'Booted Rails'",
+            timeout=600,
+        )
         gitlab.succeed(
             "cd /tmp/test-flake && "
             "echo '# trigger' >> flake.nix && "

--- a/nixbot/nixbot/status.py
+++ b/nixbot/nixbot/status.py
@@ -611,17 +611,17 @@ class ForgeStatusReporter:
         while len(self._posted_generations) > POSTED_GENERATIONS_MAX:
             self._posted_generations.popitem(last=False)
 
-        counts = await self._post_attribute_statuses(
-            event, build, results, result.attr_prefix
+        # results may be a rerun subset. attr_statuses is the whole build.
+        detail = {r.attr: r for r in results}
+        statuses = (
+            attr_statuses
+            if attr_statuses is not None
+            else {r.attr: r.status.value for r in results}
         )
-        if attr_statuses is not None:
-            # Reruns pass only the re-run subset as `results`: the
-            # summary description must still cover the whole build.
-            counts = {"failed": 0, "succeeded": 0, "cancelled": 0}
-            for attr_status in attr_statuses.values():
-                counts[_count_key(attr_status)] += 1
-        table_statuses = attr_statuses or {r.attr: r.status.value for r in results}
-        await self._post_summary(event, build, result.status, counts, table_statuses)
+        counts = await self._post_attribute_statuses(
+            event, build, statuses, detail, result.attr_prefix
+        )
+        await self._post_summary(event, build, result.status, counts, statuses)
 
     async def build_restarted(
         self, event: ChangeEvent, build: BuildRecord, attr: str | None
@@ -666,26 +666,31 @@ class ForgeStatusReporter:
         self,
         event: ChangeEvent,
         build: BuildRecord,
-        results: list[AttributeResult],
+        statuses: dict[str, str],
+        detail: dict[str, AttributeResult],
         attr_prefix: str,
     ) -> dict[str, int]:
-        """Per-attribute failure statuses and success flips. Returns
-        failed/succeeded counts over `results`."""
+        """Per-attribute failure statuses and success flips over the
+        whole build. Returns failed/succeeded/cancelled counts."""
         revision = event.commit_sha
         previously_failed = await self.failed_statuses.get_failed(revision)
 
         counts = {"failed": 0, "succeeded": 0, "cancelled": 0}
         reported = 0
-        for result in results:
+        for attr, status in statuses.items():
+            counts[_count_key(status)] += 1
             context = attr_status_context(
                 event.repo.forge,
                 event.repo.name,
-                result.attr,
+                attr,
                 attr_prefix,
                 context_prefix=self.context_prefix,
             )
-            if result.status.value in FAILED_STATUS_STATES:
-                counts[_count_key(result.status.value)] += 1
+            if status in FAILED_STATUS_STATES:
+                result = detail.get(attr)
+                if context in previously_failed and result is None:
+                    # Already posted with error detail.
+                    continue
                 if context not in previously_failed:
                     # Only new failures consume the report budget;
                     # previously-failed contexts always re-post so they
@@ -694,34 +699,27 @@ class ForgeStatusReporter:
                         continue
                     reported += 1
                 await self.failed_statuses.mark_failed(revision, context)
+                error = result.error if result else None
                 headline = (
                     result.failure.headline()
-                    if result.failure
-                    else _error_headline(result.error or "")
+                    if result and result.failure
+                    else _error_headline(error or "")
                 )
-                description = headline or result.status.value
                 await self._post(
                     event,
                     build,
                     context,
                     StatusState.failure,
-                    description,
-                    attr=result.attr,
-                    text=_fence(result.error) if result.error else None,
+                    headline or status,
+                    attr=attr,
+                    text=_fence(error) if error else None,
                 )
-            else:
-                counts["succeeded"] += 1
-                if context in previously_failed:
-                    # Success-flip for a previously failed status.
-                    await self.failed_statuses.clear(revision, context)
-                    await self._post(
-                        event,
-                        build,
-                        context,
-                        StatusState.success,
-                        "succeeded",
-                        attr=result.attr,
-                    )
+            elif context in previously_failed:
+                # Success-flip for a previously failed status.
+                await self.failed_statuses.clear(revision, context)
+                await self._post(
+                    event, build, context, StatusState.success, "succeeded", attr=attr
+                )
         return counts
 
     async def _post_summary(

--- a/nixbot/nixbot/tests/test_status.py
+++ b/nixbot/nixbot/tests/test_status.py
@@ -614,6 +614,27 @@ async def test_summary_counts_use_all_attribute_statuses() -> None:
     assert combined.description == "100 attributes built"
 
 
+async def test_success_flip_for_attributes_outside_the_rerun_subset() -> None:
+    """results is a rerun subset. Earlier successes must still flip."""
+    reporter, poster, store = make_reporter()
+    context = attr_status_context("github", "acme/widget", "a")
+    await store.mark_failed("sha1", context)
+    await reporter.build_finished(
+        EVENT,
+        BUILD,
+        BuildResult(
+            "succeeded",
+            1,
+            [attr_result("b", AttributeStatus.succeeded)],
+            attr_statuses={"a": "succeeded", "b": "succeeded"},
+        ),
+    )
+    assert context not in await store.get_failed("sha1")
+    assert [p.state for p in poster.posts if p.context == context] == [
+        StatusState.success
+    ]
+
+
 async def test_failed_effect_posts_failure_status() -> None:
     """A failed effect must flip the commit status to failure. A green
     status on a failed deploy hides the breakage (issue #30)."""


### PR DESCRIPTION
build_finished only looked at the rerun subset, so after a restart mid-build stale red check runs from an earlier build were never flipped (seen on #198). Iterate attr_statuses instead.

Also retry GitLab project creation in the VM test. gitaly returned 400 right after sign_in answered on a loaded builder.