### PR TITLE
migrations: fix DBs with old 0028 or 0029

### DIFF
--- a/nixbot/nixbot/migrations.py
+++ b/nixbot/nixbot/migrations.py
@@ -4,7 +4,8 @@ Scripts live in the `migrations/` package directory and are named
 `NNNN_description.sql`. Each script runs in its own transaction. The
 whole run is guarded by a Postgres advisory lock so concurrent service
 starts cannot race. Applied versions are recorded in
-`schema_migrations`.
+`schema_migrations` with a sha256 of the script; a shipped script that
+no longer matches aborts startup, since applied versions never re-run.
 
 asyncpg is used directly (not through SQLAlchemy) because it executes
 multi-statement scripts natively.
@@ -13,6 +14,7 @@ multi-statement scripts natively.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import logging
 import re
 from dataclasses import dataclass
@@ -35,6 +37,10 @@ class Migration:
     version: int
     name: str
     sql: str
+
+    @property
+    def checksum(self) -> str:
+        return hashlib.sha256(self.sql.encode()).hexdigest()
 
 
 _SCRIPT_RE = re.compile(r"^(\d{4})_(.+)\.sql$")
@@ -62,6 +68,32 @@ def load_migrations() -> list[Migration]:
     return migrations
 
 
+async def _verify_checksums(
+    conn: asyncpg.Connection,
+    migrations: list[Migration],
+    applied: dict[int, str | None],
+) -> None:
+    """Reject shipped scripts that differ from what was applied; record
+    checksums for rows that predate them."""
+    for migration in migrations:
+        if migration.version not in applied:
+            continue
+        recorded = applied[migration.version]
+        if recorded is None:
+            await conn.execute(
+                "UPDATE schema_migrations SET checksum = $2 WHERE version = $1",
+                migration.version,
+                migration.checksum,
+            )
+        elif recorded != migration.checksum:
+            msg = (
+                f"migration {migration.version:04d}_{migration.name} changed "
+                f"after it was applied ({recorded[:12]} -> "
+                f"{migration.checksum[:12]}); add a new migration instead"
+            )
+            raise MigrationError(msg)
+
+
 async def apply_migrations(dsn: str) -> None:
     """Apply all pending migrations to the database at `dsn`."""
     migrations = load_migrations()
