### PR TITLE
uploaders: stream paths to one long-running niks3 push

### DIFF
--- a/checks/nixbot.nix
+++ b/checks/nixbot.nix
@@ -44,20 +44,38 @@ in
   nodes = {
     # GitHub mode against a fake GitHub API: discovery, webhook, eval,
     # build, and commit-status assertions all run against local fakes.
-    github = {
-      imports = [ (import ./github-node.nix { flakeText = testFlake; }) ];
-      services.nixbot.uploaders = [
-        {
-          name = "local-cache";
-          command = [
-            "nix"
-            "copy"
-            "--to"
-            "file:///var/lib/nixbot/cache"
-          ];
-        }
-      ];
-    };
+    github =
+      { pkgs, ... }:
+      {
+        imports = [ (import ./github-node.nix { flakeText = testFlake; }) ];
+        services.nixbot.uploaders = [
+          {
+            name = "local-cache";
+            command = [
+              "nix"
+              "copy"
+              "--to"
+              "file:///var/lib/nixbot/cache"
+            ];
+          }
+          {
+            # Stand-in for `niks3 push --stdin`.
+            name = "stream-cache";
+            pathsVia = "stream";
+            command = [
+              (pkgs.writeShellScript "stream-cache" ''
+                while read -r p; do
+                  if nix copy --to file:///var/lib/nixbot/stream-cache "$p"; then
+                    printf '{"path":"%s","status":"ok"}\n' "$p"
+                  else
+                    printf '{"path":"%s","status":"error","message":"copy failed"}\n' "$p"
+                  fi
+                done
+              '')
+            ];
+          }
+        ];
+      };
 
     # Gitea mode against a real Gitea: discovery registers the webhook,
     # a push delivers it, and nixbot posts commit statuses back.
@@ -212,6 +230,13 @@ in
             "grep -h StorePath: /var/lib/nixbot/cache/*.narinfo"
         )
         print(narinfos)
+        names = {line.rsplit("-", 1)[1] for line in narinfos.split()[1::2]}
+        assert names == {"test", "dep"}, narinfos
+        narinfos = github.wait_until_succeeds(
+            "test $(ls /var/lib/nixbot/stream-cache/*.narinfo | wc -l) -ge 2 && "
+            "grep -h StorePath: /var/lib/nixbot/stream-cache/*.narinfo",
+            timeout=60,
+        )
         names = {line.rsplit("-", 1)[1] for line in narinfos.split()[1::2]}
         assert names == {"test", "dep"}, narinfos
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -96,7 +96,8 @@ at discovery time.
 **Cache uploads.** `services.nixbot.cachix`/`niks3` now push every derivation
 built locally, not just each attribute's output closure. Custom `nix copy` or
 `attic push` post-build steps belong in `services.nixbot.uploaders` to get the
-same behaviour (attic needs `pathsVia = "stdin"`).
+same behaviour (attic needs `pathsVia = "stdin"`). The niks3 module runs one
+long-lived `niks3 push --stdin` and needs niks3 >= 1.11.
 
 **Buildbot customizations.** Anything that reached into Buildbot itself —
 `services.buildbot-master.extraConfig`, the manhole, `pythonPackages` — has no

--- a/nixbot/nixbot/bootstrap.py
+++ b/nixbot/nixbot/bootstrap.py
@@ -289,7 +289,7 @@ async def build_service(config: Config) -> tuple[CIService, FastAPI]:
         repos=RepoManager(config.state_dir),
         eval_runner=EvalRunner(limiter=CgroupLimiter.create()),
         executor=executor,
-        uploaders=[Uploader(c, pool) for c in config.uploaders],
+        uploaders=[Uploader.create(c, pool) for c in config.uploaders],
         failed_build_cache=lambda project_id: PostgresFailedBuildCache(
             pool, project_id
         ),

--- a/nixbot/nixbot/config.py
+++ b/nixbot/nixbot/config.py
@@ -228,7 +228,7 @@ class UploaderConfig(BaseModel):
     name: str
     command: list[str | Interpolate]
     environment: Mapping[str, str | Interpolate] = {}
