### PR TITLE
migrations: repair existing effect run schemas

### DIFF
--- a/nixbot/nixbot/migrations/0033_effect_runs_owner.sql
+++ b/nixbot/nixbot/migrations/0033_effect_runs_owner.sql
@@ -1,0 +1,11 @@
+-- Migration 0028 originally created effect_runs without owner. Adding the
+-- generated column to that migration only covered fresh databases, leaving
+-- upgraded installations incompatible with queries that use owner.
+ALTER TABLE effect_runs
+ADD COLUMN IF NOT EXISTS owner TEXT GENERATED ALWAYS AS (
+    CASE
+        WHEN kind IN ('push', 'check') THEN 'build'
+        WHEN kind = 'schedule' THEN 'schedule'
+        ELSE 'delivery'
+    END
+) STORED;

--- a/nixbot/nixbot/tests/test_db.py
+++ b/nixbot/nixbot/tests/test_db.py
@@ -51,6 +51,26 @@ async def test_migrations_idempotent(postgres_dsn: str) -> None:
     assert await check() == len(load_migrations())
 
 
+async def test_effect_runs_owner_upgrade_migration(postgres_dsn: str) -> None:
+    """Databases that applied migration 28 before owner was added must upgrade."""
+    conn = await _connect(postgres_dsn)
+    try:
+        await conn.execute("ALTER TABLE effect_runs DROP COLUMN owner")
+        await conn.execute("DELETE FROM schema_migrations WHERE version = 33")
+        await apply_migrations(postgres_dsn)
+
+        generation = await conn.fetchval(
+            """
+            SELECT is_generated
+            FROM information_schema.columns
+            WHERE table_name = 'effect_runs' AND column_name = 'owner'
+            """
+        )
+        assert generation == "ALWAYS"
+    finally:
+        await conn.close()
+
+
 async def test_failed_migration_error_not_masked(
     postgres_dsn: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Existing installations that applied migration 28 before the generated effect_runs.owner column was added fail current effect queries and leave builds stuck pending. This adds an idempotent follow-up migration that repairs upgraded databases without changing fresh schemas, plus regression coverage for that upgrade path.