@@ -74,14 +106,22 @@ async def apply_migrations(dsn: str) -> None:
                 CREATE TABLE IF NOT EXISTS schema_migrations (
                     version BIGINT PRIMARY KEY,
                     name TEXT NOT NULL,
-                    applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                    applied_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    checksum TEXT
                 )
                 """
             )
+            # Tables created before checksums were recorded.
+            await conn.execute(
+                "ALTER TABLE schema_migrations ADD COLUMN IF NOT EXISTS checksum TEXT"
+            )
             applied = {
-                row["version"]
-                for row in await conn.fetch("SELECT version FROM schema_migrations")
+                row["version"]: row["checksum"]
+                for row in await conn.fetch(
+                    "SELECT version, checksum FROM schema_migrations"
+                )
             }
+            await _verify_checksums(conn, migrations, applied)
             for migration in migrations:
                 if migration.version in applied:
                     continue
@@ -100,9 +140,13 @@ async def apply_migrations(dsn: str) -> None:
                 try:
                     await conn.execute(migration.sql)
                     await conn.execute(
-                        "INSERT INTO schema_migrations (version, name) VALUES ($1, $2)",
+                        """
+                        INSERT INTO schema_migrations (version, name, checksum)
+                        VALUES ($1, $2, $3)
+                        """,
                         migration.version,
                         migration.name,
+                        migration.checksum,
                     )
                 except BaseException:
                     with contextlib.suppress(Exception):

--- a/nixbot/nixbot/migrations/0033_effect_runs_catchup.sql
+++ b/nixbot/nixbot/migrations/0033_effect_runs_catchup.sql
@@ -1,0 +1,20 @@
+-- 0028 and 0029 were edited after they had shipped (b2473dd). Databases
+-- that applied the originals lack these three objects; elsewhere this is
+-- a no-op.
+ALTER TABLE effect_runs
+    ADD COLUMN IF NOT EXISTS owner TEXT NOT NULL GENERATED ALWAYS AS (
+        CASE
+            WHEN kind IN ('push', 'check') THEN 'build'
+            WHEN kind = 'schedule' THEN 'schedule'
+            ELSE 'delivery'
+        END
+    ) STORED;
+ALTER TABLE effect_runs ADD COLUMN IF NOT EXISTS lock TEXT;
+CREATE TABLE IF NOT EXISTS effect_eval_errors (
+    build_id BIGINT NOT NULL REFERENCES builds (id) ON DELETE CASCADE,
+    source TEXT NOT NULL,
+    error TEXT NOT NULL,
+    code_rev TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (build_id, source)
+);

--- a/nixbot/nixbot/tests/test_db.py
+++ b/nixbot/nixbot/tests/test_db.py
@@ -69,6 +69,54 @@ async def test_failed_migration_error_not_masked(
         await migrations_mod.apply_migrations(postgres_dsn)
 
 
+async def test_catchup_migration_repairs_pre_0033_schema(
+    postgres_dsn: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Databases that applied 0028/0029 before b2473dd edited them lack
+    owner, lock and effect_eval_errors; 0033 adds them."""
+    async with db_pool(postgres_dsn) as pool:
+        await pool.execute("CREATE DATABASE db_pre_0033")
+    dsn = postgres_dsn.replace("/db?", "/db_pre_0033?")
+
+    shipped = load_migrations()
+    monkeypatch.setattr(
+        migrations_mod,
+        "load_migrations",
+        lambda: [m for m in shipped if m.version < 33],
+    )
+    await apply_migrations(dsn)
+    async with db_pool(dsn) as pool:
+        await pool.execute(
+            "ALTER TABLE effect_runs DROP COLUMN owner, DROP COLUMN lock"
+        )
+        await pool.execute("DROP TABLE effect_eval_errors")
+
+    monkeypatch.setattr(migrations_mod, "load_migrations", lambda: shipped)
+    await apply_migrations(dsn)
+
+    async with db_pool(dsn) as pool:
+        project_id = await insert_project(pool, "catchup")
+        build_id = await insert_build(pool, project_id)
+        await pool.execute(
+            "INSERT INTO effect_runs (project_id, kind, build_id, schedule_name, name)"
+            " VALUES ($1, 'push', $2, NULL, 'n'), ($1, 'check', $2, NULL, 'n'),"
+            " ($1, 'deployment_status', $2, NULL, 'n'),"
+            " ($1, 'schedule', NULL, 'nightly', 'n')",
+            project_id,
+            build_id,
+        )
+        rows = await pool.fetch(
+            "SELECT kind, owner, lock FROM effect_runs ORDER BY kind"
+        )
+        assert [tuple(r) for r in rows] == [
+            ("check", "build", None),
+            ("deployment_status", "delivery", None),
+            ("push", "build", None),
+            ("schedule", "schedule", None),
+        ]
+        assert await pool.fetchval("SELECT count(*) FROM effect_eval_errors") == 0
+
+
 async def test_huge_attr_name_does_not_break_notify_trigger(pool: asyncpg.Pool) -> None:
     """pg_notify payloads cap at ~8000 bytes. The notify trigger must
     truncate the repo-controlled attr name or every insert/update of

--- a/nixbot/nixbot/tests/test_db.py
+++ b/nixbot/nixbot/tests/test_db.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import json
 
 import asyncpg
@@ -67,6 +68,28 @@ async def test_failed_migration_error_not_masked(
     # rollback/unlock raise on the now-dead connection.
     with pytest.raises(asyncpg.PostgresConnectionError):
         await migrations_mod.apply_migrations(postgres_dsn)
+
+
+async def test_edited_migration_rejected(
+    postgres_dsn: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An applied script never re-runs, so an edited one must abort startup."""
+    shipped = load_migrations()
+    conn = await _connect(postgres_dsn)
+    try:
+        recorded = await conn.fetchval(
+            "SELECT checksum FROM schema_migrations WHERE version = 1"
+        )
+    finally:
+        await conn.close()
+    assert recorded == shipped[0].checksum
+
+    edited = dataclasses.replace(shipped[0], sql=shipped[0].sql + "\n-- edited")
+    monkeypatch.setattr(
+        migrations_mod, "load_migrations", lambda: [edited, *shipped[1:]]
+    )
+    with pytest.raises(migrations_mod.MigrationError, match=r"0001_initial changed"):
+        await apply_migrations(postgres_dsn)
 
 
 async def test_catchup_migration_repairs_pre_0033_schema(


### PR DESCRIPTION
Migrations are only identified by their number which means that as both 0028 and 0029 got amended, anyone who happened to run an old commit will not rerun those migrations leaving their database in an inconsistent
state.

In this PR, I add an idempotent migration 0033 which contains all the changes that were added to 0028 and 0029 which means that any database that is missing these changes will gain them after running this migration. I also added checksums to make nixbot fail on startup to immediately catch when the applied migrations have changed.

~~Draft as untested :)~~