-    paths_via: Literal["argv", "stdin"] = "argv"
+    paths_via: Literal["argv", "stdin", "stream"] = "argv"
 
 
 def glob_to_regex(glob: str) -> re.Pattern:

--- a/nixbot/nixbot/db_gen/uploads.py
+++ b/nixbot/nixbot/db_gen/uploads.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 __all__: collections.abc.Sequence[str] = (
     "PendingUploadPathsRow",
     "QueryResults",
+    "all_pending_upload_paths",
+    "delete_upload_path",
     "delete_upload_paths",
     "drop_unknown_uploaders",
     "enqueue_upload_paths",
@@ -63,6 +65,14 @@ WITH dropped AS (
 UPDATE upload_queue SET attempts = attempts + 1
 WHERE id = ANY($1::bigint[])
   AND attempts + 1 < $2::int
+"""
+
+ALL_PENDING_UPLOAD_PATHS: typing.Final[str] = """-- name: AllPendingUploadPaths :many
+SELECT DISTINCT path FROM upload_queue WHERE uploader = $1
+"""
+
+DELETE_UPLOAD_PATH: typing.Final[str] = """-- name: DeleteUploadPath :exec
+DELETE FROM upload_queue WHERE uploader = $1 AND path = $2
 """
 
 DROP_UNKNOWN_UPLOADERS: typing.Final[str] = """-- name: DropUnknownUploaders :exec
@@ -129,6 +139,14 @@ async def delete_upload_paths(conn: ConnectionLike, *, ids: collections.abc.Sequ
 
 async def retry_upload_paths(conn: ConnectionLike, *, ids: collections.abc.Sequence[int], max_attempts: int) -> None:
     await conn.execute(RETRY_UPLOAD_PATHS, ids, max_attempts)
+
+
+def all_pending_upload_paths(conn: ConnectionLike, *, uploader: str) -> QueryResults[str]:
+    return QueryResults(conn, ALL_PENDING_UPLOAD_PATHS, operator.itemgetter(0), uploader)
+
+
+async def delete_upload_path(conn: ConnectionLike, *, uploader: str, path: str) -> None:
+    await conn.execute(DELETE_UPLOAD_PATH, uploader, path)
 
 
 async def drop_unknown_uploaders(conn: ConnectionLike, *, names: collections.abc.Sequence[str]) -> None:

--- a/nixbot/nixbot/queries/uploads.sql
+++ b/nixbot/nixbot/queries/uploads.sql
@@ -25,5 +25,11 @@ UPDATE upload_queue SET attempts = attempts + 1
 WHERE id = ANY(sqlc.arg(ids)::bigint[])
   AND attempts + 1 < sqlc.arg(max_attempts)::int;
 
+-- name: AllPendingUploadPaths :many
+SELECT DISTINCT path FROM upload_queue WHERE uploader = $1;
+
+-- name: DeleteUploadPath :exec
+DELETE FROM upload_queue WHERE uploader = $1 AND path = $2;
+
 -- name: DropUnknownUploaders :exec
 DELETE FROM upload_queue WHERE NOT (uploader = ANY(sqlc.arg(names)::text[]));

--- a/nixbot/nixbot/tests/test_upload.py
+++ b/nixbot/nixbot/tests/test_upload.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import sys
+import textwrap
 from typing import TYPE_CHECKING
 
 import pytest
@@ -12,6 +14,8 @@ from nixbot.config import UploaderConfig
 from nixbot.db_gen import uploads as q
 from nixbot.upload import (
     MAX_ATTEMPTS,
+    BatchUploader,
+    StreamUploader,
     Uploader,
     chunk_args,
     parse_path_info,
@@ -77,7 +81,7 @@ def test_parse_path_info_both_formats() -> None:
 async def test_final_upload_reports_and_clears_queue(
     pool: asyncpg.Pool, tmp_path: Path
 ) -> None:
-    up = Uploader(recorder(tmp_path), pool, resolve=identity)
+    up = Uploader.create(recorder(tmp_path), pool, resolve=identity)
     async with running(up, pool):
         result = await up.upload(["/nix/store/a", "/nix/store/b"])
     assert result.success
@@ -92,7 +96,7 @@ async def test_final_upload_reports_and_clears_queue(
 async def test_intermediates_batch_with_final_and_drop_invalid(
     pool: asyncpg.Pool, tmp_path: Path
 ) -> None:
-    up = Uploader(recorder(tmp_path), pool, resolve=drv_to_out)
+    up = Uploader.create(recorder(tmp_path), pool, resolve=drv_to_out)
     # Queued before the worker runs: everything lands in one push.
     up.enqueue_nowait("/nix/store/dep1.drv")
     up.enqueue_nowait("/nix/store/failed.drv")
@@ -105,7 +109,7 @@ async def test_intermediates_batch_with_final_and_drop_invalid(
 
 
 async def test_stdin_mode(pool: asyncpg.Pool, tmp_path: Path) -> None:
-    up = Uploader(recorder(tmp_path, stdin=True), pool, resolve=identity)
+    up = Uploader.create(recorder(tmp_path, stdin=True), pool, resolve=identity)
     async with running(up, pool):
         assert (await up.upload(["/nix/store/a"])).success
     assert (tmp_path / "up.log").read_text().split() == ["/nix/store/a", "batch"]
@@ -117,13 +121,113 @@ async def test_pending_paths_survive_restart(
     # Left over by a previous service instance that died mid-batch.
     await q.enqueue_upload_paths(pool, uploader="up", paths=["/nix/store/old"])
     await q.enqueue_upload_paths(pool, uploader="gone", paths=["/nix/store/x"])
-    up = Uploader(recorder(tmp_path), pool, resolve=identity)
+    up = Uploader.create(recorder(tmp_path), pool, resolve=identity)
     async with running(up, pool):
         assert (await up.upload(["/nix/store/new"])).success
     lines = (tmp_path / "up.log").read_text().split()
     assert "/nix/store/old" in lines
     assert "/nix/store/new" in lines
     # Rows of uploaders no longer configured are dropped at startup.
+    assert await pool.fetchval("SELECT count(*) FROM upload_queue") == 0
+
+
+def streamer(tmp_path: Path, body: str, name: str = "up") -> UploaderConfig:
+    """Fake `niks3 push --stdin`: `body` runs per input line with `p`
+    bound and may call ok(p)/err(p, msg)."""
+    script = tmp_path / f"{name}.py"
+    script.write_text(
+        textwrap.dedent("""
+        import json, os, sys
+        log = open(os.environ["LOG"], "a")
+        log.write("start\\n"); log.flush()
+        def ok(p): print(json.dumps({"path": p, "status": "ok"}), flush=True)
+        def err(p, m): print(json.dumps({"path": p, "status": "error", "message": m}), flush=True)
+        for line in sys.stdin:
+            p = line.strip()
+            log.write(p + "\\n"); log.flush()
+        """)
+        + textwrap.indent(textwrap.dedent(body), "    ")
+    )
+    return UploaderConfig(
+        name=name,
+        command=[sys.executable, str(script)],
+        environment={"LOG": str(tmp_path / f"{name}.log")},
+        paths_via="stream",
+    )
+
+
+def test_uploader_factory_picks_stream(pool: asyncpg.Pool, tmp_path: Path) -> None:
+    assert isinstance(Uploader.create(recorder(tmp_path), pool), BatchUploader)
+    assert isinstance(
+        Uploader.create(streamer(tmp_path, "ok(p)"), pool), StreamUploader
+    )
+
+
+async def test_stream_reports_per_path_and_clears_queue(
+    pool: asyncpg.Pool, tmp_path: Path
+) -> None:
+    up = Uploader.create(streamer(tmp_path, "ok(p)"), pool, resolve=drv_to_out)
+    up.enqueue_nowait("/nix/store/dep1.drv")
+    up.enqueue_nowait("/nix/store/failed.drv")
+    async with running(up, pool):
+        a, b = await asyncio.gather(
+            up.upload(["/nix/store/a"]), up.upload(["/nix/store/b"])
+        )
+        assert a.success
+        assert b.success
+        for _ in range(200):
+            if await pool.fetchval("SELECT count(*) FROM upload_queue") == 0:
+                break
+            await asyncio.sleep(0.01)
+    lines = (tmp_path / "up.log").read_text().split()
+    assert lines.count("start") == 1
+    assert set(lines) == {"start", "/nix/store/dep1", "/nix/store/a", "/nix/store/b"}
+    assert await pool.fetchval("SELECT count(*) FROM upload_queue") == 0
+
+
+async def test_stream_error_is_reported_with_message(
+    pool: asyncpg.Pool, tmp_path: Path
+) -> None:
+    body = 'err(p, "cache down") if p.endswith("bad") else ok(p)'
+    up = Uploader.create(streamer(tmp_path, body), pool, resolve=identity)
+    async with running(up, pool):
+        good, bad = await asyncio.gather(
+            up.upload(["/nix/store/good"]), up.upload(["/nix/store/bad"])
+        )
+    assert good.success
+    assert not bad.success
+    assert "cache down" in bad.output
+    # niks3 retries itself; nixbot does not resend.
+    assert (tmp_path / "up.log").read_text().split().count("/nix/store/bad") == 1
+    assert await pool.fetchval("SELECT count(*) FROM upload_queue") == 0
+
+
+async def test_stream_child_crash_refeeds_pending(
+    pool: asyncpg.Pool, tmp_path: Path
+) -> None:
+    # First instance dies on its first path; the restart is fed the
+    # queue again and the waiter gets its ack from there.
+    marker = tmp_path / "crashed"
+    body = f"""
+        import pathlib
+        m = pathlib.Path({str(marker)!r})
+        if not m.exists():
+            m.touch(); sys.exit(3)
+        ok(p)
+    """
+    await q.enqueue_upload_paths(pool, uploader="up", paths=["/nix/store/old"])
+    up = Uploader.create(
+        streamer(tmp_path, body), pool, resolve=identity, retry_delay=0.01
+    )
+    async with running(up, pool):
+        assert (await up.upload(["/nix/store/new"])).success
+        for _ in range(300):
+            if await pool.fetchval("SELECT count(*) FROM upload_queue") == 0:
+                break
+            await asyncio.sleep(0.01)
+    runs = (tmp_path / "up.log").read_text().split("start\n")
+    assert len(runs) == 1 + 2
+    assert {"/nix/store/old", "/nix/store/new"} <= set(runs[2].split())
     assert await pool.fetchval("SELECT count(*) FROM upload_queue") == 0
 
 
@@ -135,7 +239,7 @@ async def test_failure_reports_retries_and_gives_up(
         name="up",
         command=["sh", "-c", f"echo x >> {counter}; echo cache down; exit 1", "sh"],
     )
-    up = Uploader(cfg, pool, resolve=identity, retry_delay=0.01)
+    up = Uploader.create(cfg, pool, resolve=identity, retry_delay=0.01)
     async with running(up, pool):
         result = await up.upload(["/nix/store/a"])
         assert not result.success

--- a/nixbot/nixbot/upload.py
+++ b/nixbot/nixbot/upload.py
@@ -1,21 +1,25 @@
-"""Binary-cache uploads through one persistent batching queue per uploader.
+"""Binary-cache uploads through one persistent queue per uploader.
 
 Every locally built derivation (intermediates included) and each
-attribute's final outputs land in `upload_queue`. One worker per
-uploader drains whatever accumulated into a single push, so at most one
-push per uploader runs service-wide and a restart loses nothing.
-Intermediates arrive as .drv paths and silently drop out when their
-outputs are invalid (the derivation failed).
+attribute's final outputs land in `upload_queue` so a restart loses
+nothing. Intermediates arrive as .drv paths and silently drop out when
+their outputs are invalid (the derivation failed).
+
+Batch uploaders run one push over whatever accumulated. Stream
+uploaders keep one long-running child (`niks3 push --stdin`) that
+acknowledges each path, so an attribute waits only for its own paths.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
+from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from nixbot_effects.proc import ProcessGroup
 
@@ -37,19 +41,13 @@ RETRY_DELAY = 30.0
 BATCH_LIMIT = 5000
 # Well below ARG_MAX (2 MiB incl. environment on Linux).
 MAX_ARGS_BYTES = 512 * 1024
+STREAM_STOP_GRACE = 10.0
 
 
 @dataclass
 class UploadResult:
     success: bool
     output: str
-
-
-@dataclass
-class _Waiter:
-    future: asyncio.Future[UploadResult]
-    # Highest queue row of this attribute; rows push in id order.
-    last_id: int | None = None
 
 
 def chunk_args(args: Sequence[str], limit: int = MAX_ARGS_BYTES) -> list[list[str]]:
@@ -144,8 +142,12 @@ class Uploader:
     retry_delay: float = RETRY_DELAY
     resolve: Callable[[set[str]], Awaitable[set[str]]] = resolve_valid_outputs
     _wake: asyncio.Event = field(default_factory=asyncio.Event, init=False)
-    _waiters: list[_Waiter] = field(default_factory=list, init=False)
     _buffer: list[str] = field(default_factory=list, init=False)
+
+    @staticmethod
+    def create(config: UploaderConfig, pool: asyncpg.Pool, **kwargs: Any) -> Uploader:
+        cls = StreamUploader if config.paths_via == "stream" else BatchUploader
+        return cls(config, pool, **kwargs)
 
     @property
     def name(self) -> str:
@@ -153,14 +155,42 @@ class Uploader:
 
     def enqueue_nowait(self, drv_path: str) -> None:
         """Best-effort upload of a .drv the build log reported as built;
-        persisted by the worker on its next iteration."""
+        picked up by the worker on its next iteration."""
         self._buffer.append(drv_path)
         self._wake.set()
 
-    async def _flush_buffer(self) -> None:
-        if self._buffer:
-            paths, self._buffer = self._buffer, []
-            await q.enqueue_upload_paths(self.pool, uploader=self.name, paths=paths)
+    def _take_buffer(self) -> list[str]:
+        paths, self._buffer = self._buffer, []
+        return paths
+
+    def _command(self) -> tuple[list[str], dict[str, str]]:
+        # No %(prop:..)s: one process spans many attributes.
+        command = [interpolate(arg, {}) for arg in self.config.command]
+        env = {
+            **os.environ,
+            **{k: interpolate(v, {}) for k, v in self.config.environment.items()},
+        }
+        return command, env
+
+    async def upload(self, paths: list[str]) -> UploadResult:
+        raise NotImplementedError
+
+    async def run(self) -> None:
+        raise NotImplementedError
+
+
+@dataclass
+class _Waiter:
+    future: asyncio.Future[UploadResult]
+    # Highest queue row of this attribute; rows push in id order.
+    last_id: int | None = None
+
+
+@dataclass
+class BatchUploader(Uploader):
+    """One push per iteration over everything queued (argv or stdin)."""
+
+    _waiters: list[_Waiter] = field(default_factory=list, init=False)
 
     async def upload(self, paths: list[str]) -> UploadResult:
         """Upload an attribute's final outputs and wait for the first verdict."""
@@ -190,7 +220,10 @@ class Uploader:
     async def run(self) -> None:
         while True:
             self._wake.clear()
-            await self._flush_buffer()
+            if buffered := self._take_buffer():
+                await q.enqueue_upload_paths(
+                    self.pool, uploader=self.name, paths=buffered
+                )
             rows = await q.pending_upload_paths(
                 self.pool, uploader=self.name, limit=BATCH_LIMIT
             )
@@ -219,15 +252,6 @@ class Uploader:
             if not result.success:
                 await asyncio.sleep(self.retry_delay)
 
-    def _command(self) -> tuple[list[str], dict[str, str]]:
-        # No %(prop:..)s: one batch spans many attributes.
-        command = [interpolate(arg, {}) for arg in self.config.command]
-        env = {
-            **os.environ,
-            **{k: interpolate(v, {}) for k, v in self.config.environment.items()},
-        }
-        return command, env
-
     async def _push(self, raw: set[str]) -> UploadResult:
         paths = sorted(await self.resolve(raw))
         if not paths:
@@ -254,8 +278,109 @@ class Uploader:
         return UploadResult(success=ok, output="".join(outputs))
 
 
+@dataclass
+class StreamUploader(Uploader):
+    """Long-running child speaking `niks3 push --stdin`: store paths in,
+    one JSON `{path, status, message}` line per path out. Queue rows only
+    bridge child or service restarts; retrying is the child's job."""
+
+    _pending: defaultdict[str, list[asyncio.Future[UploadResult]]] = field(
+        default_factory=lambda: defaultdict(list), init=False
+    )
+
+    async def upload(self, paths: list[str]) -> UploadResult:
+        loop = asyncio.get_running_loop()
+        futures = [loop.create_future() for _ in paths]
+        for p, fut in zip(paths, futures, strict=True):
+            self._pending[p].append(fut)
+        self._buffer.extend(paths)
+        self._wake.set()
+        try:
+            results = await asyncio.wait_for(asyncio.gather(*futures), self.timeout)
+        except TimeoutError:
+            return UploadResult(
+                success=False, output=f"timed out after {self.timeout}s"
+            )
+        failed = [r.output for r in results if not r.success]
+        return UploadResult(success=not failed, output="\n".join(failed))
+
+    async def _ack(self, line: bytes) -> None:
+        try:
+            msg = json.loads(line)
+            path, ok = msg["path"], msg["status"] == "ok"
+        except (ValueError, KeyError, TypeError):
+            logger.warning(
+                "uploader emitted garbage",
+                extra={"uploader": self.name, "line": line[:200]},
+            )
+            return
+        result = UploadResult(success=ok, output=str(msg.get("message", "")))
+        if not ok:
+            logger.warning(
+                "upload failed",
+                extra={"uploader": self.name, "path": path, "output": result.output},
+            )
+        for fut in self._pending.pop(path, []):
+            if not fut.done():
+                fut.set_result(result)
+        await q.delete_upload_path(self.pool, uploader=self.name, path=path)
+
+    async def _feed(self, stdin: asyncio.StreamWriter) -> None:
+        paths = list(await q.all_pending_upload_paths(self.pool, uploader=self.name))
+        while True:
+            if paths:
+                stdin.write("".join(f"{p}\n" for p in paths).encode())
+                await stdin.drain()
+            await self._wake.wait()
+            self._wake.clear()
+            paths = sorted(await self.resolve(set(self._take_buffer())))
+            if paths:
+                await q.enqueue_upload_paths(self.pool, uploader=self.name, paths=paths)
+
+    async def _run_child(self) -> None:
+        command, env = self._command()
+        group = await ProcessGroup.start(
+            command,
+            env=env,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+        )
+        proc = group.proc
+        assert proc.stdin is not None  # noqa: S101
+        assert proc.stdout is not None  # noqa: S101
+        logger.info("uploader started", extra={"uploader": self.name})
+        feed = asyncio.create_task(self._feed(proc.stdin))
+        try:
+            async for line in proc.stdout:
+                await self._ack(line)
+        finally:
+            feed.cancel()
+            with contextlib.suppress(asyncio.CancelledError, ConnectionError):
+                await feed
+            if proc.returncode is None:
+                # EOF lets niks3 finish in-flight pushes.
+                proc.stdin.close()
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(proc.wait(), STREAM_STOP_GRACE)
+            await group.reap()
+        logger.warning(
+            "uploader exited",
+            extra={"uploader": self.name, "returncode": proc.returncode},
+        )
+
+    async def run(self) -> None:
+        while True:
+            try:
+                await self._run_child()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("uploader crashed", extra={"uploader": self.name})
+            await asyncio.sleep(self.retry_delay)
+
+
 async def start_uploaders(
-    uploaders: list[Uploader], pool: asyncpg.Pool
+    uploaders: Sequence[Uploader], pool: asyncpg.Pool
 ) -> list[asyncio.Task[None]]:
     await q.drop_unknown_uploaders(pool, names=[u.name for u in uploaders])
     return [asyncio.create_task(u.run(), name=f"uploader-{u.name}") for u in uploaders]

--- a/nixbot/nixbot/web/static/structured-logs.js
+++ b/nixbot/nixbot/web/static/structured-logs.js
@@ -63,9 +63,6 @@
   /** @param {HTMLElement} card @param {number} idx @param {number|null} line */
   function jump(card, idx, line) {
     card.scrollIntoView({ block: "nearest" });
-    document
-      .querySelectorAll(".log-lines .logline.hit")
-      .forEach((x) => x.classList.remove("hit"));
     if (line == null) return;
     const el = document.getElementById(`d${idx}-L${line}`);
     el?.classList.add("hit");
@@ -93,6 +90,9 @@
       list.querySelector(`.log-card[data-idx="${idx}"]`)
     );
     if (!card) return;
+    document
+      .querySelectorAll(".log-lines .logline.hit")
+      .forEach((x) => x.classList.remove("hit"));
     if (succeeded && succeeded.contains(card)) succeeded.open = true;
     card.open = true; // triggers the htmx fetch if not yet loaded
     if (pick(card, ".log-lines").hasAttribute("aria-busy")) {

--- a/nixosModules/niks3.nix
+++ b/nixosModules/niks3.nix
@@ -38,19 +38,37 @@ in
     systemd.services.nixbot.path = [ cfg.niks3.package ];
 
     services.nixbot.uploaders = [
-      {
-        name = "niks3";
-        environment = {
-          NIKS3_SERVER_URL = cfg.niks3.serverUrl;
-          # Token via file, never on the command line: /proc/<pid>/cmdline
-          # is world-readable.
-          NIKS3_AUTH_TOKEN_FILE = "/run/credentials/nixbot.service/niks3-auth-token";
-        };
-        command = [
-          "niks3"
-          "push"
-        ];
-      }
+      (
+        {
+          name = "niks3";
+          environment = {
+            NIKS3_SERVER_URL = cfg.niks3.serverUrl;
+            # Token via file, never on the command line: /proc/<pid>/cmdline
+            # is world-readable.
+            NIKS3_AUTH_TOKEN_FILE = "/run/credentials/nixbot.service/niks3-auth-token";
+          };
+        }
+        // (
+          # One long-running `niks3 push --stdin` (niks3 >= 1.11): each
+          # attribute waits only for its own paths, not a shared batch.
+          if lib.versionAtLeast (lib.getVersion cfg.niks3.package) "1.11" then
+            {
+              pathsVia = "stream";
+              command = [
+                "niks3"
+                "push"
+                "--stdin"
+              ];
+            }
+          else
+            {
+              command = [
+                "niks3"
+                "push"
+              ];
+            }
+        )
+      )
     ];
   };
 }

--- a/nixosModules/nixbot.nix
+++ b/nixosModules/nixbot.nix
@@ -782,9 +782,8 @@ in
       description = ''
         Binary-cache push commands. Each receives batches of store paths:
         every derivation nixbot built locally (intermediates included) plus
-        each attribute's outputs. One push per uploader runs at a time;
-        pending paths survive restarts. Failures are logged, never fail a
-        build.
+        each attribute's outputs. Pending paths survive restarts. Failures
+        are logged, never fail a build.
       '';
       type = lib.types.listOf (
         lib.types.submodule {
@@ -815,9 +814,15 @@ in
               type = lib.types.enum [
                 "argv"
                 "stdin"
+                "stream"
               ];
               default = "argv";
-              description = "`stdin`: newline-separated paths on stdin (e.g. `attic push --stdin`).";
+              description = ''
+                `stdin`: newline-separated paths on stdin per batch (e.g.
+                `attic push --stdin`). `stream`: one long-running process
+                fed paths on stdin that acknowledges each with a JSON
+                `{"path", "status"}` line (`niks3 push --stdin`).
+              '';
             };
           };
         }


### PR DESCRIPTION
The batching queue serialised all niks3 uploads service-wide: an
attribute that finished while a push ran waited for that batch and the
next one, so with a slow bucket every build looked slow.

pathsVia = "stream" keeps one `niks3 push --stdin` child per uploader,
feeds it paths as they are built and completes each attribute on its
own ack line. The queue table now only bridges child or service
restarts; retrying is left to niks3.

Requires https://github.com/Mic92/niks3/pull/489.

Change-Id: Iba14128969e3ea7794852118b9deb74c17ee5398
